### PR TITLE
Allow deleting groups between versions

### DIFF
--- a/versioned_hdf5/backend.py
+++ b/versioned_hdf5/backend.py
@@ -82,7 +82,13 @@ def write_dataset(f, name, data, chunks=None, compression=None,
     if compression or compression_opts:
         raise ValueError("Compression options can only be specified for the first version of a dataset")
     if fillvalue is not None and fillvalue != ds.fillvalue:
-        raise ValueError(f"fillvalues do not match ({fillvalue} != {ds.fillvalue})")
+        dtype = ds.dtype
+        if dtype.metadata and ('vlen' in dtype.metadata or 'h5py_encoding' in dtype.metadata):
+            # Variable length string dtype. The ds.fillvalue will be None in
+            # this case (see create_virtual_dataset() below)
+            pass
+        else:
+            raise ValueError(f"fillvalues do not match ({fillvalue} != {ds.fillvalue})")
     if data.dtype != ds.dtype:
         raise ValueError(f"dtypes do not match ({data.dtype} != {ds.dtype})")
     # TODO: Handle more than one dimension

--- a/versioned_hdf5/backend.py
+++ b/versioned_hdf5/backend.py
@@ -79,7 +79,7 @@ def write_dataset(f, name, data, chunks=None, compression=None,
         if chunks != tuple(ds.attrs['chunks']):
             raise ValueError("Chunk size specified but doesn't match already existing chunk size")
 
-    if compression or compression_opts:
+    if compression and compression != ds.compression or compression_opts and compression_opts != ds.compression_opts:
         raise ValueError("Compression options can only be specified for the first version of a dataset")
     if fillvalue is not None and fillvalue != ds.fillvalue:
         dtype = ds.dtype

--- a/versioned_hdf5/tests/test_api.py
+++ b/versioned_hdf5/tests/test_api.py
@@ -1374,7 +1374,6 @@ def test_delete_datasets(vfile):
     with vfile.stage_version('version1') as g:
         g['data'] = data1
         g.create_group('group1/group2')
-        g['group1']['data1'] = data1
         g['group1']['group2']['data1'] = data1
 
     with vfile.stage_version('del_data') as g:
@@ -1387,13 +1386,12 @@ def test_delete_datasets(vfile):
         del g['group1/group2']
 
     with vfile.stage_version('del_group1', 'version1') as g:
-        del g['group1/group2']
+        del g['group1/']
 
     with vfile.stage_version('version2', 'del_data') as g:
         g['data'] = np.zeros(20, dtype=int)
 
     with vfile.stage_version('version3', 'del_data1') as g:
-        g.create_group('group1/group2')
         g['group1/group2/data1'] = data2
 
     with vfile.stage_version('version4', 'del_group2') as g:
@@ -1404,49 +1402,49 @@ def test_delete_datasets(vfile):
         g.create_group('group1/group2')
         g['group1/group2/data1'] = data2
 
-    assert list(vfile['version1']) == ['group1', 'data']
+    assert set(vfile['version1']) == {'group1', 'data'}
     assert list(vfile['version1']['group1']) == ['group2']
     assert list(vfile['version1']['group1']['group2']) == ['data1']
     assert_equal(vfile['version1']['data'][:], data1)
-    assert_equal(vfile['version1']['group1/group2/data'][:], data1)
+    assert_equal(vfile['version1']['group1/group2/data1'][:], data1)
 
     assert list(vfile['del_data']) == ['group1']
     assert list(vfile['del_data']['group1']) == ['group2']
     assert list(vfile['del_data']['group1']['group2']) == ['data1']
-    assert_equal(vfile['del_data']['group1/group2/data'][:], data1)
+    assert_equal(vfile['del_data']['group1/group2/data1'][:], data1)
 
-    assert list(vfile['del_data1']) == ['group1', 'data']
+    assert set(vfile['del_data1']) == {'group1', 'data'}
     assert list(vfile['del_data1']['group1']) == ['group2']
     assert list(vfile['del_data1']['group1']['group2']) == []
     assert_equal(vfile['del_data1']['data'][:], data1)
 
-    assert list(vfile['del_group2']) == ['group1', 'data']
+    assert set(vfile['del_group2']) == {'group1', 'data'}
     assert list(vfile['del_group2']['group1']) == []
     assert_equal(vfile['del_group2']['data'][:], data1)
 
     assert list(vfile['del_group1']) == ['data']
     assert_equal(vfile['del_group1']['data'][:], data1)
 
-    assert list(vfile['version2']) == ['group1', 'data']
+    assert set(vfile['version2']) == {'group1', 'data'}
     assert list(vfile['version2']['group1']) == ['group2']
     assert list(vfile['version2']['group1']['group2']) == ['data1']
     assert_equal(vfile['version2']['data'][:], data2)
-    assert_equal(vfile['version2']['group1/group2/data'][:], data1)
+    assert_equal(vfile['version2']['group1/group2/data1'][:], data1)
 
-    assert list(vfile['version3']) == ['group1', 'data']
+    assert set(vfile['version3']) == {'group1', 'data'}
     assert list(vfile['version3']['group1']) == ['group2']
     assert list(vfile['version3']['group1']['group2']) == ['data1']
     assert_equal(vfile['version3']['data'][:], data1)
-    assert_equal(vfile['version3']['group1/group2/data'][:], data2)
+    assert_equal(vfile['version3']['group1/group2/data1'][:], data2)
 
-    assert list(vfile['version4']) == ['group1', 'data']
+    assert set(vfile['version4']) == {'group1', 'data'}
     assert list(vfile['version4']['group1']) == ['group2']
     assert list(vfile['version4']['group1']['group2']) == ['data1']
     assert_equal(vfile['version4']['data'][:], data1)
-    assert_equal(vfile['version4']['group1/group2/data'][:], data2)
+    assert_equal(vfile['version4']['group1/group2/data1'][:], data2)
 
-    assert list(vfile['version5']) == ['group1', 'data']
+    assert set(vfile['version5']) == {'group1', 'data'}
     assert list(vfile['version5']['group1']) == ['group2']
     assert list(vfile['version5']['group1']['group2']) == ['data1']
     assert_equal(vfile['version5']['data'][:], data1)
-    assert_equal(vfile['version5']['group1/group2/data'][:], data2)
+    assert_equal(vfile['version5']['group1/group2/data1'][:], data2)

--- a/versioned_hdf5/wrappers.py
+++ b/versioned_hdf5/wrappers.py
@@ -114,8 +114,23 @@ class InMemoryGroup(Group):
 
     def __delitem__(self, name):
         self._check_committed()
+        dirname, basename = pp.split(name)
+        if dirname:
+            if not basename:
+                del self[dirname]
+            else:
+                del self[dirname][basename]
+            return
+
         if name in self._data:
             del self._data[name]
+        elif name in self._subgroups:
+            for i in self[name]:
+                del self[name][i]
+            del self._subgroups[name]
+            super().__delitem__(name)
+        else:
+            raise KeyError(f"{name!r} is not in {self}")
 
     @property
     def parent(self):


### PR DESCRIPTION
Deleting datasets was already supported, but not tested.

This works as long as the dimensionality or dtype does not change between
versions. Changing the dtype would be possible, but would require some work.
Changing the dimensionality would be more difficult.

Fixes #131.