### PR TITLE
Fix the str dtype not being maintained from the fillvalue

### DIFF
--- a/versioned_hdf5/tests/test_api.py
+++ b/versioned_hdf5/tests/test_api.py
@@ -1665,3 +1665,13 @@ def test_sparse_large(vfile):
     assert vfile['version2']['test_data'][0] == 1
     assert vfile['version2']['test_data'][1] == 0
     assert vfile['version2']['test_data'][20_000_000] == 2
+
+def test_empty_dataset_str_dtype(vfile):
+    # Issue #161. Make sure the dtype is maintained correctly for empty
+    # datasets with custom string dtypes.
+    with vfile.stage_version('version1') as g:
+        g.create_dataset('bar', data=np.array(['a', 'b', 'c'], dtype='S5'), dtype=np.dtype('S5'))
+        g['bar'].resize((0,))
+    with vfile.stage_version('version2') as g:
+        g['bar'].resize((3,))
+        g['bar'][:] = np.array(['a', 'b', 'c'], dtype='S5')

--- a/versioned_hdf5/wrappers.py
+++ b/versioned_hdf5/wrappers.py
@@ -698,15 +698,9 @@ class InMemoryDataset(Dataset):
 
         for c in self.chunks.as_subchunks(idx, self.shape):
             if c not in self.id.data_dict:
-                # TODO: Handle this more efficiently if there are many chunks
-                # without explicit data (see
-                # https://github.com/Quansight/ndindex/issues/45). This would
-                # also make things more efficient for the non-sparse case as
-                # well.
-
                 # Broadcasted arrays do not actually consume memory
                 fill = np.broadcast_to(self.fillvalue, c.newshape(self.shape))
-                self.id.data_dict[c] = fill.copy()
+                self.id.data_dict[c] = fill.astype(self.dtype)
             elif isinstance(self.id.data_dict[c], (slice, Slice, tuple, Tuple)):
                 raw_idx = Tuple(self.id.data_dict[c], *[slice(0, len(i)) for i
                                                         in c.args[1:]]).raw


### PR DESCRIPTION
This used to work because it used to always add trivial chunks, which ended up
maintaining the dtype, but now that it is more efficient, it doesn't do that
any more. The correct behavior is to maintain the dtype, since self.fillvalue
loses that information, basically because of this:

```py
>>> np.array([b''], dtype='S5')[0].dtype
dtype('S')
```

Fixes #161.