### PR TITLE
Pin h5py to version 2 for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
   - conda config --add channels conda-forge
   - conda update -q conda
   - conda info -a
-  - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION h5py numpy scipy ndindex pyflakes pytest pytest-doctestplus pytest-flakes doctr sphinx pytest-cov myst-parser graphviz
+  - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION h5py=2 numpy scipy ndindex pyflakes pytest pytest-doctestplus pytest-flakes doctr sphinx pytest-cov myst-parser graphviz
   - source activate test-environment
 
 script:

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
     packages=['versioned_hdf5', 'versioned_hdf5.tests'],
     license="BSD",
     install_requires=[
-        "h5py",
+        "h5py<3",
         "numpy",
         "ndindex>=1.3",
     ],


### PR DESCRIPTION
Version 3 support is being worked on in #148, but will take some time to get
working, and we want to do a release before then.