### PR TITLE
More performance improvements

### DIFF
--- a/.authors.yml
+++ b/.authors.yml
@@ -28,6 +28,10 @@
   first_commit: 2020-06-12 18:49:22
 - name: Aaron Meurer
   email: asmeurer@gmail.com
-  num_commits: 394
+  num_commits: 416
   first_commit: 2019-11-26 18:13:42
   github: asmeurer
+- name: Marc Udoff
+  email: marc.udoff@deshaw.com
+  num_commits: 1
+  first_commit: 2021-03-02 11:24:01

--- a/.mailmap
+++ b/.mailmap
@@ -17,3 +17,4 @@ Arvid Bessen <bessen@deshaw.com>
 Saul Shanabrook <s.shanabrook@gmail.com>
 Anthony Scopatz <scopatz@gmail.com>
 Marc Udoff <mlucool@gmail.com>
+Marc Udoff <marc.udoff@deshaw.com>

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -7,3 +7,4 @@ Authors are sorted by number of commits.
 * Saul Shanabrook
 * Anthony Scopatz
 * Marc Udoff
+* Marc Udoff

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -28,7 +28,7 @@
 
     // List of branches to benchmark. If not provided, defaults to "master"
     // (for git) or "default" (for mercurial).
-    "branches": ["master", "performance3"], // for git
+    "branches": ["master", "performance2", "performance3"], // for git
     // "branches": ["default"],    // for mercurial
 
     // The DVCS being used.  If not set, it will be automatically

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -28,7 +28,7 @@
 
     // List of branches to benchmark. If not provided, defaults to "master"
     // (for git) or "default" (for mercurial).
-    "branches": ["master", "performance2"], // for git
+    "branches": ["master", "performance3"], // for git
     // "branches": ["default"],    // for mercurial
 
     // The DVCS being used.  If not set, it will be automatically

--- a/benchmarks/many_chunks.py
+++ b/benchmarks/many_chunks.py
@@ -45,3 +45,16 @@ def time_many_chunks_integer_index():
             i2 = np.random.choice(d1, 30, replace=False)
             i2 = np.sort(i2)
             sv['bar'][:, i2, :] = np.full((d0, len(i2), d2), i, dtype=dt)
+
+def time_many_chunks_arange():
+    d0 = 2
+    d1 = 15220
+    d2 = 2
+    shape = (d0, d1, d2)
+    chunks = (600, 2, 4)
+    with h5py.File('foo.h5', 'w') as f:
+        vf = VersionedHDF5File(f)
+        with vf.stage_version('0') as sv:
+            sv.create_dataset('bar', shape=shape, maxshape=(None, None, None),
+                              chunks=chunks, dtype=dt,
+                              data=np.arange(np.prod(shape), dtype=dt).reshape(shape))

--- a/benchmarks/many_chunks.py
+++ b/benchmarks/many_chunks.py
@@ -1,0 +1,47 @@
+# Benchmarks from https://github.com/deshaw/versioned-hdf5/issues/167
+
+import h5py
+import numpy as np
+from versioned_hdf5 import VersionedHDF5File
+
+dt = np.dtype('double')
+
+def time_many_chunks():
+    d0 = 2
+    d1 = 15220
+    d2 = 2
+    shape = (d0, d1, d2)
+    chunks = (600, 2, 4)
+    with h5py.File('foo.h5', 'w') as f:
+        vf = VersionedHDF5File(f)
+        with vf.stage_version('0') as sv:
+            sv.create_dataset('bar', shape=shape, maxshape=(None, None, None),
+                              chunks=chunks, dtype=dt,
+                              data=np.full(shape, 0, dtype=dt))
+
+    i = 1
+    with h5py.File('foo.h5', 'r+') as f:
+        vf = VersionedHDF5File(f)
+        with vf.stage_version(str(i)) as sv:
+            sv['bar'][:] = np.full(shape, i, dtype=dt)
+
+def time_many_chunks_integer_index():
+    d0 = 2
+    d1 = 15220
+    d2 = 2
+    shape = (d0, d1, d2)
+    chunks = (600, 2, 4)
+    with h5py.File('foo.h5', 'w') as f:
+        vf = VersionedHDF5File(f)
+        with vf.stage_version('0') as sv:
+            sv.create_dataset('bar', shape=shape, maxshape=(None, None, None),
+                              chunks=chunks, dtype=dt,
+                              data=np.full(shape, 0, dtype=dt))
+
+    i = 1
+    with h5py.File('foo.h5', 'r+') as f:
+        vf = VersionedHDF5File(f)
+        with vf.stage_version(str(i)) as sv:
+            i2 = np.random.choice(d1, 30, replace=False)
+            i2 = np.sort(i2)
+            sv['bar'][:, i2, :] = np.full((d0, len(i2), d2), i, dtype=dt)

