### PR TITLE
Add info log showing stats about data upon exiting stage_version context

### DIFF
--- a/versioned_hdf5/backend.py
+++ b/versioned_hdf5/backend.py
@@ -72,6 +72,7 @@ def create_base_dataset(f, name, *, shape=None, data=None, dtype=None,
     dataset.attrs['chunks'] = chunks
     return write_dataset(f, name, data, chunks=chunks)
 
+
 def write_dataset(f, name, data, chunks=None, dtype=None, compression=None,
                   compression_opts=None, fillvalue=None):
 

--- a/versioned_hdf5/wrappers.py
+++ b/versioned_hdf5/wrappers.py
@@ -820,6 +820,9 @@ class DatasetLike:
     def ndim(self):
         return len(self.shape)
 
+    def __bool__(self):
+        return bool(self.size)
+
     def __len__(self):
         return self.len()
 
@@ -840,7 +843,7 @@ class DatasetLike:
             )
 
     def __iter__(self):
-        """ Iterate over the first axis.  TypeError if scalar.
+        """Iterate over the first axis. TypeError if scalar.
 
         BEWARE: Modifications to the yielded data are *NOT* written to file.
         """


### PR DESCRIPTION
This PR logs a message when exiting the `VersionedHDF5File.stage_version` context manager displaying some useful information about the data written. Information is displayed at the `INFO` log level.

This PR closes #166.

Here's a simple example taken from a test:

```python
import logging
import pathlib

import h5py
import numpy as np
from versioned_hdf5 import VersionedHDF5File

logging.basicConfig(level=logging.INFO)

dt = np.dtype('double')

# Clean out old data files
for p in pathlib.Path().glob("*.h5"):
    p.unlink()

# Create new versioned file
with h5py.File('foo.h5', 'w') as f:
    vf = VersionedHDF5File(f)
    with vf.stage_version('0') as sv:
        sv.create_dataset('bar', (2, 15220, 2),
                          chunks=(300, 100, 2),
                          dtype=dt, data=np.full((2, 15220, 2), 0, dtype=dt))
        sv.create_dataset('baz', (1, 10, 2),
                          chunks=(600, 2, 4),
                          dtype=dt, data=np.full((1, 10, 2), 0, dtype=dt))

with h5py.File('foo.h5', 'r+') as f:
    vf = VersionedHDF5File(f)
    with vf.stage_version('1') as sv:
        bar = sv['bar']
        bar.resize((3, 15222, 2))
        baz = sv['baz']
        baz.resize((1, (4) * 10, 2))
        baz[:, -10:, :] = np.full((1, 10, 2), 3, dtype=dt)
```

Running this produces displays the following:

```
INFO:versioned_hdf5.api:
  bar: Shape: None -> (2, 15220, 2); Chunks: None -> (300, 100, 2); New chunks written: 2; Number of chunks reused: 0
  baz: Shape: None -> (1, 10, 2); Chunks: None -> (600, 2, 4); New chunks written: 1; Number of chunks reused: 0
INFO:versioned_hdf5.api:
  bar: Shape: (2, 15220, 2) -> (3, 15222, 2); Chunks: ChunkSize((300, 100, 2)) -> ChunkSize((300, 100, 2)); New chunks written: 0; Number of chunks reused: 4
  baz: Shape: (1, 10, 2) -> (1, 40, 2); Chunks: ChunkSize((600, 2, 4)) -> ChunkSize((600, 2, 4)); New chunks written: 0; Number of chunks reused: 2
```

@ArvidJB @quarl What do you think of this? As long as this looks good to you, I'll move this out of draft and mark it ready for review.