### PR TITLE
Add diff API

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,7 +53,8 @@ autodoc_type_aliases = {
 
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
-    'h5py': ('https://docs.h5py.org/en/stable', None)
+    'h5py': ('https://docs.h5py.org/en/stable', None),
+    "numpy": ("https://numpy.org/doc/stable/", None),
 }
 
 # -- Options for HTML output -------------------------------------------------


### PR DESCRIPTION
## Changes

This PR adds an API for calculating the diff between two versions of a dataset; closes #264.

Tests are provided which check

- The diff between a version and itself is nothing
- The diff between two versions of a dataset gives the expected slices and data, including for nested datasets

An intersphinx mapping was added for numpy as well in order to handle docstrings for this new function.

## Testing

I wrote a small benchmark to check how fast this implementation was. In the benchmark, I compared calling `get_diff` to iterating over two versions of a dataset and comparing the chunks using `np.assert_equal`. For very small datasets, direct comparison with numpy is fastest. As datasets get larger, directly iterating over the data becomes impractical:

![comparison](https://github.com/deshaw/versioned-hdf5/assets/14017872/f3cb4e9d-afca-4a31-b5e6-8a011a9e4d2d)

@rahasurana Can you take a look at this?
