### PR TITLE
Disallow accessing vfile[version] before version has been committed

### DIFF
--- a/versioned_hdf5/api.py
+++ b/versioned_hdf5/api.py
@@ -83,6 +83,9 @@ class VersionedHDF5File:
         self._version_cache.clear()
 
     def get_version_by_name(self, version):
+        if version.startswith('/'):
+            raise ValueError("Versions cannot start with '/'. VersionedHDF5File should not be used to access the top-level of an h5py File.")
+
         if version == '':
             version = '__first_version__'
 

--- a/versioned_hdf5/api.py
+++ b/versioned_hdf5/api.py
@@ -87,13 +87,19 @@ class VersionedHDF5File:
         if version not in self._versions:
             raise KeyError(f"Version {version!r} not found")
 
+        g = self._versions[version]
+        if not g.attrs['committed']:
+            raise ValueError("Version groups cannot accessed from the VersionedHDF5File object before they are committed.")
         # TODO: Don't give an in-memory group if the file is read-only
-        return InMemoryGroup(self._versions[version]._id, _committed=True)
+        return InMemoryGroup(g._id, _committed=True)
 
     def get_version_by_timestamp(self, timestamp, exact=False):
         version = get_version_by_timestamp(self.f, timestamp, exact=exact)
         # TODO: Don't give an in-memory group if the file is read-only
-        return InMemoryGroup(self._versions[version]._id, _committed=True)
+        g = self._versions[version]
+        if not g.attrs['committed']:
+            raise ValueError("Version groups cannot accessed from the VersionedHDF5File object before they are committed.")
+        return InMemoryGroup(g._id, _committed=True)
 
     def __getitem__(self, item):
         if item is None:

--- a/versioned_hdf5/tests/conftest.py
+++ b/versioned_hdf5/tests/conftest.py
@@ -22,9 +22,13 @@ def h5file(tmp_path, request):
     yield f
     try:
         f.close()
+    # Workaround upstream h5py bug. https://github.com/deshaw/versioned-hdf5/issues/162
     except ValueError as e:
-        # Workaround upstream h5py bug. https://github.com/deshaw/versioned-hdf5/issues/162
         if e.args[0] == "Unrecognized type code -1":
+            return
+        raise
+    except RuntimeError as e:
+        if e.args[0] == "Can't increment id ref count (can't locate ID)":
             return
         raise
 

--- a/versioned_hdf5/tests/test_api.py
+++ b/versioned_hdf5/tests/test_api.py
@@ -581,14 +581,6 @@ def test_resize_multiple_dimensions(tmp_path, h5file):
         assert version3_2[f'dataset3_{i}'].shape == newshape
         assert_equal(version3_2[f'dataset3_{i}'][()], new_data)
 
-    vfile.close()
-    try:
-        h5file.close()
-    except ValueError:
-        # Work around a bug in h5py. See
-        # https://github.com/deshaw/versioned-hdf5/pull/125
-        pass
-
 def test_getitem(vfile):
     data = np.arange(2*DEFAULT_CHUNK_SIZE)
 

--- a/versioned_hdf5/tests/test_api.py
+++ b/versioned_hdf5/tests/test_api.py
@@ -210,6 +210,8 @@ def test_version_name_slicing(vfile):
     assert vfile[-1]['test_data'][0] == 2.0
     assert vfile[-2]['test_data'][0] == 1.0, vfile[-2]
 
