### PR TITLE
Unpin h5py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
     packages=['versioned_hdf5', 'versioned_hdf5.tests'],
     license="BSD",
     install_requires=[
-        "h5py<3",
+        "h5py",
         "numpy",
         "ndindex>=1.5.1",
     ],


### PR DESCRIPTION
It looks like PR #148 fixed the incompatibilities and resumed running the CI with h5py 3.x, so hopefully the requirement can be relaxed now.