### PR TITLE
Fixed a few issues interfering with running tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,53 +5,20 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9']
-        h5py-version: ['2.10', '3.6', '3']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        h5py-version: ['3.6', '3']
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install Dependencies
+      - name: Install
         run: |
-          set -x
-          set -e
-          # $CONDA is an environment variable pointing to the root of the miniconda directory
-          echo $CONDA/bin >> $GITHUB_PATH
-          conda config --set always_yes yes --set changeps1 no
-          conda config --add channels conda-forge
-          conda update -q conda
-          conda info -a
-          conda create -n test-environment python=${{ matrix.python-version }} h5py=${{ matrix.h5py-version }} numpy scipy ndindex>=1.5.1 pyflakes pytest pytest-doctestplus pytest-flakes doctr sphinx pytest-cov myst-parser graphviz
-          conda init
+          set -xe
+          pip install .[test]
 
       - name: Run Tests
         run: |
-          # Copied from .bashrc. We can't just source .bashrc because it exits
-          # when the shell isn't interactive.
-
-          # >>> conda initialize >>>
-          # !! Contents within this block are managed by 'conda init' !!
-          __conda_setup="$('/usr/share/miniconda/bin/conda' 'shell.bash' 'hook' 2> /dev/null)"
-          if [ $? -eq 0 ]; then
-              eval "$__conda_setup"
-          else
-              if [ -f "/usr/share/miniconda/etc/profile.d/conda.sh" ]; then
-                  . "/usr/share/miniconda/etc/profile.d/conda.sh"
-              else
-                  export PATH="/usr/share/miniconda/bin:$PATH"
-              fi
-          fi
-          unset __conda_setup
-          # <<< conda initialize <<<
-
-          set -x
-          set -e
-
-          conda activate test-environment
-          python -We:invalid -We::SyntaxWarning -m compileall -f -q versioned_hdf5/
-          PYTEST_FLAGS="$PYTEST_FLAGS -v"
-          pytest $PYTEST_FLAGS
-          # Make sure it installs
-          python setup.py install
+          set -xe
+          pytest -v .

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --doctest-modules --flakes --ignore=analysis/
+addopts = --doctest-modules --ignore=analysis/
 doctest_optionflags= NORMALIZE_WHITESPACE
 markers =
     setup_args : kwargs for setup fixture.

--- a/setup.py
+++ b/setup.py
@@ -27,4 +27,9 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     python_requires='>=3.7',
+    extras_require={
+        "test": [
+            "pytest",
+        ]
+    }
 )

--- a/versioned_hdf5/tests/conftest.py
+++ b/versioned_hdf5/tests/conftest.py
@@ -5,12 +5,8 @@ from ..api import VersionedHDF5File
 
 # Run tests marked with @pytest.mark.slow last. See
 # https://stackoverflow.com/questions/61533694/run-slow-pytest-commands-at-the-end-of-the-test-suite
-from _pytest.mark import Mark
-
-empty_mark = Mark('', [], {})
-
 def by_slow_marker(item):
-    return item.get_closest_marker('slow', default=empty_mark)
+    return bool(item.get_closest_marker('slow'))
 
 def pytest_collection_modifyitems(items):
     items.sort(key=by_slow_marker)

--- a/versioned_hdf5/tests/test_api.py
+++ b/versioned_hdf5/tests/test_api.py
@@ -1,7 +1,7 @@
 import os
 import itertools
 
-from pytest import raises, mark
+from pytest import raises, mark, importorskip
 
 import h5py
 
@@ -618,30 +618,6 @@ def test_timestamp_manual(vfile):
     data2 = np.ones((3*DEFAULT_CHUNK_SIZE))
 
     ts1 = datetime.datetime(2020, 6, 29, 20, 12, 56, tzinfo=datetime.timezone.utc)
-    ts2 = datetime.datetime(2020, 6, 29, 22, 12, 56)
-    with vfile.stage_version('version1', timestamp=ts1) as group:
-        group['test_data_1'] = data1
-
-    assert vfile['version1'].attrs['timestamp'] == ts1.strftime(TIMESTAMP_FMT)
-
-    with raises(ValueError):
-        with vfile.stage_version('version2', timestamp=ts2) as group:
-            group['test_data_2'] = data2
-
-    with raises(TypeError):
-        with vfile.stage_version('version3', timestamp='2020-6-29') as group:
-            group['test_data_3'] = data1
-
-
-def test_timestamp_pytz(vfile):
-    # pytz is not a dependency of versioned-hdf5, but it is supported if it is
-    # used.
-    import pytz
-
-    data1 = np.ones((2*DEFAULT_CHUNK_SIZE,))
-    data2 = np.ones((3*DEFAULT_CHUNK_SIZE))
-
-    ts1 = datetime.datetime(2020, 6, 29, 20, 12, 56, tzinfo=pytz.utc)
     ts2 = datetime.datetime(2020, 6, 29, 22, 12, 56)
     with vfile.stage_version('version1', timestamp=ts1) as group:
         group['test_data_1'] = data1


### PR DESCRIPTION
This PR fixes a few issues which interfered with running the tests:

- Sorting slow tests to run at the end of the test run was using a deprecated pytest code path. That's been updated to fix a warning.
- Remove the `test_timestamp_pytz` test, `pytz` was an optional dependency and it isn't really used anymore.
- Removed `--flakes` command line arg; if we want to run a linter I can set it up using pre-commit and github actions to do this in a more robust way
- Added a `.[test]` extra which installs pytest so that the github CI doesn't do this manually
- Drop support for `h5py==2.10`. Supporting this was causing a test to fail before, so this closes #243.
- Removed conda commands from CI, they aren't needed here
- Added CI tests for python 3.10 and 3.11.