+    with raises(ValueError):
+        vfile['/_version_data']
 
 def test_iter_versions(vfile):
     test_data = np.concatenate((np.ones((2*DEFAULT_CHUNK_SIZE,)),
@@ -1253,8 +1255,7 @@ def test_closes(vfile):
     assert vfile.__repr__() == "<Closed VersionedHDF5File>"
 
     reopened_file = VersionedHDF5File(h5pyfile)
-    assert list(reopened_file['/_version_data/versions/__first_version__']) == []
-    assert list(reopened_file['/_version_data/versions/version1']) == list(reopened_file['version1']) == ['test_data']
+    assert list(reopened_file['version1']) == ['test_data']
     assert_equal(reopened_file['version1']['test_data'][()], data)
 
     assert reopened_file._version_data == version_data

--- a/versioned_hdf5/tests/test_api.py
+++ b/versioned_hdf5/tests/test_api.py
@@ -907,34 +907,34 @@ def test_groups(vfile):
         assert set(group['group1']['group2']) == set(group['group1/group2']) == {'group3', 'test_data2', 'test_data4'}
         assert list(group['group1']['group2']['group3']) == list(group['group1/group2/group3']) == ['test_data3']
 
-        version = vfile['version6']
-        assert_equal(version['group1']['test_data1'], data)
-        assert_equal(version['group1/test_data1'], data)
+    version = vfile['version6']
+    assert_equal(version['group1']['test_data1'], data)
+    assert_equal(version['group1/test_data1'], data)
 
-        assert_equal(version['group1']['group2']['test_data2'], 2*data)
-        assert_equal(version['group1/group2']['test_data2'], 2*data)
-        assert_equal(version['group1']['group2/test_data2'], 2*data)
-        assert_equal(version['group1/group2/test_data2'], 2*data)
+    assert_equal(version['group1']['group2']['test_data2'], 2*data)
+    assert_equal(version['group1/group2']['test_data2'], 2*data)
+    assert_equal(version['group1']['group2/test_data2'], 2*data)
+    assert_equal(version['group1/group2/test_data2'], 2*data)
 
-        assert_equal(version['group1']['group2']['group3']['test_data3'], 3*data)
-        assert_equal(version['group1/group2']['group3']['test_data3'], 3*data)
-        assert_equal(version['group1/group2']['group3/test_data3'], 3*data)
-        assert_equal(version['group1']['group2/group3/test_data3'], 3*data)
-        assert_equal(version['group1/group2/group3/test_data3'], 3*data)
+    assert_equal(version['group1']['group2']['group3']['test_data3'], 3*data)
+    assert_equal(version['group1/group2']['group3']['test_data3'], 3*data)
+    assert_equal(version['group1/group2']['group3/test_data3'], 3*data)
+    assert_equal(version['group1']['group2/group3/test_data3'], 3*data)
+    assert_equal(version['group1/group2/group3/test_data3'], 3*data)
 
-        assert_equal(version['group1']['group2']['test_data4'], 4*data)
-        assert_equal(version['group1/group2']['test_data4'], 4*data)
-        assert_equal(version['group1']['group2/test_data4'], 4*data)
-        assert_equal(version['group1/group2/test_data4'], 4*data)
+    assert_equal(version['group1']['group2']['test_data4'], 4*data)
+    assert_equal(version['group1/group2']['test_data4'], 4*data)
+    assert_equal(version['group1']['group2/test_data4'], 4*data)
+    assert_equal(version['group1/group2/test_data4'], 4*data)
 
-        assert list(version) == ['group1']
-        assert set(version['group1']) == {'group2', 'test_data1'}
-        assert set(version['group1']['group2']) == set(version['group1/group2']) == {'group3', 'test_data2', 'test_data4'}
-        assert list(version['group1']['group2']['group3']) == list(version['group1/group2/group3']) == ['test_data3']
+    assert list(version) == ['group1']
+    assert set(version['group1']) == {'group2', 'test_data1'}
+    assert set(version['group1']['group2']) == set(version['group1/group2']) == {'group3', 'test_data2', 'test_data4'}
+    assert list(version['group1']['group2']['group3']) == list(version['group1/group2/group3']) == ['test_data3']
 
-        with vfile.stage_version('version-bad', '') as group:
-            raises(ValueError, lambda: group.create_dataset('/group1/test_data', data=data))
-            raises(ValueError, lambda: group.create_group('/group1'))
+    with vfile.stage_version('version-bad', '') as group:
+        raises(ValueError, lambda: group.create_dataset('/group1/test_data', data=data))
+        raises(ValueError, lambda: group.create_group('/group1'))
 
 def test_group_contains(vfile):
     data = np.ones(2*DEFAULT_CHUNK_SIZE)
@@ -1665,3 +1665,21 @@ def test_sparse_large(vfile):
     assert vfile['version2']['test_data'][0] == 1
     assert vfile['version2']['test_data'][1] == 0
     assert vfile['version2']['test_data'][20_000_000] == 2
+
+def test_no_recursive_version_group_access(vfile):
+    timestamp1 = datetime.datetime.now(datetime.timezone.utc)
+    with vfile.stage_version('version1', timestamp=timestamp1) as g:
+        g.create_dataset('test', data=[1, 2, 3])
+
+    timestamp2 = datetime.datetime.now(datetime.timezone.utc)
+    minute = datetime.timedelta(minutes=1)
+    with vfile.stage_version('version2', timestamp=timestamp2) as g:
+        vfile['version1'] # Doesn't raise
+        raises(ValueError, lambda: vfile['version2'])
+
+        vfile[timestamp1] # Doesn't raise
+        # Without +minute, it will pick the previous version, as the
+        # uncommitted group only has a placeholder timestamp, which will be
+        # after timestamp2. Since this isn't supposed to work in the first
+        # place, this isn't a big deal.
+        raises(ValueError, lambda: vfile[timestamp2+minute])

--- a/versioned_hdf5/versions.py
+++ b/versioned_hdf5/versions.py
@@ -30,6 +30,11 @@ def create_version_group(f, version_name, prev_version=None):
     group.attrs['prev_version'] = prev_version
     group.attrs['committed'] = False
 
+    # Placeholder timestamp, just so the attr is there in case something calls
+    # get_version_by_timestamp before the version is committed.
+    ts = datetime.datetime.now(datetime.timezone.utc)
+    group.attrs['timestamp'] = ts.strftime(TIMESTAMP_FMT)
+
     # Copy everything over from the previous version
     prev_group = versions[prev_version]
 


### PR DESCRIPTION
This makes it easier to have a single version group object before the version
is committed, which is important because the object is still writable at that
stage.