### PR TITLE
Test docs on PR; deploy docs on push to default branch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,35 @@
+name: Build docs
+on:
+  pull_request:
+  workflow_call:
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+
+      - name: Setup Graphviz
+        run: |
+          sudo apt install graphviz -y
+
+      - name: Install versioned-hdf5
+        run: |
+          pip install .[doc]
+
+      - name: Build docs
+        working-directory: docs
+        run: |
+          # Need to set timezone to avoid a sphinx/babel issue
+          # when using act to run locally:
+          # https://github.com/nektos/act/issues/1853
+          TZ=UTC make html
+
+      - name: Upload docs
+        uses: actions/upload-artifact@v3
+        with:
+          name: docs
+          path: docs/_build/html/*

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -1,0 +1,47 @@
+name: Deploy static content to Pages
+
+on:
+  push:
+    branches: ["master"]
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    uses: deshaw/versioned-hdf5/.github/workflows/docs.yml@master
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Download docs
+        uses: actions/download-artifact@v3
+        with:
+          name: docs
+          path: docs
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: 'docs/'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,6 +34,7 @@ extensions = [
     'myst_parser',
     'sphinx.ext.autodoc',
     'sphinx.ext.graphviz',
+    'sphinx.ext.intersphinx',
 ]
 
 graphviz_output_format = 'svg'
@@ -46,6 +47,14 @@ templates_path = ['_templates']
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
+autodoc_type_aliases = {
+    "File": "h5py.File"
+}
+
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+    'h5py': ('https://docs.h5py.org/en/stable', None)
+}
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/rever.xsh
+++ b/rever.xsh
@@ -35,15 +35,9 @@ $ACTIVITIES = [
             'push_tag',  # Pushes the tag up to the $TAG_REMOTE
             # 'ghrelease',  # Creates a Github release entry for the new tag
             'pypi',  # Sends the package to pypi
-            # 'ghpages',
 ]
 
 $PUSH_TAG_REMOTE = 'git@github.com:deshaw/versioned-hdf5.git'  # Repo to push tags to
 
 $GITHUB_ORG = 'deshaw'  # Github org for Github releases and conda-forge
 $GITHUB_REPO = 'versioned-hdf5'  # Github repo for Github releases and conda-forge
-
-$GHPAGES_REPO = 'git@github.com:deshaw/versioned-hdf5.git'
-$GHPAGES_COPY = $GHPAGES_COPY = (
-    ('docs/_build/html', '$GHPAGES_REPO_DIR'),
-)

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,10 @@ setuptools.setup(
     extras_require={
         "test": [
             "pytest",
+        ],
+        "doc": [
+            "sphinx",
+            "myst-parser",
         ]
     }
 )

--- a/versioned_hdf5/replay.py
+++ b/versioned_hdf5/replay.py
@@ -480,7 +480,6 @@ def _walk(g: HLObject, prefix: str = '') -> List[str]:
 
     return datasets
 
-
 def delete_versions(
     f: Union[VersionedHDF5File, File],
     versions_to_delete: Iterable[str]


### PR DESCRIPTION
This PR handles automatic building and deploying of the docs.

- A new workflow was added to ensure doc builds pass on every PR
- A new workflow was added which builds and deploys docs when there's a push to the `master` branch. This workflow makes use of the new github pages action-based deployment mechanism.
- Finally, sphinx refused to build unless I used a string type annotation for `delete_versions`. I think this has something to do with `h5py.File` being a dependency, but I couldn't get sphinx to build if I did anything else. Here's all the things I tried that failed to build:
  - Using `sphinx.ext.intersphinx` and setting `intersphinx_mapping` to the `h5py` docs. I verified that the correct object file was being pulled by `sphinx` during the build process, and that the object file contained the `File` class as expected
  - Using `autodoc_mock_modules` to mock out the external dependency; still `sphinx` complained about not being able to find the class definition
  - If I do `import h5py` inside `replay.py` the build fails with the string annotation
  - If I do `import h5py` inside `replay.py` and convert the string annotation to an actual reference to the `File` class, the build fails
- Remove gh-pages publish step from `rever.xsh`

So while it would be nice to have an intersphinx connection, I'm not sure it's worth it at this time to continue fighting with sphinx. If anyone knows how to do this correctly, a PR against the branch would be welcome.

Closes #199.

## Testing

I tested these workflows in a separate repository and was able to deploy the docs successfully.