### PR TITLE
Support for storing binary data as void

### DIFF
--- a/versioned_hdf5/tests/test_api.py
+++ b/versioned_hdf5/tests/test_api.py
@@ -1064,3 +1064,18 @@ def test_multidimsional():
         version2 = file['version2']
         assert version2['test_data'][0, 1] == 2
         assert_equal(version2['test_data'][()], data2)
+
+def test_store_binary_as_void():
+    with setup() as f:
+        vf = VersionedHDF5File(f)
+        with vf.stage_version('version1') as sv:
+            sv['test_store_binary_data'] = [np.void(b'1111')]
+
+        version1 = vf['version1']
+        assert_equal(version1['test_store_binary_data'][0], np.void(b'1111'))
+
+        with vf.stage_version('version2') as sv:
+            sv['test_store_binary_data'][:] = [np.void(b'1234567890')]
+
+        version2 = vf['version2']
+        assert_equal(version2['test_store_binary_data'][0], np.void(b'1234'))

--- a/versioned_hdf5/wrappers.py
+++ b/versioned_hdf5/wrappers.py
@@ -335,7 +335,7 @@ class InMemoryArrayDataset:
         self.name = name
         self._array = array
         self.attrs = {}
-        self.fillvalue = fillvalue or np.zeros((), dtype=array.dtype)
+        self.fillvalue = fillvalue or np.zeros((), dtype=array.dtype)[()]
 
     @property
     def array(self):

--- a/versioned_hdf5/wrappers.py
+++ b/versioned_hdf5/wrappers.py
@@ -335,7 +335,7 @@ class InMemoryArrayDataset:
         self.name = name
         self._array = array
         self.attrs = {}
-        self.fillvalue = fillvalue
+        self.fillvalue = fillvalue or np.zeros((), dtype=array.dtype)
 
     @property
     def array(self):
@@ -412,7 +412,7 @@ class InMemoryArrayDataset:
             raise NotImplementedError("More than one dimension is not yet supported")
         if size[0] > self.shape[0]:
             self.array = np.concatenate((self.array, np.full(size[0] - self.shape[0],
-                                                             self.fillvalue or self.dtype.type(),
+                                                             self.fillvalue,
                                                              dtype=self.dtype)))
         else:
             self.array = self.array[:size[0]]

--- a/versioned_hdf5/wrappers.py
+++ b/versioned_hdf5/wrappers.py
@@ -335,7 +335,7 @@ class InMemoryArrayDataset:
         self.name = name
         self._array = array
         self.attrs = {}
-        self.fillvalue = fillvalue or array.dtype.type()
+        self.fillvalue = fillvalue
 
     @property
     def array(self):
@@ -411,8 +411,8 @@ class InMemoryArrayDataset:
         if len(size) > 1:
             raise NotImplementedError("More than one dimension is not yet supported")
         if size[0] > self.shape[0]:
-            self.array = np.concatenate((self.array, np.full(size[0] -
-                                                             self.shape[0], self.fillvalue,
+            self.array = np.concatenate((self.array, np.full(size[0] - self.shape[0],
+                                                             self.fillvalue or self.dtype.type(),
                                                              dtype=self.dtype)))
         else:
             self.array = self.array[:size[0]]


### PR DESCRIPTION
This fixes #69. Storing void data is kind of weirdly supported by h5py
and we seem to use this particular corner case.