### PR TITLE
Add workflow to publish to pypi upon release tag

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -1,0 +1,67 @@
+name: Release Python Bindings to PyPI
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      test_pypi:
+        type: boolean
+        description: 'Test release: publish on test.pypi.org'
+        default: false
+
+jobs:
+  build-package:
+    name: Build package
+    runs-on: ubuntu-latest
+    steps:
+      - name: 💻 Checkout the repo
+        uses: actions/checkout@v3
+
+      - name: 🐍 Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: 🚀 Install build dependencies
+        run: |
+          python -m pip install build
+
+      - name: 📦 Build the sdist and wheel
+        run: |
+          python -m build
+
+      - name: ⤴️  Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: dist/*.tar.gz
+
+  publish:
+    name: Publish Python packages on PyPI
+    needs: [build-package]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/versioned-hdf5
+    permissions:
+      id-token: write
+    steps:
+      - name: ⤵️  Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: wheels
+          path: dist
+
+      - name: 🧪 Publish to PyPI Testing
+        uses: pypa/gh-action-pypi-publish@release/v1
+        if: ${{ inputs.test_pypi }}
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          packages_dir: dist
+
+      - name: 🎉 Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        if: ${{ !inputs.test_pypi }}
+        with:
+          packages_dir: dist


### PR DESCRIPTION
This PR adds a workflow to publish the package to PYPI using [trusted publishing.](https://docs.pypi.org/trusted-publishers/adding-a-publisher/) We'll need to add this workflow as a trusted publisher for the project before the next release.

Partially addresses #258.