### PR TITLE
Fix np.datetime64 handling when the second has 0 fractional part

### DIFF
--- a/versioned_hdf5/api.py
+++ b/versioned_hdf5/api.py
@@ -178,6 +178,14 @@ class VersionedHDF5File:
         as the current version. The current version is used as the default
         `prev_version` for any future `stage_version` call.
 
+        `timestamp` may be a datetime.datetime or np.datetime64 timestamp for
+        the version. Note that datetime.datetime timestamps must be in the UTC
+        timezone (np.datetime64 timestamps are not timezone aware and are
+        assumed to be UTC). If `timestamp` is `None` (the default) the current
+        time when the context manager exits is used. When passing in a manual
+        timestamp, be aware that no consistency checks are made to ensure that
+        version timestamps are linear or not duplicated.
+
         """
         if self.closed:
             raise ValueError("File is closed")

--- a/versioned_hdf5/tests/conftest.py
+++ b/versioned_hdf5/tests/conftest.py
@@ -40,7 +40,8 @@ def h5file(tmp_path, request):
         raise
     except RuntimeError as e:
         if e.args[0] in ["Can't increment id ref count (can't locate ID)",
-                         "Unspecified error in H5Iget_type (return value <0)"]:
+                         "Unspecified error in H5Iget_type (return value <0)",
+                         "Can't retrieve file id (invalid data ID)"]:
             return
         raise
 

--- a/versioned_hdf5/tests/test_api.py
+++ b/versioned_hdf5/tests/test_api.py
@@ -617,8 +617,8 @@ def test_timestamp_manual(vfile):
     data1 = np.ones((2*DEFAULT_CHUNK_SIZE,))
     data2 = np.ones((3*DEFAULT_CHUNK_SIZE))
 
-    ts1 = datetime.datetime(2020, 6, 29, 20, 12, 56, 2560, tzinfo=datetime.timezone.utc)
-    ts2 = datetime.datetime(2020, 6, 29, 22, 12, 56, 2560)
+    ts1 = datetime.datetime(2020, 6, 29, 20, 12, 56, tzinfo=datetime.timezone.utc)
+    ts2 = datetime.datetime(2020, 6, 29, 22, 12, 56)
     with vfile.stage_version('version1', timestamp=ts1) as group:
         group['test_data_1'] = data1
 
@@ -631,6 +631,26 @@ def test_timestamp_manual(vfile):
     with raises(TypeError):
         with vfile.stage_version('version3', timestamp='2020-6-29') as group:
             group['test_data_3'] = data1
+
+
+def test_timestamp_manual_datetime64(vfile):
+    data = np.ones((2*DEFAULT_CHUNK_SIZE,))
+
+    # Also tests that it works correctly for 0 fractional part (issue #190).
+    ts = datetime.datetime(2020, 6, 29, 20, 12, 56, tzinfo=datetime.timezone.utc)
+    npts = np.datetime64(ts.replace(tzinfo=None))
+
+    with vfile.stage_version('version1', timestamp=npts) as group:
+        group['test_data'] = data
+
+    v1 = vfile['version1']
+
+    assert v1.attrs['timestamp'] == ts.strftime(TIMESTAMP_FMT)
+
+    assert vfile[npts] == v1
+    assert vfile[ts] == v1
+    assert vfile.get_version_by_timestamp(npts, exact=True) == v1
+    assert vfile.get_version_by_timestamp(ts, exact=True) == v1
 
 
 def test_getitem_by_timestamp(vfile):
@@ -701,7 +721,6 @@ def test_getitem_by_timestamp(vfile):
     raises(KeyError, lambda: vfile[dt0] == v1)
     raises(KeyError, lambda: vfile.get_version_by_timestamp(dt0) == v1)
     raises(KeyError, lambda: vfile.get_version_by_timestamp(dt0, exact=True))
-
 
 def test_nonroot(vfile):
     g = vfile.f.create_group('subgroup')

--- a/versioned_hdf5/tests/test_api.py
+++ b/versioned_hdf5/tests/test_api.py
@@ -633,6 +633,30 @@ def test_timestamp_manual(vfile):
             group['test_data_3'] = data1
 
 
+def test_timestamp_pytz(vfile):
+    # pytz is not a dependency of versioned-hdf5, but it is supported if it is
+    # used.
+    import pytz
+
+    data1 = np.ones((2*DEFAULT_CHUNK_SIZE,))
+    data2 = np.ones((3*DEFAULT_CHUNK_SIZE))
+
+    ts1 = datetime.datetime(2020, 6, 29, 20, 12, 56, tzinfo=pytz.utc)
+    ts2 = datetime.datetime(2020, 6, 29, 22, 12, 56)
+    with vfile.stage_version('version1', timestamp=ts1) as group:
+        group['test_data_1'] = data1
+
+    assert vfile['version1'].attrs['timestamp'] == ts1.strftime(TIMESTAMP_FMT)
+
+    with raises(ValueError):
+        with vfile.stage_version('version2', timestamp=ts2) as group:
+            group['test_data_2'] = data2
+
+    with raises(TypeError):
+        with vfile.stage_version('version3', timestamp='2020-6-29') as group:
+            group['test_data_3'] = data1
+
+
 def test_timestamp_manual_datetime64(vfile):
     data = np.ones((2*DEFAULT_CHUNK_SIZE,))
 

--- a/versioned_hdf5/versions.py
+++ b/versioned_hdf5/versions.py
@@ -145,7 +145,7 @@ def commit_version(version_group, datasets, *,
 
     if timestamp is not None:
         if isinstance(timestamp, datetime.datetime):
-            if timestamp.tzinfo != datetime.timezone.utc:
+            if timestamp.utcoffset() != datetime.timedelta(0):
                 raise ValueError("timestamp must be in UTC")
             version_group.attrs['timestamp'] = timestamp.strftime(TIMESTAMP_FMT)
         elif isinstance(timestamp, np.datetime64):
@@ -193,7 +193,7 @@ def get_version_by_timestamp(f, timestamp, exact=False):
     if isinstance(timestamp, np.datetime64):
         ts = timestamp.astype(datetime.datetime).replace(tzinfo=datetime.timezone.utc).strftime(TIMESTAMP_FMT)
     elif isinstance(timestamp, datetime.datetime):
-        if timestamp.tzinfo != datetime.timezone.utc:
+        if timestamp.utcoffset() != datetime.timedelta(0):
             raise ValueError("timestamp must be in UTC")
         ts = timestamp.strftime(TIMESTAMP_FMT)
     else:


### PR DESCRIPTION
Also adds some additional type checks on the timestamp in
get_version_by_timestamp() to be consistent with commit_version().

Fixes #190.