### PR TITLE
Garbage collect closed groups

### DIFF
--- a/versioned_hdf5/api.py
+++ b/versioned_hdf5/api.py
@@ -163,7 +163,7 @@ class VersionedHDF5File:
 
         try:
             yield group
-            group._committed = True
+            group.close()
             commit_version(group, group.datasets(), make_current=make_current,
                            chunks=group.chunks,
                            compression=group.compression,

--- a/versioned_hdf5/tests/test_api.py
+++ b/versioned_hdf5/tests/test_api.py
@@ -522,9 +522,10 @@ def test_resize_unaligned(vfile):
             assert_equal(group[ds_name][:], np.arange((i + 1) * 1000))
 
 
-def test_resize_multiple_dimensions(vfile):
+def test_resize_multiple_dimensions(tmp_path, h5file):
     # Test semantics against raw HDF5
 
+    vfile = VersionedHDF5File(h5file)
     shapes = range(5, 25, 5)  # 5, 10, 15, 20
     chunks = (10, 10, 10)
     for i, (oldshape, newshape) in\
@@ -577,6 +578,13 @@ def test_resize_multiple_dimensions(vfile):
         assert version3_2[f'dataset3_{i}'].shape == newshape
         assert_equal(version3_2[f'dataset3_{i}'][()], new_data)
 
+    vfile.close()
+    try:
+        h5file.close()
+    except ValueError:
+        # Work around a bug in h5py. See
+        # https://github.com/deshaw/versioned-hdf5/pull/125
+        pass
 
 def test_getitem(vfile):
     data = np.arange(2*DEFAULT_CHUNK_SIZE)

--- a/versioned_hdf5/tests/test_api.py
+++ b/versioned_hdf5/tests/test_api.py
@@ -1045,6 +1045,10 @@ def test_group_contains():
         assert 'test_data2' not in version1['group1/group2']
         assert 'test_data2' not in version2['group1/group2']
 
+        assert '/_version_data/versions/version1/' in version1
+        assert '/_version_data/versions/version1' in version1
+        assert '/_version_data/versions/version1/' not in version2
+        assert '/_version_data/versions/version1' not in version2
         assert '/_version_data/versions/version1/group1' in version1
         assert '/_version_data/versions/version1/group1' not in version2
         assert '/_version_data/versions/version1/group1/group2' in version1

--- a/versioned_hdf5/tests/test_api.py
+++ b/versioned_hdf5/tests/test_api.py
@@ -1004,21 +1004,37 @@ def test_group_contains():
         version1 = file['version1']
         version2 = file['version2']
         assert 'group1' in version1
+        assert 'group1/' in version1
         assert 'group1' in version2
+        assert 'group1/' in version2
         assert 'group2' in version1['group1']
+        assert 'group2/' in version1['group1']
         assert 'group2' in version2['group1']
+        assert 'group2/' in version2['group1']
         assert 'group3' not in version1['group1']
+        assert 'group3/' not in version1['group1']
         assert 'group3' in version2['group1']
+        assert 'group3/' in version2['group1']
         assert 'group1/group2' in version1
+        assert 'group1/group2/' in version1
         assert 'group1/group2' in version2
+        assert 'group1/group2/' in version2
         assert 'group1/group3' not in version1
+        assert 'group1/group3/' not in version1
         assert 'group1/group3' in version2
+        assert 'group1/group3/' in version2
         assert 'group1/group2/test_data' in version1
+        assert 'group1/group2/test_data/' in version1
         assert 'group1/group2/test_data' in version2
+        assert 'group1/group2/test_data/' in version2
         assert 'group1/group3/test_data' not in version1
+        assert 'group1/group3/test_data/' not in version1
         assert 'group1/group3/test_data' not in version2
+        assert 'group1/group3/test_data/' not in version2
         assert 'group1/group3/test_data2' not in version1
+        assert 'group1/group3/test_data2/' not in version1
         assert 'group1/group3/test_data2' in version2
+        assert 'group1/group3/test_data2/' in version2
         assert 'test_data' in version1['group1/group2']
         assert 'test_data' in version2['group1/group2']
         assert 'test_data' not in version1

--- a/versioned_hdf5/tests/test_api.py
+++ b/versioned_hdf5/tests/test_api.py
@@ -1045,6 +1045,11 @@ def test_group_contains():
         assert 'test_data2' not in version1['group1/group2']
         assert 'test_data2' not in version2['group1/group2']
 
+        assert '/_version_data/versions/version1/group1' in version1
+        assert '/_version_data/versions/version1/group1' not in version2
+        assert '/_version_data/versions/version1/group1/group2' in version1
+        assert '/_version_data/versions/version1/group1/group2' not in version2
+
         file.close()
 
 def test_moved_file():

--- a/versioned_hdf5/wrappers.py
+++ b/versioned_hdf5/wrappers.py
@@ -29,7 +29,6 @@ class InMemoryGroup(Group):
         # Make sure each group only corresponds to one InMemoryGroup instance.
         # Otherwise a new instance would lose track of any datasets or
         # subgroups created in the old one.
-        # TODO: Garbage collect closed groups.
         if bind in _groups:
             return _groups[bind]
         obj = super().__new__(cls)
@@ -49,6 +48,12 @@ class InMemoryGroup(Group):
         self._initialized = True
         self._committed = False
         super().__init__(bind)
+
+    def close(self):
+        self._committed = True
+        for bind in list(_groups.keys()):
+            if _groups[bind].name in self:
+                del _groups[bind]
 
     # Based on Group.__repr__
     def __repr__(self):

--- a/versioned_hdf5/wrappers.py
+++ b/versioned_hdf5/wrappers.py
@@ -185,9 +185,12 @@ class InMemoryGroup(Group):
             yield i
 
     def __contains__(self, item):
+        item = item + '/'
         root = self.versioned_root.name + '/'
         if item.startswith(root):
             item = item[len(root):]
+            if not item.rstrip('/'):
+                return self == self.versioned_root
         item = item.rstrip('/')
         dirname, data_name = pp.split(item)
         if dirname not in ['', '/']:

--- a/versioned_hdf5/wrappers.py
+++ b/versioned_hdf5/wrappers.py
@@ -52,7 +52,9 @@ class InMemoryGroup(Group):
     def close(self):
         self._committed = True
         for bind in list(_groups.keys()):
-            if _groups[bind].name in self:
+            if not _groups[bind]:
+                del _groups[bind]
+            elif _groups[bind].name in self:
                 del _groups[bind]
 
     # Based on Group.__repr__

--- a/versioned_hdf5/wrappers.py
+++ b/versioned_hdf5/wrappers.py
@@ -185,6 +185,9 @@ class InMemoryGroup(Group):
             yield i
 
     def __contains__(self, item):
+        root = self.versioned_root.name + '/'
+        if item.startswith(root):
+            item = item[len(root):]
         item = item.rstrip('/')
         dirname, data_name = pp.split(item)
         if dirname not in ['', '/']:

--- a/versioned_hdf5/wrappers.py
+++ b/versioned_hdf5/wrappers.py
@@ -185,6 +185,7 @@ class InMemoryGroup(Group):
             yield i
 
     def __contains__(self, item):
+        item = item.rstrip('/')
         dirname, data_name = pp.split(item)
         if dirname not in ['', '/']:
             return dirname in self and data_name in self[dirname]

--- a/versioned_hdf5/wrappers.py
+++ b/versioned_hdf5/wrappers.py
@@ -19,11 +19,12 @@ import numpy as np
 from collections import defaultdict
 import posixpath as pp
 import warnings
+from weakref import WeakValueDictionary
 
 from .backend import DEFAULT_CHUNK_SIZE
 from .slicetools import spaceid_to_slice, as_subchunks, split_chunks
 
-_groups = {}
+_groups = WeakValueDictionary({})
 class InMemoryGroup(Group):
     def __new__(cls, bind):
         # Make sure each group only corresponds to one InMemoryGroup instance.
@@ -51,11 +52,6 @@ class InMemoryGroup(Group):
 
     def close(self):
         self._committed = True
-        for bind in list(_groups.keys()):
-            if not _groups[bind]:
-                del _groups[bind]
-            elif _groups[bind].name in self:
-                del _groups[bind]
 
     # Based on Group.__repr__
     def __repr__(self):


### PR DESCRIPTION
This should fix the memory leak issues (fixes #121). @ArvidJB let me know if you still have memory leaking issues with this PR.

Also fixes trailing slashes in `__contains__` (fixes #122).