### PR TITLE
Fix some issues with h5py 3.3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.7', '3.8', '3.9']
-        h5py-version: ['2.10', '3']
+        h5py-version: ['2.10', '3.2', '3']
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/versioned_hdf5/backend.py
+++ b/versioned_hdf5/backend.py
@@ -199,8 +199,12 @@ def create_virtual_dataset(f, version_name, name, shape, slices, attrs=None, fil
             if len(c.args[0]) != len(s):
                 raise ValueError(f"Inconsistent slices dictionary ({c.args[0]}, {s})")
 
+        # h5py 3.3 changed the VirtualLayout code. See
+        # https://github.com/h5py/h5py/pull/1905.
         layout = VirtualLayout(shape, dtype=raw_data.dtype)
-        # vs = VirtualSource('.', name=raw_data.name, shape=raw_data.shape, dtype=raw_data.dtype)
+        layout_has_sources = hasattr(layout, 'sources')
+        if not layout_has_sources:
+            vs = VirtualSource('.', name=raw_data.name, shape=raw_data.shape, dtype=raw_data.dtype)
 
         for c, s in slices.items():
             if c.isempty():
@@ -210,18 +214,18 @@ def create_virtual_dataset(f, version_name, name, shape, slices, attrs=None, fil
             idx = Tuple(s, *S)
             # assert c.newshape(shape) == vs[idx.raw].shape, (c, shape, s)
 
-            # This is equivalent to
-            #
-            # layout[c.raw] = vs[idx.raw]
-            #
-            # But it is faster because vs[idx.raw] does a deepcopy(vs), which
-            # is slow.
-            vs_sel = select(raw_data_shape, idx.raw, None)
-            layout_sel = select(shape, c.raw, None)
-            layout.sources.append(VDSmap(layout_sel.id,
-                                   '.',
-                                   raw_data.name,
-                                   vs_sel.id))
+            if not layout_has_sources:
+                # TODO: Use a faster workaround here too
+                layout[c.raw] = vs[idx.raw]
+            else:
+                # This is equivalent, but it is faster because vs[idx.raw] does a deepcopy(vs), which
+                # is slow.
+                vs_sel = select(raw_data_shape, idx.raw, None)
+                layout_sel = select(shape, c.raw, None)
+                layout.sources.append(VDSmap(layout_sel.id,
+                                       '.',
+                                       raw_data.name,
+                                       vs_sel.id))
 
     dtype = raw_data.dtype
     if dtype.metadata and ('vlen' in dtype.metadata or 'h5py_encoding' in dtype.metadata):


### PR DESCRIPTION
The sources attribute for VirtualLayout was removed because VirtualLayout now
creates the virtual sources property list directly, so some code that was
manipulating that needed to be rewritten. The upside is that this new
VirtualLayout code should use less memory in cases where a dataset with many
chunks is created.

See https://github.com/h5py/h5py/pull/1905.