### PR TITLE
Fix deprecated CI parameter

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -58,10 +58,10 @@ jobs:
         if: ${{ inputs.test_pypi }}
         with:
           repository-url: https://test.pypi.org/legacy/
-          packages_dir: dist
+          packages-dir: dist
 
       - name: 🎉 Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         if: ${{ !inputs.test_pypi }}
         with:
-          packages_dir: dist
+          packages-dir: dist


### PR DESCRIPTION
This PR fixes a pair of instances where a deprecated parameter was being used in the workflow that publishes to PYPI. This will be deprecated soon, so this PR will prevent the job from failing in the future. Closes #268.