--- a/benchmarks/versionedhdf5file.py
+++ b/benchmarks/versionedhdf5file.py
@@ -1,0 +1,23 @@
+import h5py
+import numpy as np
+from versioned_hdf5 import VersionedHDF5File
+
+
+class TimeDatetimeAccess:
+    def setup(self):
+        with h5py.File('foo.h5', 'w') as f:
+            vf = VersionedHDF5File(f)
+            with vf.stage_version('0') as sv:
+                sv.create_dataset('bar', data=np.random.rand(10))
+
+            for i in range(1, 1000):
+                with vf.stage_version(str(i)) as sv:
+                    self.dt = np.datetime64('now')
+                    sv['bar'][:] = np.random.rand(10)
+
+    def time_version_by_datetime(self):
+        # Based on https://github.com/deshaw/versioned-hdf5/issues/170
+        with h5py.File('foo.h5', 'r') as f:
+            vf = VersionedHDF5File(f)
+            for _ in range(1000):
+                _ = vf[self.dt]['bar'][:]

--- a/benchmarks/versionedhdf5file.py
+++ b/benchmarks/versionedhdf5file.py
@@ -10,14 +10,14 @@ class TimeDatetimeAccess:
             with vf.stage_version('0') as sv:
                 sv.create_dataset('bar', data=np.random.rand(10))
 
-            for i in range(1, 1000):
+            for i in range(1, 100):
                 with vf.stage_version(str(i)) as sv:
-                    self.dt = np.datetime64('now')
                     sv['bar'][:] = np.random.rand(10)
+            self.dt = np.datetime64(vf[str(50)].attrs['timestamp'])
 
     def time_version_by_datetime(self):
         # Based on https://github.com/deshaw/versioned-hdf5/issues/170
         with h5py.File('foo.h5', 'r') as f:
             vf = VersionedHDF5File(f)
-            for _ in range(1000):
+            for _ in range(100):
                 _ = vf[self.dt]['bar'][:]

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,13 +1,13 @@
 Versioned HDF5 Change Log
 =========================
 
-## 1.2.3 (2020-02-25)
+## 1.2.3 (2021-02-25)
 
 ## Minor Changes
 
 - Fix the length of str dtype not being maintained from the fillvalue.
 
-## 1.2.2 (2020-02-04)
+## 1.2.2 (2021-02-04)
 
 ## Minor Changes
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,15 +1,26 @@
 Versioned HDF5 Change Log
 =========================
 
+## 1.2.4 (2021-02-08)
+
+## Major Changes
+
+- Many improvements to performance throughout the library, particularly for
+  datasets with many chunks, and for looking up versions by timestamp. This
+  also sets up potential future performance improvements by automatically
+  converting sparse staged datasets to fully in-memory.
+
+- Add some additional benchmarks to the benchmark suite.
+
 ## 1.2.3 (2021-02-25)
 
-## Minor Changes
+### Minor Changes
 
 - Fix the length of str dtype not being maintained from the fillvalue.
 
 ## 1.2.2 (2021-02-04)
 
-## Minor Changes
+### Minor Changes
 
 - Many improvements to performance throughout the library.
 
@@ -21,7 +32,7 @@ Versioned HDF5 Change Log
 
 ## 1.2.1 (2020-12-30)
 
-## Minor Changes
+### Minor Changes
 
 - Python 3.6 support has been dropped. The lowest version of Python now
   supported is 3.7.
@@ -32,7 +43,7 @@ Versioned HDF5 Change Log
 
 ## 1.2 (2020-11-17)
 
-## Major Changes
+### Major Changes
 
 - Add support for sparse datasets (`data=None`).
 - Store the chunks on an attribute of the dataset.

--- a/rever.xsh
+++ b/rever.xsh
@@ -13,7 +13,7 @@ def run_tests():
                            'doctr', 'sphinx']):
         pyflakes versioned_hdf5/
         python -We:invalid -We::SyntaxWarning -m compileall -f -q versioned_hdf5/
-        pytest
+        pytest versioned_hdf5/
 
 @activity
 def build_docs():

