### PR TITLE
Fix support for empty datasets

### DIFF
--- a/versioned_hdf5/backend.py
+++ b/versioned_hdf5/backend.py
@@ -124,7 +124,7 @@ def write_dataset_chunks(f, name, data_dict):
     chunk_size = chunks[0]
 
     shape = tuple(max(c.args[i].stop for c in data_dict) for i in
-    range(len(chunks)))
+                  range(len(chunks)))
     all_chunks = list(split_chunks(shape, chunks))
     for c in all_chunks:
         if c not in data_dict:

--- a/versioned_hdf5/hashtable.py
+++ b/versioned_hdf5/hashtable.py
@@ -96,6 +96,9 @@ class Hashtable(MutableMapping):
             value = value.args[0]
         if not isinstance(value, (slice, Slice)):
             raise TypeError("value must be a slice object")
+        value = Slice(value)
+        if value.isempty():
+            return
         if value.step not in [1, None]:
             raise ValueError("only step-1 slices are supported")
 

--- a/versioned_hdf5/slicetools.py
+++ b/versioned_hdf5/slicetools.py
@@ -89,6 +89,8 @@ def split_chunks(shape, chunks):
             raise ValueError("chunks shape must equal the array shape")
 
     d = [math.ceil(i/c) for i, c in zip(shape, chunks)]
+    if 0 in d:
+        yield Tuple(*[Slice(0, bool(i)*chunk_size, 1) for i, chunk_size in zip(d, chunks)]).expand(shape)
     for c in product(*[range(i) for i in d]):
         # c = (0, 0, 0), (0, 0, 1), ...
         yield Tuple(*[Slice(chunk_size*i, min(chunk_size*(i + 1), n), 1) for n, chunk_size,

--- a/versioned_hdf5/tests/test_api.py
+++ b/versioned_hdf5/tests/test_api.py
@@ -1353,3 +1353,17 @@ def test_string_dtypes():
             assert file['1']['name'][10] == typ(), dt.metadata
             assert file['1']['name'][11] == typ(), dt.metadata
         f.close()
+
+def test_empty(vfile):
+    with vfile.stage_version('version1') as g:
+        g['data'] = np.arange(10)
+        g.create_dataset('data2', data=np.empty((1, 0, 2)), chunks=(5, 5, 5))
+        assert_equal(g['data2'][()], np.empty((1, 0, 2)))
+    assert_equal(vfile['version1']['data2'][()], np.empty((1, 0, 2)))
+
+    with vfile.stage_version('version2') as g:
+        g['data'].resize((0,))
+        assert_equal(g['data'][()], np.empty((0,)))
+
+    assert_equal(vfile['version2']['data'][()], np.empty((0,)))
+    assert_equal(vfile['version2']['data2'][()], np.empty((1, 0, 2)))


### PR DESCRIPTION
We need to make sure we have at least one dummy entry in the data_dict so we
can infer the shape.

There is a bug with getting the virtual dataset sources for empty dataset in
h5py, so we have to work around it.

Fixes #98.