### PR TITLE
Improve the performance for small chunks

### DIFF
--- a/versioned_hdf5/backend.py
+++ b/versioned_hdf5/backend.py
@@ -125,6 +125,7 @@ def write_dataset(f, name, data, chunks=None, dtype=None, compression=None,
 
             ds.resize((old_shape[0] + len(slices_to_write)*chunk_size,) + chunks[1:])
             for raw_slice, s in slices_to_write.items():
+                # idx = raw_slice.expand(ds.shape[:1] + s.newshape(data.shape)[1:])
                 data_s = data[s.raw]
                 idx = Tuple(raw_slice, *[slice(0, i) for i in data_s.shape[1:]])
                 ds[idx.raw] = data[s.raw]

--- a/versioned_hdf5/wrappers.py
+++ b/versioned_hdf5/wrappers.py
@@ -662,7 +662,7 @@ class InMemoryDataset(Dataset):
 
     @with_phil
     def __setitem__(self, args, val):
-        """ Write to the HDF5 dataset from a Numpy array.
+        """ Write to the HDF5 dataset from a NumPy array.
 
         NumPy's broadcasting rules are honored, for "simple" indexing
         (slices and integers).  For advanced indexing, the shapes must

--- a/versioned_hdf5/wrappers.py
+++ b/versioned_hdf5/wrappers.py
@@ -1181,6 +1181,13 @@ class InMemoryDatasetID(h5d.DatasetID):
     def data_dict(self, value):
         self._data_dict = value
 
+    @property
+    def has_arrays(self):
+        if self._data_dict is None:
+            return False
+        return any(isinstance(i, np.ndarray) for i in
+                   self._data_dict.values())
+
     def set_extent(self, shape):
         raise NotImplementedError("Resizing an InMemoryDataset other than via resize()")
 

--- a/versioned_hdf5/wrappers.py
+++ b/versioned_hdf5/wrappers.py
@@ -1197,6 +1197,3 @@ class InMemoryDatasetID(h5d.DatasetID):
 
     def write(self, mspace, fspace, arr_obj, mtype=None, dxpl=None):
         raise NotImplementedError("Writing to an InMemoryDataset other than via __setitem__")
-
-    def read(self, mspace, fspace, arr_obj, mtype=None, dxpl=None):
-        raise NotImplementedError("Reading from an InMemoryDataset other than via __getitem__")

--- a/versioned_hdf5/wrappers.py
+++ b/versioned_hdf5/wrappers.py
@@ -1190,8 +1190,9 @@ class InMemoryDatasetID(h5d.DatasetID):
         """
         Whether reading directly from the underlying dataset is OK
 
-        If this is True, then calling h5py.Dataset.__getitem__ on the Dataset
-        can be used, which may be faster than InMemoryDataset.__getitem__.
+        If this is True, then h5py.Dataset.__getitem__ can be used, which may
+        be faster than InMemoryDataset.__getitem__. This will happen in
+        particular when reading a read-only dataset.
 
         """
         if (self._data_dict is not None

--- a/versioned_hdf5/wrappers.py
+++ b/versioned_hdf5/wrappers.py
@@ -640,6 +640,9 @@ class InMemoryDataset(Dataset):
 
         arr = np.ndarray(idx.newshape(self.shape), new_dtype, order='C')
 
+        if not self.id.has_arrays:
+            return super().__getitem__(args)
+
         for c in self.chunks.as_subchunks(idx, self.shape):
             if c not in self.id.data_dict:
                 fill = np.broadcast_to(self.fillvalue, c.newshape(self.shape))


### PR DESCRIPTION
Fixes #193.

So far this primarily focuses on the read performance, particularly for the case when reading an already committed version. There are still some optimizations that can be made to improve the performance for

- Writing the dataset (especially writing a new dataset).
- Reading the dataset in the case when it is not read-only and some modifications have already been made to it.
- Writing a dataset when the majority, but not the entirety, of the dataset is being overwritten.

I have some ideas how to improve each of these cases, but they will take some work, so we should determine if any of them are not actually that important for our use cases. 