--- a/update_benchmarks.sh
+++ b/update_benchmarks.sh
@@ -14,4 +14,4 @@ cp -R .asv/html benchmarks
 git add benchmarks
 git commit -m "Update benchmarks"
 git checkout -
-git push gh-pages
+git push origin gh-pages

--- a/update_benchmarks.sh
+++ b/update_benchmarks.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# Run and update the benchmarks in the gh-pages branch. This commits to that
-# branch but does not push. The resulting benchmarks are served at
+# Run and update the benchmarks in the gh-pages branch. The resulting
+# benchmarks are served at
 # https://deshaw.github.io/versioned-hdf5/benchmarks/index.html
 set -e
 set -x
@@ -14,3 +14,4 @@ cp -R .asv/html benchmarks
 git add benchmarks
 git commit -m "Update benchmarks"
 git checkout -
+git push gh-pages

--- a/versioned_hdf5/api.py
+++ b/versioned_hdf5/api.py
@@ -64,6 +64,7 @@ class VersionedHDF5File:
         self._version_data = f['_version_data']
         self._versions = self._version_data['versions']
         self._closed = False
+        self._version_cache = {}
 
     @property
     def current_version(self):
@@ -79,6 +80,7 @@ class VersionedHDF5File:
     @current_version.setter
     def current_version(self, version_name):
         set_current_version(self.f, version_name)
+        self._version_cache.clear()
 
     def get_version_by_name(self, version):
         if version == '':
@@ -96,6 +98,11 @@ class VersionedHDF5File:
         return InMemoryGroup(self._versions[version]._id, _committed=True)
 
     def __getitem__(self, item):
+        if item in self._version_cache:
+            # We don't cache version names because those are already cheap to
+            # lookup.
+            return self._version_cache[item]
+
         if item is None:
             return self.get_version_by_name(self.current_version)
         elif isinstance(item, str):
@@ -103,10 +110,12 @@ class VersionedHDF5File:
         elif isinstance(item, (int, np.integer)):
             if item > 0:
                 raise IndexError("Integer version slice must be negative")
