### PR TITLE
Don't return wrapper classes when the file is in read-only mode

### DIFF
--- a/versioned_hdf5/api.py
+++ b/versioned_hdf5/api.py
@@ -103,15 +103,17 @@ class VersionedHDF5File:
         g = self._versions[version]
         if not g.attrs['committed']:
             raise ValueError("Version groups cannot accessed from the VersionedHDF5File object before they are committed.")
-        # TODO: Don't give an in-memory group if the file is read-only
+        if self.f.file.mode == 'r':
+            return g
         return InMemoryGroup(g._id, _committed=True)
 
     def get_version_by_timestamp(self, timestamp, exact=False):
         version = get_version_by_timestamp(self.f, timestamp, exact=exact)
-        # TODO: Don't give an in-memory group if the file is read-only
         g = self._versions[version]
         if not g.attrs['committed']:
             raise ValueError("Version groups cannot accessed from the VersionedHDF5File object before they are committed.")
+        if self.f.file.mode == 'r':
+            return g
         return InMemoryGroup(g._id, _committed=True)
 
     def __getitem__(self, item):

--- a/versioned_hdf5/tests/conftest.py
+++ b/versioned_hdf5/tests/conftest.py
@@ -1,6 +1,6 @@
 import os
 from pytest import fixture
-from .helpers import setup
+from .helpers import setup_vfile
 from ..api import VersionedHDF5File
 
 # Run tests marked with @pytest.mark.slow last. See
@@ -28,7 +28,7 @@ def h5file(tmp_path, request):
         if 'version_name' in m.kwargs.keys():
             version_name = m.kwargs['version_name']
 
-    f = setup(file_name=file_name, version_name=version_name)
+    f = setup_vfile(file_name=file_name, version_name=version_name)
     yield f
     try:
         f.close()

--- a/versioned_hdf5/tests/helpers.py
+++ b/versioned_hdf5/tests/helpers.py
@@ -2,7 +2,7 @@ import h5py
 from ..backend import initialize
 
 
-def setup(file_name='file.hdf5', *, version_name=None):
+def setup_vfile(file_name='file.hdf5', *, version_name=None):
     f = h5py.File(file_name, 'w')
     initialize(f)
     if version_name:

--- a/versioned_hdf5/tests/test_api.py
+++ b/versioned_hdf5/tests/test_api.py
@@ -1811,10 +1811,12 @@ def test_mask_reading(tmp_path):
         b = sv['bar'][mask]
         assert_equal(b, [1, 2])
 
-# This fails in h5py 2.10 because read-only files return the virtual
-# dataset directly, but h5py 2.10 does not support mask indices on virtual
+# This fails prior to h5py 3.3 because read-only files return the virtual
+# dataset directly, but h5py <3.3 does not support mask indices on virtual
 # datasets.
-@mark.xfail(h5py.__version__[0] == '2', reason='h5py 2 does not support masks on virtual datasets')
+@mark.xfail(h5py.__version__[0] == '2'
+            or h5py.__version__[0] == '3' and int(h5py.__version__[2]) < 3,
+            reason='h5py 2 does not support masks on virtual datasets')
 def test_mask_reading_read_only(tmp_path):
     # Reading a virtual dataset with a mask does not work in HDF5, so make
     # sure it still works for versioned datasets.

--- a/versioned_hdf5/tests/test_api.py
+++ b/versioned_hdf5/tests/test_api.py
@@ -10,7 +10,7 @@ import datetime
 import numpy as np
 from numpy.testing import assert_equal
 
-from .helpers import setup
+from .helpers import setup_vfile
 from ..backend import DEFAULT_CHUNK_SIZE
 from ..api import VersionedHDF5File
 from ..versions import TIMESTAMP_FMT
@@ -1315,7 +1315,7 @@ def test_scalar_dataset():
     ]:
 
         dt = np.asarray(data1).dtype
-        with setup() as f:
+        with setup_vfile() as f:
             file = VersionedHDF5File(f)
             with file.stage_version('v1') as group:
                 group['scalar_ds'] = data1
