### PR TITLE
Fix InMemoryDataset.__getitem__ to work with development version of h5py

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,18 +5,33 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
-        h5py-version: ['3.6', '3']
+        python-version: ['3.9', '3.10', '3.11']
+        h5py-version: ['3.8', 'dev']
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install
+
+      - name: Install versioned-hdf5
         run: |
           set -xe
           pip install .[test]
+
+      - name: Install target h5py version
+        if: matrix.h5py-version != 'dev'
+        run: |
+          set -xe
+          pip install h5py==${{ matrix.h5py-version }}
+          pip list
+
+      - name: Install development h5py version
+        if: matrix.h5py-version == 'dev'
+        run: |
+          set -xe
+          pip install git+https://github.com/h5py/h5py
+          pip list
 
       - name: Run Tests
         run: |

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setuptools.setup(
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
     ],
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     extras_require={
         "test": [
             "pytest",

--- a/versioned_hdf5/tests/test_wrappers.py
+++ b/versioned_hdf5/tests/test_wrappers.py
@@ -6,7 +6,6 @@ from numpy.testing import assert_equal
 from ..wrappers import InMemoryArrayDataset, InMemorySparseDataset, InMemoryGroup
 import pytest
 
-
 def test_InMemoryArrayDataset(h5file):
     group = h5file.create_group('group')
     parent = InMemoryGroup(group.id)
@@ -78,10 +77,12 @@ def test_InMemorySparseDataset_getitem(h5file):
     assert_equal(d[:], np.ones((1000,)))
     assert_equal(d[10:20], np.ones((10,)))
 
-shapes = range(5, 25, 5) # 5, 10, 15, 20
-chunks = (10, 10, 10)
-@pytest.mark.parametrize('oldshape,newshape',
-                         itertools.combinations_with_replacement(itertools.product(shapes, repeat=3), 2))
+@pytest.mark.parametrize(
+    'oldshape,newshape',
+    itertools.combinations_with_replacement(
+        itertools.product(range(5, 25, 5), repeat=3), 2
+    )
+)
 @pytest.mark.slow
 def test_InMemoryArrayDataset_resize_multidimension(oldshape, newshape, h5file):
     # Test semantics against raw HDF5
@@ -93,7 +94,12 @@ def test_InMemoryArrayDataset_resize_multidimension(oldshape, newshape, h5file):
     dataset = InMemoryArrayDataset('data', a, parent=parent, fillvalue=-1)
     dataset.resize(newshape)
 
-    h5file.create_dataset('data', data=a, fillvalue=-1,
-                     chunks=chunks, maxshape=(None, None, None))
+    h5file.create_dataset(
+        'data',
+        data=a,
+        fillvalue=-1,
+        chunks=(10, 10, 10),
+        maxshape=(None, None, None)
+    )
     h5file['data'].resize(newshape)
     assert_equal(dataset[()], h5file['data'][()], str(newshape))

--- a/versioned_hdf5/wrappers.py
+++ b/versioned_hdf5/wrappers.py
@@ -595,9 +595,6 @@ class InMemoryDataset(Dataset):
         # This boilerplate code is based on h5py.Dataset.__getitem__
         args = args if isinstance(args, tuple) else (args,)
 
-        if new_dtype is None:
-            new_dtype = getattr(self._local, 'astype', None)
-
         # Sort field names from the rest of the args.
         names = tuple(x for x in args if isinstance(x, str))
 


### PR DESCRIPTION
This PR fixes versioned-hdf5 to work with the current development version of `h5py`, and removes an instance where we were making an `h5py` internal API call. To ensure we don't break compatibility with future `h5py` versions, I've also added a CI job to run against the development version.

Additionally this PR aligns itself with [NEP29 for python version support](https://numpy.org/neps/nep-0029-deprecation_policy.html), which simplifies the CI.

Closes #246.