-            return self.get_version_by_name(get_nth_previous_version(self.f,
+            self._version_cache[item] = self.get_version_by_name(get_nth_previous_version(self.f,
                 self.current_version, -item))
+            return self._version_cache[item]
         elif isinstance(item, (datetime.datetime, np.datetime64)):
-            return self.get_version_by_timestamp(item)
+            self._version_cache[item] = self.get_version_by_timestamp(item)
+            return self._version_cache[item]
         else:
             raise KeyError(f"Don't know how to get the version for {item!r}")
 
@@ -123,6 +132,7 @@ class VersionedHDF5File:
             raise KeyError(item)
         new_current = self.current_version if item != self.current_version else self[item].attrs['prev_version']
         delete_version(self.f, item, new_current)
+        self._version_cache.clear()
 
     def __iter__(self):
         return all_versions(self.f, include_first=False)
@@ -167,6 +177,8 @@ class VersionedHDF5File:
         except:
             delete_version(self.f, version_name, old_current)
             raise
+        finally:
+            self._version_cache.clear()
 
     def close(self):
         """

--- a/versioned_hdf5/backend.py
+++ b/versioned_hdf5/backend.py
@@ -195,7 +195,7 @@ def create_virtual_dataset(f, version_name, name, shape, slices, attrs=None, fil
             if c.isempty():
                 continue
             # idx = Tuple(s, *Tuple(*[slice(0, i) for i in shape[1:]]).as_subindex(Tuple(*c.args[1:])).args)
-            S = [Slice(0, c.args[i].stop - c.args[i].start) for i in range(1, len(shape))]
+            S = [Slice(0, len(c.args[i])) for i in range(1, len(shape))]
             idx = Tuple(s, *S)
             # assert c.newshape(shape) == vs[idx.raw].shape, (c, shape, s)
 

--- a/versioned_hdf5/backend.py
+++ b/versioned_hdf5/backend.py
@@ -195,7 +195,7 @@ def create_virtual_dataset(f, version_name, name, shape, slices, attrs=None, fil
             if c.isempty():
                 continue
             # idx = Tuple(s, *Tuple(*[slice(0, i) for i in shape[1:]]).as_subindex(Tuple(*c.args[1:])).args)
-            S = [Slice(0, shape[i], 1).as_subindex(c.args[i]) for i in range(1, len(shape))]
+            S = [Slice(0, c.args[i].stop - c.args[i].start) for i in range(1, len(shape))]
             idx = Tuple(s, *S)
             # assert c.newshape(shape) == vs[idx.raw].shape, (c, shape, s)
 

--- a/versioned_hdf5/backend.py
+++ b/versioned_hdf5/backend.py
@@ -172,6 +172,7 @@ def create_virtual_dataset(f, version_name, name, shape, slices, attrs=None, fil
     from h5py._hl.vds import VDSmap
 
     raw_data = f['_version_data'][name]['raw_data']
+    raw_data_shape = raw_data.shape
     slices = {c: s.reduce() for c, s in slices.items()}
 
     if len(raw_data) == 0:
@@ -205,7 +206,7 @@ def create_virtual_dataset(f, version_name, name, shape, slices, attrs=None, fil
             #
             # But it is faster because vs[idx.raw] does a deepcopy(vs), which
             # is slow.
-            vs_sel = select(raw_data.shape, idx.raw, dsid=None)
+            vs_sel = select(raw_data_shape, idx.raw, dsid=None)
             layout_sel = select(shape, c.raw, dsid=None)
             layout.sources.append(VDSmap(layout_sel.id,
                                    '.',

--- a/versioned_hdf5/slicetools.py
+++ b/versioned_hdf5/slicetools.py
@@ -1,3 +1,5 @@
+from functools import lru_cache
+
 from ndindex import Slice, Tuple
 
 def spaceid_to_slice(space):
@@ -16,15 +18,18 @@ def spaceid_to_slice(space):
     elif sel_type == h5s.SEL_HYPERSLABS:
         slices = []
         starts, strides, counts, blocks = space.get_regular_hyperslab()
-        for _start, _stride, count, block in zip(starts, strides, counts, blocks):
-            start = _start
-            if not (block == 1 or count == 1):
-                raise NotImplementedError("Nontrivial blocks are not yet supported")
-            end = _start + (_stride*(count - 1) + 1)*block
-            stride = _stride if block == 1 else 1
-            slices.append(Slice(start, end, stride))
+        for start, stride, count, block in zip(starts, strides, counts, blocks):
+            slices.append(hyperslab_to_slice(start, stride, count, block))
         return Tuple(*slices)
     elif sel_type == h5s.SEL_NONE:
         return Tuple(Slice(0, 0),)
     else:
         raise NotImplementedError("Point selections are not yet supported")
+
+@lru_cache(2048)
+def hyperslab_to_slice(start, stride, count, block):
+    if not (block == 1 or count == 1):
+        raise NotImplementedError("Nontrivial blocks are not yet supported")
+    end = start + (stride*(count - 1) + 1)*block
+    stride = stride if block == 1 else 1
+    return Slice(start, end, stride)

--- a/versioned_hdf5/tests/test_hashtable.py
+++ b/versioned_hdf5/tests/test_hashtable.py
@@ -8,24 +8,24 @@ from ..hashtable import Hashtable
 
 def test_hashtable(h5file):
     create_base_dataset(h5file, 'test_data', data=np.empty((0,)))
-    h = Hashtable(h5file, 'test_data')
-    assert len(h) == 0
-    h[b'\xff'*32] = slice(0, 1)
-    assert len(h) == 1
-    assert h[b'\xff'*32] == slice(0, 1)
-    assert h.largest_index == 1
-    assert bytes(h.hash_table[0][0]) == b'\xff'*32
-    assert tuple(h.hash_table[0][1]) == (0, 1)
-    assert h == {b'\xff'*32: slice(0, 1)}
+    with Hashtable(h5file, 'test_data') as h:
+        assert len(h) == 0
+        h[b'\xff'*32] = slice(0, 1)
+        assert len(h) == 1
+        assert h[b'\xff'*32] == slice(0, 1)
+        assert h.largest_index == 1
+        assert bytes(h.hash_table[0][0]) == b'\xff'*32
+        assert tuple(h.hash_table[0][1]) == (0, 1)
+        assert h == {b'\xff'*32: slice(0, 1)}
 
-    with raises(TypeError):
-        h['\x01'*32] = slice(0, 1)
-    with raises(ValueError):
-        h[b'\x01'] = slice(0, 1)
-    with raises(TypeError):
-        h[b'\x01'*32] = (0, 1)
-    with raises(ValueError):
-        h[b'\x01'*32] = slice(0, 4, 2)
+        with raises(TypeError):
+            h['\x01'*32] = slice(0, 1)
+        with raises(ValueError):
+            h[b'\x01'] = slice(0, 1)
+        with raises(TypeError):
+            h[b'\x01'*32] = (0, 1)
+        with raises(ValueError):
+            h[b'\x01'*32] = slice(0, 4, 2)
 
 
 def test_hashtable_multidimension(h5file):

--- a/versioned_hdf5/versions.py
+++ b/versioned_hdf5/versions.py
@@ -11,6 +11,13 @@ from .wrappers import InMemoryGroup, DatasetWrapper, InMemoryDataset, InMemoryAr
 TIMESTAMP_FMT = "%Y-%m-%d %H:%M:%S.%f%z"
 
 def create_version_group(f, version_name, prev_version=None):
+    """
+    Create the version group for a new version.
+
+    prev_version should be a pre-existing version name, None, or ''
+    If it is None, it defaults to the current version. If it is '', it creates
+    a version with no parent version.
+    """
     versions = f['_version_data/versions']
 
     if prev_version == '':
@@ -52,10 +59,6 @@ def commit_version(version_group, datasets, *,
                    timestamp=None):
     """
     Create a new version
-
-    prev_version should be a pre-existing version name, None, or ''
-    If it is None, it defaults to the current version. If it is '', it creates
-    a version with no parent version.
 
     datasets should be a dictionary mapping {path: dataset}, where `dataset`
     is either a numpy array, or a dictionary mapping {chunk_index:

--- a/versioned_hdf5/versions.py
+++ b/versioned_hdf5/versions.py
@@ -198,6 +198,8 @@ def get_version_by_timestamp(f, timestamp, exact=False):
                 if ts == version_ts:
                     return version
             else:
+                if ts == version_ts:
+                    return version
                 # Find the version whose timestamp is closest to ts and before
                 # it.
                 if best_ts < version_ts <= ts:

--- a/versioned_hdf5/versions.py
+++ b/versioned_hdf5/versions.py
@@ -6,7 +6,7 @@ import datetime
 import numpy as np
 
 from .backend import write_dataset, write_dataset_chunks, create_virtual_dataset
-from .wrappers import InMemoryGroup, InMemoryDataset, InMemoryArrayDataset, InMemorySparseDataset
+from .wrappers import InMemoryGroup, DatasetWrapper, InMemoryDataset, InMemoryArrayDataset, InMemorySparseDataset
 
 TIMESTAMP_FMT = "%Y-%m-%d %H:%M:%S.%f%z"
 
@@ -83,6 +83,8 @@ def commit_version(version_group, datasets, *,
 
     for name, data in datasets.items():
         fillvalue = None
+        if isinstance(data, DatasetWrapper):
+            data = data.dataset
         if isinstance(data, (InMemoryDataset, InMemoryArrayDataset, InMemorySparseDataset)):
             attrs = data.attrs
             fillvalue = data.fillvalue

--- a/versioned_hdf5/wrappers.py
+++ b/versioned_hdf5/wrappers.py
@@ -967,13 +967,10 @@ class DatasetWrapper(DatasetLike):
 class InMemoryDatasetID(h5d.DatasetID):
     def __init__(self, _id):
         # super __init__ is handled by DatasetID.__cinit__ automatically
-        self.data_dict = {}
+        self._data_dict = None
         with phil:
             sid = self.get_space()
             self._shape = sid.get_simple_extent_dims()
-
-        dcpl = self.get_create_plist()
-        is_virtual = dcpl.get_layout() == h5d.VIRTUAL
 
         attr = h5a.open(self, b'raw_data')
         htype = h5t.py_create(attr.dtype)
@@ -981,50 +978,67 @@ class InMemoryDatasetID(h5d.DatasetID):
         attr.read(_arr, mtype=htype)
         raw_data_name = _arr[()]
 
-        if not is_virtual:
-            # A dataset created with only a fillvalue will be nonvirtual,
-            # since create_virtual_dataset makes a nonvirtual dataset when
-            # there are no virtual sources.
-            slice_map = {}
-        # Same as dataset.get_virtual_sources
-        elif 0 in self._shape:
-            # Work around https://github.com/h5py/h5py/issues/1660
-            empty_idx = Tuple().expand(self._shape)
-            slice_map = {empty_idx: empty_idx}
-        else:
-            virtual_sources = [
-                    VDSmap(dcpl.get_virtual_vspace(j),
-                           dcpl.get_virtual_filename(j),
-                           dcpl.get_virtual_dsetname(j),
-                           dcpl.get_virtual_srcspace(j))
-                    for j in range(dcpl.get_virtual_count())]
-
-            slice_map = {spaceid_to_slice(i.vspace): spaceid_to_slice(i.src_space)
-                         for i in virtual_sources}
-            assert raw_data_name == virtual_sources[0].dset_name
-            assert all(i.dset_name == raw_data_name for i in virtual_sources)
-
-        # slice_map = {i.args[0]: j.args[0] for i, j in slice_map.items()}
         fid = h5i.get_file_id(self)
         g = Group(fid)
         self.raw_data = g[raw_data_name]
         self.chunks = tuple(self.raw_data.attrs['chunks'])
 
-        for s in slice_map:
-            src_idx = slice_map[s]
-            if isinstance(src_idx, Tuple):
-                # The pointers to the raw data should only be slices, since
-                # the raw data chunks are extended in the first dimension
-                # only.
-                assert src_idx != Tuple()
-                assert len(src_idx.args) == len(self.chunks)
-                src_idx = src_idx.args[0]
-            assert isinstance(src_idx, Slice)
-            self.data_dict[s] = src_idx
-
         fillvalue_a = np.empty((1,), dtype=self.dtype)
+        dcpl = self.get_create_plist()
         dcpl.get_fill_value(fillvalue_a)
         self.fillvalue = fillvalue_a[0]
+
+    @property
+    def data_dict(self):
+        if self._data_dict is None:
+            self._data_dict = {}
+
+            dcpl = self.get_create_plist()
+            is_virtual = dcpl.get_layout() == h5d.VIRTUAL
+
+
+            if not is_virtual:
+                # A dataset created with only a fillvalue will be nonvirtual,
+                # since create_virtual_dataset makes a nonvirtual dataset when
+                # there are no virtual sources.
+                slice_map = {}
+            # Same as dataset.get_virtual_sources
+            elif 0 in self._shape:
+                # Work around https://github.com/h5py/h5py/issues/1660
+                empty_idx = Tuple().expand(self._shape)
+                slice_map = {empty_idx: empty_idx}
+            else:
+                virtual_sources = [
+                        VDSmap(dcpl.get_virtual_vspace(j),
+                               dcpl.get_virtual_filename(j),
+                               dcpl.get_virtual_dsetname(j),
+                               dcpl.get_virtual_srcspace(j))
+                        for j in range(dcpl.get_virtual_count())]
+
+                slice_map = {spaceid_to_slice(i.vspace): spaceid_to_slice(i.src_space)
+                             for i in virtual_sources}
+                assert self.raw_data.name == virtual_sources[0].dset_name
+                assert all(i.dset_name == self.raw_data.name for i in virtual_sources)
+
+            # slice_map = {i.args[0]: j.args[0] for i, j in slice_map.items()}
+
+            for s in slice_map:
+                src_idx = slice_map[s]
+                if isinstance(src_idx, Tuple):
+                    # The pointers to the raw data should only be slices, since
+                    # the raw data chunks are extended in the first dimension
+                    # only.
+                    assert src_idx != Tuple()
+                    assert len(src_idx.args) == len(self.chunks)
+                    src_idx = src_idx.args[0]
+                assert isinstance(src_idx, Slice)
+                self._data_dict[s] = src_idx
+
+        return self._data_dict
+
+    @data_dict.setter
+    def data_dict(self, value):
+        self._data_dict = value
 
     def set_extent(self, shape):
         raise NotImplementedError("Resizing an InMemoryDataset other than via resize()")


### PR DESCRIPTION
The goal here is to improve the performance, particularly in situations where there are many chunks (see https://github.com/deshaw/versioned-hdf5/issues/167). 

This is still a work in progress. 

Some key improvements here:

- Bypass the h5py VirtualSource object and create the layout manually (see the commit message of https://github.com/deshaw/versioned-hdf5/commit/d45a045b2bd7fab0263fd6cc97b4315404400925)
- Allow dataset objects to be promoted from storing a dictionary of chunks to an InMemoryArrayDataset object, which stores a single array. The benefits of referencing the original dataset are lost if the majority of the dataset is modified. Currently this is only done if the entire dataset is modified at once, but it opens open the possibility to do it more generally.
- Directly copy datasets that aren't modified at all in a version. Previously they were recreated chunk-by-chunk. This should improve the performance in cases where there are many datasets that aren't modified in a version (this isn't reflected in the benchmark from https://github.com/deshaw/versioned-hdf5/issues/167).

There is also an ndindex pull request that improves the performance in some cases https://github.com/Quansight-Labs/ndindex/pull/114 (so far, this PR and the ndindex PR are independent). 