### PR TITLE
Return the closest version before the given timestamp

### DIFF
--- a/versioned_hdf5/api.py
+++ b/versioned_hdf5/api.py
@@ -90,8 +90,8 @@ class VersionedHDF5File:
         # TODO: Don't give an in-memory group if the file is read-only
         return InMemoryGroup(self._versions[version]._id, _committed=True)
 
-    def get_version_by_timestamp(self, timestamp):
-        version = get_version_by_timestamp(self.f, timestamp)
+    def get_version_by_timestamp(self, timestamp, exact=False):
+        version = get_version_by_timestamp(self.f, timestamp, exact=exact)
         # TODO: Don't give an in-memory group if the file is read-only
         return InMemoryGroup(self._versions[version]._id, _committed=True)
 

--- a/versioned_hdf5/api.py
+++ b/versioned_hdf5/api.py
@@ -11,8 +11,8 @@ import datetime
 
 from .backend import initialize
 from .versions import (create_version_group, commit_version,
-                       get_nth_previous_version, set_current_version,
-                       all_versions, delete_version, TIMESTAMP_FMT)
+                       get_version_by_timestamp, get_nth_previous_version,
+                       set_current_version, all_versions, delete_version, )
 from .wrappers import InMemoryGroup
 
 
@@ -91,16 +91,9 @@ class VersionedHDF5File:
         return InMemoryGroup(self._versions[version]._id, _committed=True)
 
     def get_version_by_timestamp(self, timestamp):
-        for version in self._versions:
-            if version != '__first_version__':
-                if isinstance(timestamp, np.datetime64):
-                    ts = f"{timestamp.astype(datetime.datetime)}+0000"
-                else:
-                    ts = timestamp.strftime(TIMESTAMP_FMT)
-                if ts == self[version].attrs['timestamp']:
-                    # TODO: Don't give an in-memory group if the file is read-only
-                    return InMemoryGroup(self._versions[version]._id, _committed=True)
-        raise KeyError(f"Version with timestamp {timestamp} not found")
+        version = get_version_by_timestamp(self.f, timestamp)
+        # TODO: Don't give an in-memory group if the file is read-only
+        return InMemoryGroup(self._versions[version]._id, _committed=True)
 
     def __getitem__(self, item):
         if item is None:

--- a/versioned_hdf5/backend.py
+++ b/versioned_hdf5/backend.py
@@ -14,10 +14,15 @@ def get_chunks(shape, dtype, chunk_size):
     return (chunk_size,)
 
 def initialize(f):
+    import datetime
+    from .versions import TIMESTAMP_FMT
+
     version_data = f.create_group('_version_data')
     versions = version_data.create_group('versions')
     versions.create_group('__first_version__')
     versions.attrs['current_version'] = '__first_version__'
+    ts = datetime.datetime.now(datetime.timezone.utc)
+    versions['__first_version__'].attrs['timestamp'] = ts.strftime(TIMESTAMP_FMT)
 
 
 def create_base_dataset(f, name, *, shape=None, data=None, dtype=None,

--- a/versioned_hdf5/versions.py
+++ b/versioned_hdf5/versions.py
@@ -149,17 +149,31 @@ def get_nth_previous_version(f, version_name, n):
 
     return version
 
-def get_version_by_timestamp(f, timestamp):
+def get_version_by_timestamp(f, timestamp, exact=False):
     versions = f['_version_data/versions']
+    if isinstance(timestamp, np.datetime64):
+        ts = f"{timestamp.astype(datetime.datetime)}+0000"
+    else:
+        ts = timestamp.strftime(TIMESTAMP_FMT)
+    best_match = '__first_version__'
+    best_ts = versions[best_match].attrs['timestamp']
     for version in versions:
+        version_ts = versions[version].attrs['timestamp']
         if version != '__first_version__':
-            if isinstance(timestamp, np.datetime64):
-                ts = f"{timestamp.astype(datetime.datetime)}+0000"
+            if exact:
+                if ts == version_ts:
+                    return version
             else:
-                ts = timestamp.strftime(TIMESTAMP_FMT)
-            if ts == versions[version].attrs['timestamp']:
-                return version
-    raise KeyError(f"Version with timestamp {timestamp} not found")
+                # Find the version whose timestamp is closest to ts and before
+                # it.
+                if best_ts < version_ts <= ts:
+                    best_match = version
+                    best_ts = version_ts
+    if best_match == '__first_version__':
+        if exact:
+            raise KeyError(f"Version with timestamp {timestamp} not found")
+        raise KeyError(f"Version with timestamp before {timestamp} not found")
+    return best_match
 
 def set_current_version(f, version_name):
     versions = f['_version_data/versions']

--- a/versioned_hdf5/versions.py
+++ b/versioned_hdf5/versions.py
@@ -149,6 +149,18 @@ def get_nth_previous_version(f, version_name, n):
 
     return version
 
+def get_version_by_timestamp(f, timestamp):
+    versions = f['_version_data/versions']
+    for version in versions:
+        if version != '__first_version__':
+            if isinstance(timestamp, np.datetime64):
+                ts = f"{timestamp.astype(datetime.datetime)}+0000"
+            else:
+                ts = timestamp.strftime(TIMESTAMP_FMT)
+            if ts == versions[version].attrs['timestamp']:
+                return version
+    raise KeyError(f"Version with timestamp {timestamp} not found")
+
 def set_current_version(f, version_name):
     versions = f['_version_data/versions']
     if version_name not in versions:


### PR DESCRIPTION
The previous behavior of requiring an exact timestamp match can be enabled by using vfile.get_version_by_timestamp(timestamp, exact=True).

Fixes #141.
