### PR TITLE
Guess a sensible default chunk size if none specified

### DIFF
--- a/versioned_hdf5/backend.py
+++ b/versioned_hdf5/backend.py
@@ -1,4 +1,5 @@
 import numpy as np
+from h5py._hl.filters import guess_chunk
 from h5py import VirtualLayout, VirtualSource, h5s
 from ndindex import Slice, ndindex, Tuple, ChunkSize
 
@@ -48,8 +49,12 @@ def create_base_dataset(f, name, *, shape=None, data=None, dtype=None,
     if isinstance(chunks, int) and not isinstance(chunks, bool):
         chunks = (chunks,)
     if chunks in [True, None]:
-        if ndims <= 1:
+        if ndims == 0:
+            # Chunks are not allowed for scalar datasets; keeping original
+            # behavior here
             chunks = (DEFAULT_CHUNK_SIZE,)
+        elif ndims == 1:
+            chunks = guess_chunk(shape, None, data.dtype.itemsize)
         else:
             raise NotImplementedError("chunks must be specified for multi-dimensional datasets")
     group = f['_version_data'].create_group(name)

--- a/versioned_hdf5/tests/test_backend.py
+++ b/versioned_hdf5/tests/test_backend.py
@@ -2,6 +2,7 @@ import numpy as np
 from numpy.testing import assert_equal
 
 from ndindex import Slice, Tuple, ChunkSize
+from h5py._hl.filters import guess_chunk
 
 from pytest import mark, raises
 
@@ -34,32 +35,62 @@ def test_create_base_dataset_multidimension(h5file):
 
 
 def test_write_dataset(h5file):
-    slices1 = write_dataset(h5file, 'test_data', np.ones((2*DEFAULT_CHUNK_SIZE,)))
-    slices2 = write_dataset(h5file, 'test_data',
-                            np.concatenate((2*np.ones((DEFAULT_CHUNK_SIZE,)),
-                                            2*np.ones((DEFAULT_CHUNK_SIZE,)),
-                                            3*np.ones((DEFAULT_CHUNK_SIZE,)),
-                            )))
+    data1 = np.ones((2*DEFAULT_CHUNK_SIZE,))
+    data2 = np.concatenate(
+        (
+            2*np.ones((DEFAULT_CHUNK_SIZE,)),
+            2*np.ones((DEFAULT_CHUNK_SIZE,)),
+            3*np.ones((DEFAULT_CHUNK_SIZE,)),
+        )
+    )
+    slices1 = write_dataset(h5file, 'test_data', data1)
+    slices2 = write_dataset(h5file, 'test_data', data2)
 
-    assert slices1 == {
-        (Slice(0*DEFAULT_CHUNK_SIZE, 1*DEFAULT_CHUNK_SIZE, 1),):
-            slice(0*DEFAULT_CHUNK_SIZE, 1*DEFAULT_CHUNK_SIZE),
-        (Slice(1*DEFAULT_CHUNK_SIZE, 2*DEFAULT_CHUNK_SIZE, 1),):
-            slice(0*DEFAULT_CHUNK_SIZE, 1*DEFAULT_CHUNK_SIZE)}
-    assert slices2 == {
-        (Slice(0*DEFAULT_CHUNK_SIZE, 1*DEFAULT_CHUNK_SIZE, 1),):
-            slice(1*DEFAULT_CHUNK_SIZE, 2*DEFAULT_CHUNK_SIZE),
-        (Slice(1*DEFAULT_CHUNK_SIZE, 2*DEFAULT_CHUNK_SIZE, 1),):
-            slice(1*DEFAULT_CHUNK_SIZE, 2*DEFAULT_CHUNK_SIZE),
-        (Slice(2*DEFAULT_CHUNK_SIZE, 3*DEFAULT_CHUNK_SIZE, 1),):
-            slice(2*DEFAULT_CHUNK_SIZE, 3*DEFAULT_CHUNK_SIZE)}
+    # Chunk size is set by the size the first dataset
+    chunksize = guess_chunk(data1.shape, None, data1.dtype.itemsize)[0]
+
+    slices1_expected = {}
+    for i in range(data1.size // chunksize):
+        data_slice = (Slice(i*chunksize, (i+1)*chunksize, 1),)
+        slices1_expected[data_slice] = slice(0, chunksize)
+
+    last_data1_idx = chunksize
+    sorted_slices1 = sorted(slices1.items(), key=lambda x: x[0].raw[0].start)
+    sorted_expected1 = sorted(slices1_expected.items(), key=lambda x: x[0][0].start)
+    assert sorted_slices1 == sorted_expected1
+
+    slices2_expected = {}
+
+    for i in range(data2.size // chunksize):
+        data_slice = (Slice(i*chunksize, (i+1)*chunksize, 1),)
+
+        if i*chunksize < 2*DEFAULT_CHUNK_SIZE:
+            # Handle first part of dataset
+            slices2_expected[data_slice] = slice(
+                last_data1_idx,
+                last_data1_idx + chunksize
+            )
+        else:
+            # Handle second part of dataset
+            slices2_expected[data_slice] = slice(
+                last_data1_idx + chunksize,
+                last_data1_idx + 2*chunksize
+            )
+
+    sorted_slices2 = sorted(slices2.items(), key=lambda x: x[0].raw[0].start)
+    sorted_expected2 = sorted(slices2_expected.items(), key=lambda x: x[0][0].start)
+
+    assert sorted_slices2 == sorted_expected2
 
     ds = h5file['/_version_data/test_data/raw_data']
-    assert ds.shape == (3*DEFAULT_CHUNK_SIZE,)
-    assert_equal(ds[0:1*DEFAULT_CHUNK_SIZE], 1.0)
-    assert_equal(ds[1*DEFAULT_CHUNK_SIZE:2*DEFAULT_CHUNK_SIZE], 2.0)
-    assert_equal(ds[2*DEFAULT_CHUNK_SIZE:3*DEFAULT_CHUNK_SIZE], 3.0)
-    assert_equal(ds[3*DEFAULT_CHUNK_SIZE:4*DEFAULT_CHUNK_SIZE], 0.0)
+
+    # This will change depending on whether data1.size and data2.size evenly divide
+    # chunksize.
+    assert ds.shape == (3*chunksize,)
+    assert_equal(ds[0:1*chunksize], 1.0)
+    assert_equal(ds[1*chunksize:2*chunksize], 2.0)
+    assert_equal(ds[2*chunksize:3*chunksize], 3.0)
+    assert_equal(ds[3*chunksize:4*chunksize], 0.0)
     assert ds.dtype == np.float64
 
 
@@ -152,38 +183,38 @@ def test_write_dataset_multidimension(h5file):
 
 
 def test_write_dataset_chunks(h5file):
-    slices1 = write_dataset(h5file, 'test_data', np.ones((2*DEFAULT_CHUNK_SIZE,)))
+    data = np.ones((2*DEFAULT_CHUNK_SIZE,))
+    slices1 = write_dataset(h5file, 'test_data', data)
+    chunksize = guess_chunk(data.shape, None, data.dtype.itemsize)[0]
+
+
+    raw_slice1 = Tuple(Slice(0*chunksize, 1*chunksize, 1))
     slices2 = write_dataset_chunks(h5file, 'test_data', {
-        Tuple(Slice(0*DEFAULT_CHUNK_SIZE, 1*DEFAULT_CHUNK_SIZE, 1)):
-            slices1[Tuple(Slice(0*DEFAULT_CHUNK_SIZE, 1*DEFAULT_CHUNK_SIZE, 1))],
-        Tuple(Slice(1*DEFAULT_CHUNK_SIZE, 2*DEFAULT_CHUNK_SIZE, 1)): 2*np.ones((DEFAULT_CHUNK_SIZE,)),
-        Tuple(Slice(2*DEFAULT_CHUNK_SIZE, 3*DEFAULT_CHUNK_SIZE, 1)): 2*np.ones((DEFAULT_CHUNK_SIZE,)),
-        Tuple(Slice(3*DEFAULT_CHUNK_SIZE, 4*DEFAULT_CHUNK_SIZE, 1)): 3*np.ones((DEFAULT_CHUNK_SIZE,)),
+        Tuple(Slice(0*chunksize, 1*chunksize, 1)): slices1[raw_slice1],
+        Tuple(Slice(1*chunksize, 2*chunksize, 1)): 2*np.ones((chunksize,)),
+        Tuple(Slice(2*chunksize, 3*chunksize, 1)): 2*np.ones((chunksize,)),
+        Tuple(Slice(3*chunksize, 4*chunksize, 1)): 3*np.ones((chunksize,)),
     })
 
-    assert slices1 == {
-        Tuple(Slice(0*DEFAULT_CHUNK_SIZE, 1*DEFAULT_CHUNK_SIZE, 1)):
-            slice(0*DEFAULT_CHUNK_SIZE, 1*DEFAULT_CHUNK_SIZE),
-        Tuple(Slice(1*DEFAULT_CHUNK_SIZE, 2*DEFAULT_CHUNK_SIZE, 1)):
-            slice(0*DEFAULT_CHUNK_SIZE, 1*DEFAULT_CHUNK_SIZE),
-        }
+    slices1_expected = {}
+    for i in range(data.size // chunksize):
+        data_slice = Tuple(Slice(i*chunksize, (i+1)*chunksize, 1))
+        slices1_expected[data_slice] = slice(0, chunksize)
+
+    assert slices1 == slices1_expected
     assert slices2 == {
-        Tuple(Slice(0*DEFAULT_CHUNK_SIZE, 1*DEFAULT_CHUNK_SIZE, 1)):
-            slice(0*DEFAULT_CHUNK_SIZE, 1*DEFAULT_CHUNK_SIZE),
-        Tuple(Slice(1*DEFAULT_CHUNK_SIZE, 2*DEFAULT_CHUNK_SIZE, 1)):
-            slice(1*DEFAULT_CHUNK_SIZE, 2*DEFAULT_CHUNK_SIZE),
-        Tuple(Slice(2*DEFAULT_CHUNK_SIZE, 3*DEFAULT_CHUNK_SIZE, 1)):
-            slice(1*DEFAULT_CHUNK_SIZE, 2*DEFAULT_CHUNK_SIZE),
-        Tuple(Slice(3*DEFAULT_CHUNK_SIZE, 4*DEFAULT_CHUNK_SIZE, 1)):
-            slice(2*DEFAULT_CHUNK_SIZE, 3*DEFAULT_CHUNK_SIZE),
-        }
+        Tuple(Slice(0*chunksize, 1*chunksize, 1)): slice(0*chunksize, 1*chunksize),
+        Tuple(Slice(1*chunksize, 2*chunksize, 1)): slice(1*chunksize, 2*chunksize),
+        Tuple(Slice(2*chunksize, 3*chunksize, 1)): slice(1*chunksize, 2*chunksize),
+        Tuple(Slice(3*chunksize, 4*chunksize, 1)): slice(2*chunksize, 3*chunksize),
+    }
 
     ds = h5file['/_version_data/test_data/raw_data']
-    assert ds.shape == (3*DEFAULT_CHUNK_SIZE,)
-    assert_equal(ds[0:1*DEFAULT_CHUNK_SIZE], 1.0)
-    assert_equal(ds[1*DEFAULT_CHUNK_SIZE:2*DEFAULT_CHUNK_SIZE], 2.0)
-    assert_equal(ds[2*DEFAULT_CHUNK_SIZE:3*DEFAULT_CHUNK_SIZE], 3.0)
-    assert_equal(ds[3*DEFAULT_CHUNK_SIZE:4*DEFAULT_CHUNK_SIZE], 0.0)
+    assert ds.shape == (3*chunksize,)
+    assert_equal(ds[0*chunksize:1*chunksize], 1.0)
+    assert_equal(ds[1*chunksize:2*chunksize], 2.0)
+    assert_equal(ds[2*chunksize:3*chunksize], 3.0)
+    assert_equal(ds[3*chunksize:4*chunksize], 0.0)
     assert ds.dtype == np.float64
 
 
@@ -215,31 +246,63 @@ def test_write_dataset_chunks_multidimension(h5file):
 
 
 def test_write_dataset_offset(h5file):
-    slices1 = write_dataset(h5file, 'test_data', np.ones((2*DEFAULT_CHUNK_SIZE,)))
-    slices2 = write_dataset(h5file, 'test_data',
-                            np.concatenate((2*np.ones((DEFAULT_CHUNK_SIZE,)),
-                                            2*np.ones((DEFAULT_CHUNK_SIZE,)),
-                                            3*np.ones((DEFAULT_CHUNK_SIZE - 2,)))))
+    data1 = np.ones((2*DEFAULT_CHUNK_SIZE,))
+    data2 = np.concatenate(
+        (
+            2*np.ones((DEFAULT_CHUNK_SIZE,)),
+            2*np.ones((DEFAULT_CHUNK_SIZE,)),
+            3*np.ones((DEFAULT_CHUNK_SIZE - 2,))
+        )
+    )
+    slices1 = write_dataset(h5file, 'test_data', data1)
+    slices2 = write_dataset(h5file, 'test_data', data2)
 
-    assert slices1 == {
-        (Slice(0*DEFAULT_CHUNK_SIZE, 1*DEFAULT_CHUNK_SIZE, 1),):
-            slice(0*DEFAULT_CHUNK_SIZE, 1*DEFAULT_CHUNK_SIZE),
-        (Slice(1*DEFAULT_CHUNK_SIZE, 2*DEFAULT_CHUNK_SIZE, 1),):
-            slice(0*DEFAULT_CHUNK_SIZE, 1*DEFAULT_CHUNK_SIZE)}
-    assert slices2 == {
-        (Slice(0*DEFAULT_CHUNK_SIZE, 1*DEFAULT_CHUNK_SIZE, 1),):
-            slice(1*DEFAULT_CHUNK_SIZE, 2*DEFAULT_CHUNK_SIZE),
-        (Slice(1*DEFAULT_CHUNK_SIZE, 2*DEFAULT_CHUNK_SIZE, 1),):
-            slice(1*DEFAULT_CHUNK_SIZE, 2*DEFAULT_CHUNK_SIZE),
-        (Slice(2*DEFAULT_CHUNK_SIZE, 3*DEFAULT_CHUNK_SIZE - 2, 1),):
-            slice(2*DEFAULT_CHUNK_SIZE, 3*DEFAULT_CHUNK_SIZE - 2)}
+    chunksize = guess_chunk(data1.shape, None, data1.dtype.itemsize)[0]
+
+    slices1_expected = {}
+    for i in range(data1.size // chunksize):
+        data_slice = (Slice(i*chunksize, (i+1)*chunksize, 1),)
+        slices1_expected[data_slice] = slice(0, chunksize)
+
+    last_data1_idx = chunksize
+    slices2_expected = {}
+    for i in range(data2.size // chunksize):
+        data_slice = (Slice(i*chunksize, (i+1)*chunksize, 1),)
+
+        if i*chunksize < 2*DEFAULT_CHUNK_SIZE:
+            slices2_expected[data_slice] = slice(
+                last_data1_idx,
+                last_data1_idx + chunksize
+            )
+        else:
+            slices2_expected[data_slice] = slice(
+                last_data1_idx + chunksize,
+                last_data1_idx + 2*chunksize
+            )
+
+    n_remaining = data2.size % chunksize
+    data_slice = (Slice((data2.size // chunksize) * chunksize, data2.size, 1),)
+    slices2_expected[data_slice] = slice(
+        last_data1_idx + 2*chunksize,
+        last_data1_idx + 2*chunksize + n_remaining,
+    )
+
+    sorted_slices1 = sorted(slices1.items(), key=lambda x: x[0].raw[0].start)
+    sorted_expected1 = sorted(slices1_expected.items(), key=lambda x: x[0][0].start)
+    sorted_slices2 = sorted(slices2.items(), key=lambda x: x[0].raw[0].start)
+    sorted_expected2 = sorted(slices2_expected.items(), key=lambda x: x[0][0].start)
+
+    assert sorted_slices1 == sorted_expected1
+    assert sorted_slices2 == sorted_expected2
 
     ds = h5file['/_version_data/test_data/raw_data']
-    assert ds.shape == (3*DEFAULT_CHUNK_SIZE,)
-    assert_equal(ds[0*DEFAULT_CHUNK_SIZE:1*DEFAULT_CHUNK_SIZE], 1.0)
-    assert_equal(ds[1*DEFAULT_CHUNK_SIZE:2*DEFAULT_CHUNK_SIZE], 2.0)
-    assert_equal(ds[2*DEFAULT_CHUNK_SIZE:3*DEFAULT_CHUNK_SIZE - 2], 3.0)
-    assert_equal(ds[3*DEFAULT_CHUNK_SIZE-2:4*DEFAULT_CHUNK_SIZE], 0.0)
+    assert ds.shape == (4*chunksize,)
+    assert_equal(ds[0*chunksize:1*chunksize], 1.0)
+    assert_equal(ds[1*chunksize:2*chunksize], 2.0)
+    assert_equal(ds[2*chunksize:3*chunksize], 3.0)
+    assert_equal(ds[2*chunksize:3*chunksize], 3.0)
+    assert_equal(ds[3*chunksize:4*chunksize-2], 3.0)
+    assert_equal(ds[4*chunksize-2:4*chunksize], 0.0)
 
 
 def test_write_dataset_offset_multidimension(h5file):
@@ -336,38 +399,85 @@ def test_write_dataset_offset_multidimension(h5file):
 
 @mark.setup_args(version_name='test_version')
 def test_create_virtual_dataset(h5file):
+    """Check that creating a virtual dataset from chunks of real datasets works."""
+    data1 = np.ones((2*DEFAULT_CHUNK_SIZE,))
+    data2 = np.concatenate(
+        (
+            2*np.ones((DEFAULT_CHUNK_SIZE,)),
+            3*np.ones((DEFAULT_CHUNK_SIZE,)),
+        )
+    )
+
+    # Chunk size is set by the size the first dataset
+    chunksize = guess_chunk(data1.shape, None, data1.dtype.itemsize)[0]
+
     with h5file as f:
-        slices1 = write_dataset(f, 'test_data', np.ones((2*DEFAULT_CHUNK_SIZE,)))
-        slices2 = write_dataset(f, 'test_data',
-                                np.concatenate((2*np.ones((DEFAULT_CHUNK_SIZE,)),
-                                                3*np.ones((DEFAULT_CHUNK_SIZE,)))))
+        slices1 = write_dataset(f, 'test_data', data1)
+        slices2 = write_dataset(f, 'test_data', data2)
 
-        virtual_data = create_virtual_dataset(f, 'test_version', 'test_data', (3*DEFAULT_CHUNK_SIZE,),
-            {**slices1,
-             Tuple(Slice(2*DEFAULT_CHUNK_SIZE, 3*DEFAULT_CHUNK_SIZE, 1),):
-             slices2[(Slice(1*DEFAULT_CHUNK_SIZE, 2*DEFAULT_CHUNK_SIZE, 1),)]})
+        nchunks1 = int(np.ceil(2*DEFAULT_CHUNK_SIZE/chunksize))
 
-        assert virtual_data.shape == (3*DEFAULT_CHUNK_SIZE,)
+        # The virtual dataset contains all the data from slices1, and one chunk of data
+        # from slices2
+        virtual_data = create_virtual_dataset(
+            f,
+            'test_version',
+            'test_data',
+            ((nchunks1 + 1)*chunksize,),
+            {
+                **slices1,
+                Tuple(
+                    Slice(nchunks1*chunksize, (nchunks1+1)*chunksize, 1),
+                ): slices2[(Slice(1*chunksize, 2*chunksize, 1),)]
+            }
+        )
+
+        assert virtual_data.shape == ((nchunks1+1)*chunksize,)
         assert_equal(virtual_data[0:2*DEFAULT_CHUNK_SIZE], 1.0)
-        assert_equal(virtual_data[2*DEFAULT_CHUNK_SIZE:3*DEFAULT_CHUNK_SIZE], 3.0)
+        assert_equal(virtual_data[2*DEFAULT_CHUNK_SIZE:3*DEFAULT_CHUNK_SIZE], 2.0)
         assert virtual_data.dtype == np.float64
 
 @mark.setup_args(version_name='test_version')
 def test_create_virtual_dataset_attrs(h5file):
+    data1 = np.ones((2*DEFAULT_CHUNK_SIZE,))
+    data2 = np.concatenate(
+        (
+            2*np.ones((DEFAULT_CHUNK_SIZE,)),
+            3*np.ones((DEFAULT_CHUNK_SIZE,)),
+        )
+    )
+
+    # Chunk size is set by the size the first dataset
+    chunksize = guess_chunk(data1.shape, None, data1.dtype.itemsize)[0]
+
     with h5file as f:
-        slices1 = write_dataset(f, 'test_data', np.ones((2*DEFAULT_CHUNK_SIZE,)))
-        slices2 = write_dataset(f, 'test_data',
-                                np.concatenate((2*np.ones((DEFAULT_CHUNK_SIZE,)),
-                                                3*np.ones((DEFAULT_CHUNK_SIZE,)))))
+        slices1 = write_dataset(f, 'test_data', data1)
+        slices2 = write_dataset(f, 'test_data', data2)
+
+        nchunks1 = int(np.ceil(2*DEFAULT_CHUNK_SIZE/chunksize))
 
         attrs = {"attribute": "value"}
-        virtual_data = create_virtual_dataset(f, 'test_version', 'test_data', (3*DEFAULT_CHUNK_SIZE,),
-            {**slices1,
-             Tuple(Slice(2*DEFAULT_CHUNK_SIZE, 3*DEFAULT_CHUNK_SIZE, 1),):
-             slices2[(Slice(1*DEFAULT_CHUNK_SIZE, 2*DEFAULT_CHUNK_SIZE,
-                            1),)]}, attrs=attrs)
+        # The virtual dataset contains all the data from slices1, and one chunk of data
+        # from slices2
+        virtual_data = create_virtual_dataset(
+            f,
+            'test_version',
+            'test_data',
+            ((nchunks1 + 1)*chunksize,),
+            {
+                **slices1,
+                Tuple(
+                    Slice(nchunks1*chunksize, (nchunks1+1)*chunksize, 1),
+                ): slices2[(Slice(1*chunksize, 2*chunksize, 1),)]
+            },
+            attrs=attrs
+        )
 
-        assert dict(virtual_data.attrs) == {**attrs, "raw_data": '/_version_data/test_data/raw_data', "chunks": np.array([DEFAULT_CHUNK_SIZE])}
+        assert dict(virtual_data.attrs) == {
+            **attrs,
+            "raw_data": '/_version_data/test_data/raw_data',
+            "chunks": np.array([chunksize])
+        }
 
 @mark.setup_args(version_name=['test_version1', 'test_version2'])
 def test_create_virtual_dataset_multidimension(h5file):
@@ -404,20 +514,44 @@ def test_create_virtual_dataset_multidimension(h5file):
 
 @mark.setup_args(version_name='test_version')
 def test_create_virtual_dataset_offset(h5file):
-    slices1 = write_dataset(h5file, 'test_data', np.ones((2*DEFAULT_CHUNK_SIZE,)))
-    slices2 = write_dataset(h5file, 'test_data',
-                            np.concatenate((2*np.ones((DEFAULT_CHUNK_SIZE,)),
-                                            3*np.ones((DEFAULT_CHUNK_SIZE - 2,)))))
+    data1 = np.ones((2*DEFAULT_CHUNK_SIZE,))
+    data2 = np.concatenate(
+        (
+            2*np.ones((DEFAULT_CHUNK_SIZE,)),
+            3*np.ones((DEFAULT_CHUNK_SIZE - 2,)),
+        )
+    )
 
-    virtual_data = create_virtual_dataset(h5file, 'test_version', 'test_data',
-                                          (3*DEFAULT_CHUNK_SIZE - 2,),
-        {**slices1,
-         Tuple(Slice(2*DEFAULT_CHUNK_SIZE, 3*DEFAULT_CHUNK_SIZE - 2, 1),):
-         slices2[(Slice(1*DEFAULT_CHUNK_SIZE, 2*DEFAULT_CHUNK_SIZE - 2, 1),)]})
+    slices1 = write_dataset(h5file, 'test_data', data1)
+    slices2 = write_dataset(h5file, 'test_data', data2)
 
-    assert virtual_data.shape == (3*DEFAULT_CHUNK_SIZE - 2,)
-    assert_equal(virtual_data[0:2*DEFAULT_CHUNK_SIZE], 1.0)
-    assert_equal(virtual_data[2*DEFAULT_CHUNK_SIZE:3*DEFAULT_CHUNK_SIZE - 2], 3.0)
+    # Chunk size is set by the size the first dataset
+    chunksize = guess_chunk(data1.shape, None, data1.dtype.itemsize)[0]
+    nchunks1 = int(np.ceil(data1.size/chunksize))
+    nchunks2 = int(np.ceil(data2.size/chunksize))
+
+    # After writing the data above, there is now 4 chunks in the raw dataset:
+    #   raw_data[0*chunksize:1*chunksize] == 1.0
+    #   raw_data[1*chunksize:2*chunksize] == 2.0
+    #   raw_data[2*chunksize:3*chunksize] == 3.0
+    #   raw_data[3*chunksize:4*chunksize-2] == 3.0
+    # Create a virtual dataset including all data from the first dataset
+    # and the last chunk of data from the second dataset.
+    virtual_data = create_virtual_dataset(
+        h5file,
+        'test_version',
+        'test_data',
+        ((nchunks1 + 1)*chunksize - 2,),
+        {
+            **slices1,
+            Tuple(Slice(nchunks1*chunksize, (nchunks1+1)*chunksize - 2, 1),):
+            slices2[(Slice((nchunks2-1)*chunksize, nchunks2*chunksize - 2, 1),)]
+        }
+    )
+
+    assert virtual_data.shape == ((nchunks1+1)*chunksize - 2,)
+    assert_equal(virtual_data[0:nchunks1*chunksize], 1.0)
+    assert_equal(virtual_data[nchunks1*chunksize:(nchunks1+1)*chunksize - 2], 3.0)
 
 
 @mark.setup_args(version_name='test_version')
@@ -516,23 +650,47 @@ def test_write_dataset_offset_chunk_size(h5file):
 
 
 def test_write_dataset_compression(h5file):
-    slices1 = write_dataset(h5file, 'test_data',
-                            np.ones((2*DEFAULT_CHUNK_SIZE,)),
-                            compression='gzip', compression_opts=3)
-    raises(ValueError, lambda: write_dataset(h5file, 'test_data',
-        np.ones((DEFAULT_CHUNK_SIZE,)), compression='lzf'))
-    raises(ValueError, lambda: write_dataset(h5file, 'test_data',
-        np.ones((DEFAULT_CHUNK_SIZE,)), compression='gzip', compression_opts=4))
 
-    assert slices1 == {
-        (Slice(0*DEFAULT_CHUNK_SIZE, 1*DEFAULT_CHUNK_SIZE, 1),):
-            slice(0*DEFAULT_CHUNK_SIZE, 1*DEFAULT_CHUNK_SIZE),
-        (Slice(1*DEFAULT_CHUNK_SIZE, 2*DEFAULT_CHUNK_SIZE, 1),):
-            slice(0*DEFAULT_CHUNK_SIZE, 1*DEFAULT_CHUNK_SIZE)}
+    data = np.ones((2*DEFAULT_CHUNK_SIZE,))
 
+    # Chunk size is set by the size the first dataset
+    chunksize = guess_chunk(data.shape, None, data.dtype.itemsize)[0]
+    nchunks = int(np.ceil(data.size/chunksize))
+
+
+    slices1 = write_dataset(
+        h5file,
+        'test_data',
+        data,
+        compression='gzip',
+        compression_opts=3
+    )
+
+    with raises(ValueError):
+        write_dataset(
+            h5file,
+            'test_data',
+            np.ones((DEFAULT_CHUNK_SIZE,)),
+            compression='lzf'
+        )
+
+    with raises(ValueError):
+        write_dataset(
+            h5file,
+            'test_data',
+            np.ones((DEFAULT_CHUNK_SIZE,)),
+            compression='gzip',
+            compression_opts=4
+        )
+
+    expected = {}
+    for i in range(nchunks):
+        expected[(Slice(i*chunksize, (i+1)*chunksize, 1),)] = slice(0, chunksize)
+
+    assert slices1 == expected
     ds = h5file['/_version_data/test_data/raw_data']
-    assert ds.shape == (1*DEFAULT_CHUNK_SIZE,)
-    assert_equal(ds[0:1*DEFAULT_CHUNK_SIZE], 1.0)
+    assert ds.shape == (chunksize,)
+    assert_equal(ds[0:chunksize], 1.0)
     assert ds.dtype == np.float64
     assert ds.compression == 'gzip'
     assert ds.compression_opts == 3


### PR DESCRIPTION
This PR guesses a sensible default chunk size if none is provided, closing #198. Here, we make use of `h5py._hl.filters.guess_chunk` for this purpose. Note this only applies to 1D datasets, with the behavior of scalar and multidimensional datasets unchanged.

The change is quite short, but many of the tests were writing `DEFAULT_CHUNK_SIZE`-sized datasets to files, and then checking that the chunks written matched the `DEFAULT_CHUNK_SIZE`. As a result, many tests needed to be modified to lift this assumption.