### PR TITLE
Delete versions OOM fix

### DIFF
--- a/versioned_hdf5/api.py
+++ b/versioned_hdf5/api.py
@@ -93,10 +93,17 @@ class VersionedHDF5File:
                     f"than what is currently installed. Please update versioned-hdf5."
                 )
 
-        self._version_data = f['_version_data']
-        self._versions = self._version_data['versions']
         self._closed = False
         self._version_cache = {}
+
+    @property
+    def _versions(self):
+        """Shorthand reference to the versions group of the file."""
+        return self.f['_version_data']['versions']
+
+    @property
+    def _version_data(self):
+        return self.f['_version_data']
 
     @property
     def closed(self):
@@ -191,8 +198,9 @@ class VersionedHDF5File:
         elif isinstance(item, (int, np.integer)):
             if item > 0:
                 raise IndexError("Integer version slice must be negative")
-            self._version_cache[item] = self.get_version_by_name(get_nth_previous_version(self.f,
-                self.current_version, -item))
+            self._version_cache[item] = self.get_version_by_name(
+                get_nth_previous_version(self.f, self.current_version, -item)
+            )
             return self._version_cache[item]
         elif isinstance(item, (datetime.datetime, np.datetime64)):
             self._version_cache[item] = self.get_version_by_timestamp(item)
@@ -255,7 +263,6 @@ class VersionedHDF5File:
         group = create_version_group(self.f, version_name,
                                      prev_version=prev_version)
 
-
         try:
             yield group
             group.close()
@@ -279,8 +286,6 @@ class VersionedHDF5File:
         """
         if not self._closed:
             del self.f
-            del self._version_data
-            del self._versions
             self._closed = True
 
     def __repr__(self):


### PR DESCRIPTION
This PR avoids writing a `_tmp_raw_data` array in calls to `_recreate_raw_data`, preventing an allocation that in the past could consume lots of memory, causing `delete_versions` to fail. Closes https://github.com/deshaw/versioned-hdf5/issues/273.

NOTE: This is a WIP PR - right now I'm seeing a really weird issue with the tests in `test_replay.py` where calls to `np.testing.assert_equal` are failing on tests which have had deleted versions. I'm guessing this is some issue flushing to disk; creating this PR here for further investigation.

Okay, confirmed that closing and opening the file objects in the offending tests seems to resolve the issue. Will look for a way to flush output to disk to close this out.

---

The intermittent test failures are indeed resolved by calling `gc.collect` at the end of `delete_versions`. Clearly this isn't ideal, but at the moment this seems like a functioning approach at least.

## Changes

- `_recreate_raw_data` now directly writes the recreated raw data to the file. Before, we were writing to a numpy array, then an intermediate `_tmp_raw_data` dataset, then we'd move the `_tmp_raw_data` to `raw_data` to replace the original raw data. This should resolve any issues related to memory usage, and will likely also speed up `delete_versions` overall, although we now pay an additional garbage collection penalty.
- Removed the `posixpath` alias, which was `pp` and thus would interfere with debugger `pp` pretty-print commands, in.