### PR TITLE
Make the hashtable dataset exactly as big as it needs to be

### DIFF
--- a/versioned_hdf5/tests/test_slicetools.py
+++ b/versioned_hdf5/tests/test_slicetools.py
@@ -24,7 +24,7 @@ def test_spaceid_to_slice(h5file):
                     sel = Selection((shape,), spaceid)
                     try:
                         a[sel]
-                    except ValueError:
+                    except (ValueError, OSError):
                         # HDF5 doesn't allow stride/count combinations
                         # that are impossible (the count must be the exact
                         # number of elements in the selected block).


### PR DESCRIPTION
Previously it was always filled with 0s to be default_chunk_size aligned, but
this is no longer necessary now that we write to it once at the end. The
chunk_size resizing is still used for the in-memory NumPy array.

This makes the hashtables much smaller on disk for datasets without many
chunks.

This keeps the largest_index attribute for backwards compatibility with hash
tables that were created before this change (which will automatically be
resized down the next time they are written to). It also fixes the
documentation of largest_index.

Fixes #205.