### PR TITLE
Workaround the upstream h5py garbage collection issue

### DIFF
--- a/versioned_hdf5/tests/conftest.py
+++ b/versioned_hdf5/tests/conftest.py
@@ -25,7 +25,7 @@ def h5file(tmp_path, request):
     except ValueError as e:
         # Workaround upstream h5py bug. https://github.com/deshaw/versioned-hdf5/issues/162
         if e.args[0] == "Unrecognized type code -1":
-            pass
+            return
         raise
 
 

--- a/versioned_hdf5/tests/conftest.py
+++ b/versioned_hdf5/tests/conftest.py
@@ -20,7 +20,13 @@ def h5file(tmp_path, request):
 
     f = setup(file_name=file_name, name=name, version_name=version_name)
     yield f
-    f.close()
+    try:
+        f.close()
+    except ValueError as e:
+        # Workaround upstream h5py bug. https://github.com/deshaw/versioned-hdf5/issues/162
+        if e.args[0] == "Unrecognized type code -1":
+            pass
+        raise
 
 
 @yield_fixture


### PR DESCRIPTION
This is the issue from https://github.com/deshaw/versioned-hdf5/issues/162.
h5py has a fix, but we won't be able to use it in 2.10.0 unless we manually
backport the patch and custom build h5py. The bug doesn't affect the actual
tests, it just causes them to crash sometimes when the file is closed.