### PR TITLE
Fix a bug in set_chunks for nested datasets

### DIFF
--- a/versioned_hdf5/tests/test_api.py
+++ b/versioned_hdf5/tests/test_api.py
@@ -1354,3 +1354,16 @@ def test_check_committed():
                 g2['test_data'].resize((100,))
 
         assert repr(g) == '<Committed InMemoryGroup "/_version_data/versions/version1">'
+
+def test_set_chunks_nested():
+    with setup() as f:
+        vf = VersionedHDF5File(f)
+        with vf.stage_version('0') as sv:
+            data_group = sv.create_group('data')
+            data_group.create_dataset('bar', data=np.arange(4))
+
+    with h5py.File('foo.h5', 'r+') as f:
+        vf = VersionedHDF5File(f)
+        with vf.stage_version('1') as sv:
+            data_group = sv['data']
+            data_group.create_dataset('props/1/bar', data=np.arange(0, 4, 2))

--- a/versioned_hdf5/tests/test_api.py
+++ b/versioned_hdf5/tests/test_api.py
@@ -1365,3 +1365,15 @@ def test_set_chunks_nested():
         with vf.stage_version('1') as sv:
             data_group = sv['data']
             data_group.create_dataset('props/1/bar', data=np.arange(0, 4, 2))
+
+def test_InMemoryArrayDataset_chunks():
+    with setup() as f:
+        vf = VersionedHDF5File(f)
+        with vf.stage_version('0') as sv:
+            data_group = sv.create_group('data')
+            data_group.create_dataset('g/bar', data=np.arange(4),
+    chunks=(100,), compression='gzip', compression_opts=3)
+            assert isinstance(data_group['g/bar'], InMemoryArrayDataset)
+            assert data_group['g/bar'].chunks == (100,)
+            assert data_group['g/bar'].compression == 'gzip'
+            assert data_group['g/bar'].compression_opts == 3

--- a/versioned_hdf5/tests/test_api.py
+++ b/versioned_hdf5/tests/test_api.py
@@ -1362,8 +1362,6 @@ def test_set_chunks_nested():
             data_group = sv.create_group('data')
             data_group.create_dataset('bar', data=np.arange(4))
 
-    with h5py.File('foo.h5', 'r+') as f:
-        vf = VersionedHDF5File(f)
         with vf.stage_version('1') as sv:
             data_group = sv['data']
             data_group.create_dataset('props/1/bar', data=np.arange(0, 4, 2))

--- a/versioned_hdf5/wrappers.py
+++ b/versioned_hdf5/wrappers.py
@@ -213,42 +213,65 @@ class InMemoryGroup(Group):
 
     @property
     def chunks(self):
-        return self.versioned_root._chunks
+        return self._chunks
 
+    # TODO: Can we generalize this, set_compression, and set_compression_opts
+    # into a single method? Descriptors?
     def set_chunks(self, item, value):
         full_name = item
         p = self
         while p._parent:
+            p._chunks[full_name] = value
             _, basename = pp.split(p.name)
             full_name = basename + '/' + full_name
             p = p._parent
         self.versioned_root._chunks[full_name] = value
 
+        dirname, basename = pp.split(item)
+        while dirname:
+            self[dirname]._chunks[basename] = value
+            dirname, b = pp.split(dirname)
+            basename = pp.join(b, basename)
+
     @property
     def compression(self):
-        return self.versioned_root._compression
+        return self._compression
 
     def set_compression(self, item, value):
         full_name = item
         p = self
         while p._parent:
+            p._compression[full_name] = value
             _, basename = pp.split(p.name)
             full_name = basename + '/' + full_name
             p = p._parent
         self.versioned_root._compression[full_name] = value
 
+        dirname, basename = pp.split(item)
+        while dirname:
+            self[dirname]._compression[basename] = value
+            dirname, b = pp.split(dirname)
+            basename = pp.join(b, basename)
+
     @property
     def compression_opts(self):
-        return self.versioned_root._compression_opts
+        return self._compression_opts
 
     def set_compression_opts(self, item, value):
         full_name = item
         p = self
         while p._parent:
+            p._compression_opts[full_name] = value
             _, basename = pp.split(p.name)
             full_name = basename + '/' + full_name
             p = p._parent
         self.versioned_root._compression_opts[full_name] = value
+
+        dirname, basename = pp.split(item)
+        while dirname:
+            self[dirname]._compression_opts[basename] = value
+            dirname, b = pp.split(dirname)
+            basename = pp.join(b, basename)
 
     def visititems(self, func):
         self._visit('', func)

--- a/versioned_hdf5/wrappers.py
+++ b/versioned_hdf5/wrappers.py
@@ -216,7 +216,7 @@ class InMemoryGroup(Group):
         return self.versioned_root._chunks
 
     def set_chunks(self, item, value):
-        _, full_name = pp.split(item)
+        full_name = item
         p = self
         while p._parent:
             _, basename = pp.split(p.name)

--- a/versioned_hdf5/wrappers.py
+++ b/versioned_hdf5/wrappers.py
@@ -229,7 +229,7 @@ class InMemoryGroup(Group):
         return self.versioned_root._compression
 
     def set_compression(self, item, value):
-        _, full_name = pp.split(item)
+        full_name = item
         p = self
         while p._parent:
             _, basename = pp.split(p.name)
@@ -242,7 +242,7 @@ class InMemoryGroup(Group):
         return self.versioned_root._compression_opts
 
     def set_compression_opts(self, item, value):
-        _, full_name = pp.split(item)
+        full_name = item
         p = self
         while p._parent:
             _, basename = pp.split(p.name)

--- a/versioned_hdf5/wrappers.py
+++ b/versioned_hdf5/wrappers.py
@@ -689,6 +689,18 @@ class InMemoryArrayDataset:
     def ndim(self):
         return len(self._array.shape)
 
+    @property
+    def chunks(self):
+        return self.parent.chunks[self.name]
+
+    @property
+    def compression(self):
+        return self.parent.compression[self.name]
+
+    @property
+    def compression_opts(self):
+        return self.parent.compression_opts[self.name]
+
     def __getitem__(self, item):
         return self.array.__getitem__(item)
 


### PR DESCRIPTION
Previously any leading groups on the path to the dataset were stripped
away. This fixes #103.