@@ -1443,7 +1443,7 @@ def test_string_dtypes():
         else:
             data = np.full(10, b'hello world', dtype=dt)
 
-        with setup() as f:
+        with setup_vfile() as f:
             file = VersionedHDF5File(f)
             with file.stage_version('0') as sv:
                 sv.create_dataset("name", shape=(10,), dtype=dt, data=data)
@@ -1488,7 +1488,7 @@ def test_empty(vfile):
 
 
 def test_read_only():
-    with setup('test.hdf5') as f:
+    with setup_vfile('test.hdf5') as f:
         file = VersionedHDF5File(f)
         timestamp = datetime.datetime.now(datetime.timezone.utc)
         with file.stage_version('version1', timestamp=timestamp) as g:
@@ -1611,7 +1611,7 @@ def test_auto_create_group(vfile):
     assert_equal(vfile['version1']['a']['b']['c'][:], [0, 1, 2])
 
 def test_scalar():
-    with setup('test.hdf5') as f:
+    with setup_vfile('test.hdf5') as f:
         vfile = VersionedHDF5File(f)
         with vfile.stage_version('version1') as g:
             dtype = h5py.special_dtype(vlen=bytes)
@@ -1839,7 +1839,7 @@ def test_mask_reading_read_only(tmp_path):
 
 def test_read_only_no_wrappers():
     # Read-only files should not use the wrapper classes
-    with setup('test.hdf5') as f:
+    with setup_vfile('test.hdf5') as f:
         vfile = VersionedHDF5File(f)
         with vfile.stage_version('version1') as g:
             g.create_dataset('bar', data=np.array([0, 1, 2]))

--- a/versioned_hdf5/tests/test_backend.py
+++ b/versioned_hdf5/tests/test_backend.py
@@ -7,7 +7,7 @@ from pytest import mark, raises
 
 import itertools
 
-from .helpers import setup
+from .helpers import setup_vfile
 
 from ..backend import (create_base_dataset, write_dataset,
                        create_virtual_dataset, DEFAULT_CHUNK_SIZE,
@@ -17,7 +17,7 @@ CHUNK_SIZE_3D = 2**4  # = cbrt(DEFAULT_CHUNK_SIZE)
 
 
 def test_initialize():
-    with setup() as f:
+    with setup_vfile() as f:
         pass
     f.close()
 

--- a/versioned_hdf5/tests/test_hashtable.py
+++ b/versioned_hdf5/tests/test_hashtable.py
@@ -5,7 +5,7 @@ import h5py
 
 from ..backend import create_base_dataset
 from ..hashtable import Hashtable
-from .helpers import setup
+from .helpers import setup_vfile
 from .. import VersionedHDF5File
 
 def test_hashtable(h5file):
@@ -30,7 +30,7 @@ def test_hashtable(h5file):
             h[b'\x01'*32] = slice(0, 4, 2)
 
 def test_from_raw_data():
-    with setup('test.h5') as f:
+    with setup_vfile('test.h5') as f:
         vf = VersionedHDF5File(f)
         with vf.stage_version('0') as sv:
             sv.create_dataset('test_data', data=np.arange(100), chunks=(10,))
@@ -50,7 +50,7 @@ def test_hashtable_multidimension(h5file):
     assert h.hash(np.ones((1, 2, 3,))) != h.hash(np.ones((3, 2, 1)))
 
 def test_issue_208():
-    with setup('test.h5') as f:
+    with setup_vfile('test.h5') as f:
         vf = VersionedHDF5File(f)
         with vf.stage_version('0') as sv:
             sv.create_dataset('bar', data=np.arange(10))


### PR DESCRIPTION
This improves the read performance in these cases. When the file is not in
read-only mode, we still use wrapper classes even for committed groups because
these have the safety checks to prevent accidental writing, which would
corrupt the raw data.

This breaks using mask indices in h5py 2.10 for read-only files, since these
are not supported for virtual datasets and we only support them manually via
the wrappers. h5py 3 does support them, however.

Fixes #217.