### PR TITLE
Pass None as fill value for vlen raw dataset recreation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install hdf5-tools
+        run: |
+          set -xe
+          sudo apt install -y hdf5-tools
+
       - name: Install versioned-hdf5
         run: |
           set -xe

--- a/versioned_hdf5/replay.py
+++ b/versioned_hdf5/replay.py
@@ -208,6 +208,11 @@ def _recreate_raw_data(
 
     fillvalue = raw_data.fillvalue
     if dtype.metadata and ('vlen' in dtype.metadata or 'h5py_encoding' in dtype.metadata):
+        # h5py string dtype
+        # (https://h5py.readthedocs.io/en/2.10.0/strings.html). Setting the fillvalue in this case doesn't work
+        # (https://github.com/h5py/h5py/issues/941).
+        if fillvalue not in [0, '', b'', None]:
+            raise ValueError("Non-default fillvalue not supported for variable length strings")
         fillvalue = None
     new_raw_data = f['_version_data'][name].create_dataset(
         '_tmp_raw_data', shape=new_shape, maxshape=(None,)+chunks[1:],

--- a/versioned_hdf5/replay.py
+++ b/versioned_hdf5/replay.py
@@ -204,13 +204,14 @@ def _recreate_raw_data(
     raw_data = f['_version_data'][name]['raw_data']
     chunks = ChunkSize(raw_data.chunks)
     new_shape = (len(chunks_to_keep)*chunks[0], *chunks[1:])
+    dtype = raw_data.dtype
 
     fillvalue = raw_data.fillvalue
-    if raw_data.dtype.metadata and 'vlen' in raw_data.dtype.metadata:
+    if dtype.metadata and ('vlen' in dtype.metadata or 'h5py_encoding' in dtype.metadata):
         fillvalue = None
     new_raw_data = f['_version_data'][name].create_dataset(
         '_tmp_raw_data', shape=new_shape, maxshape=(None,)+chunks[1:],
-        chunks=raw_data.chunks, dtype=raw_data.dtype,
+        chunks=raw_data.chunks, dtype=dtype,
         compression=raw_data.compression,
         compression_opts=raw_data.compression_opts,
         fillvalue=fillvalue)

--- a/versioned_hdf5/replay.py
+++ b/versioned_hdf5/replay.py
@@ -205,12 +205,15 @@ def _recreate_raw_data(
     chunks = ChunkSize(raw_data.chunks)
     new_shape = (len(chunks_to_keep)*chunks[0], *chunks[1:])
 
+    fillvalue = raw_data.fillvalue
+    if raw_data.dtype.metadata and 'vlen' in raw_data.dtype.metadata:
+        fillvalue = None
     new_raw_data = f['_version_data'][name].create_dataset(
         '_tmp_raw_data', shape=new_shape, maxshape=(None,)+chunks[1:],
         chunks=raw_data.chunks, dtype=raw_data.dtype,
         compression=raw_data.compression,
         compression_opts=raw_data.compression_opts,
-        fillvalue=raw_data.fillvalue)
+        fillvalue=fillvalue)
     for key, val in raw_data.attrs.items():
         new_raw_data.attrs[key] = val
 

--- a/versioned_hdf5/replay.py
+++ b/versioned_hdf5/replay.py
@@ -209,7 +209,8 @@ def _recreate_raw_data(
     fillvalue = raw_data.fillvalue
     if dtype.metadata and ('vlen' in dtype.metadata or 'h5py_encoding' in dtype.metadata):
         # h5py string dtype
-        # (https://h5py.readthedocs.io/en/2.10.0/strings.html). Setting the fillvalue in this case doesn't work
+        # (https://h5py.readthedocs.io/en/2.10.0/strings.html). Setting the
+        # fillvalue in this case doesn't work
         # (https://github.com/h5py/h5py/issues/941).
         if fillvalue not in [0, '', b'', None]:
             raise ValueError("Non-default fillvalue not supported for variable length strings")

--- a/versioned_hdf5/tests/conftest.py
+++ b/versioned_hdf5/tests/conftest.py
@@ -12,6 +12,15 @@ def pytest_collection_modifyitems(items):
     items.sort(key=by_slow_marker)
 
 @fixture
+def filepath(tmp_path, request):
+    file_name = os.path.join(tmp_path, 'file.hdf5')
+    m = request.node.get_closest_marker('setup_args')
+    if m is not None:
+        if 'file_name' in m.kwargs.keys():
+            file_name = m.kwargs['file_name']
+    yield file_name
+
+@fixture
 def h5file(tmp_path, request):
     file_name = os.path.join(tmp_path, 'file.hdf5')
     version_name = None


### PR DESCRIPTION
Pasing a non-None fillvalue during vlen dtype datset creation results in a corrupted dataset creation whose access later fails with - 'RuntimeError: Unable to get dataset creation properties'. To avoid this unexpected failure most of the existing code does use None as fillvalue, but in a corner case involving deletion of versions, the creation of the raw dataset with empty data chunks ends up using non-None fillvalue and complains on access after h5 repack.

Changes:
==============
- Fixed the fillvalue being passed,
- Added fixture to return a temp filename, and
- Added test

Fixes #238.