### PR TITLE
Better error messages from VersionedHDF5File when the underlying file is closed

### DIFF
--- a/versioned_hdf5/api.py
+++ b/versioned_hdf5/api.py
@@ -67,6 +67,14 @@ class VersionedHDF5File:
         self._version_cache = {}
 
     @property
+    def closed(self):
+        if self._closed:
+            return self._closed
+        if not self.f.id:
+            self._closed = True
+        return self._closed
+
+    @property
     def current_version(self):
         """
         The current version.
@@ -107,6 +115,8 @@ class VersionedHDF5File:
         return InMemoryGroup(g._id, _committed=True)
 
     def __getitem__(self, item):
+        if self.closed:
+            raise ValueError("File is closed")
         if item in self._version_cache:
             # We don't cache version names because those are already cheap to
             # lookup.
@@ -169,7 +179,7 @@ class VersionedHDF5File:
         `prev_version` for any future `stage_version` call.
 
         """
-        if self._closed:
+        if self.closed:
             raise ValueError("File is closed")
         old_current = self.current_version
         group = create_version_group(self.f, version_name,
@@ -205,7 +215,7 @@ class VersionedHDF5File:
 
         These messages are intended to be similar to h5py messages.
         """
-        if self._closed:
+        if self.closed:
             return "<Closed VersionedHDF5File>"
         else:
             return f"<VersionedHDF5File object \"{self.f.filename}\" (mode" \

--- a/versioned_hdf5/tests/test_api.py
+++ b/versioned_hdf5/tests/test_api.py
@@ -1233,6 +1233,7 @@ def test_closes(vfile):
     with vfile.stage_version('version1') as g:
         g.create_dataset('test_data', data=data)
     assert vfile._closed is False
+    assert vfile.closed is False
 
     version_data = vfile._version_data
     versions = vfile._versions
@@ -1241,10 +1242,11 @@ def test_closes(vfile):
     vfile.close()
 
     assert vfile._closed is True
+    assert vfile.closed is True
     raises(AttributeError, lambda: vfile.f)
     raises(AttributeError, lambda: vfile._version_data)
     raises(AttributeError, lambda: vfile._versions)
-    assert vfile.__repr__() == "<Closed VersionedHDF5File>"
+    assert repr(vfile) == "<Closed VersionedHDF5File>"
 
     reopened_file = VersionedHDF5File(h5pyfile)
     assert list(reopened_file['version1']) == ['test_data']
@@ -1253,6 +1255,12 @@ def test_closes(vfile):
     assert reopened_file._version_data == version_data
     assert reopened_file._versions == versions
 
+    # Close the underlying file
+    h5pyfile.close()
+    assert vfile.closed is True
+    raises(ValueError, lambda: vfile['version1'])
+    raises(ValueError, lambda: vfile['version2'])
+    assert repr(vfile) == "<Closed VersionedHDF5File>"
 
 def test_scalar_dataset():
     for data1, data2 in [


### PR DESCRIPTION
This addresses some comments that were brought up in issue #162.