### PR TITLE
Optimize `_recreate_raw_dataset` to use less memory; add versions method

### DIFF
--- a/versioned_hdf5/api.py
+++ b/versioned_hdf5/api.py
@@ -575,3 +575,17 @@ class VersionedHDF5File:
                 diff[vir1] = (self[v1][name][vir1.raw], None)
 
         return diff
+
+    @property
+    def versions(self) -> List[str]:
+        """Return the names of the version groups in the file.
+
+        This should return the same as calling
+        ``versioned_hdf5.versions.all_versions(self.f, include_first=False)``.
+
+        Returns
+        -------
+        List[str]
+            The names of versions in the file; order is arbitrary
+        """
+        return [v for v in self._versions if '__first_version__' not in v]

--- a/versioned_hdf5/tests/test_replay.py
+++ b/versioned_hdf5/tests/test_replay.py
@@ -548,6 +548,7 @@ def test_delete_versions(vfile):
     f = vfile.f
 
     delete_versions(f, ['version2', 'version3'])
+
     check_data(vfile, version2=False)
     assert list(vfile) == ['version1']
     assert set(f['_version_data']) == {'group', 'test_data', 'test_data2', 'versions'}


### PR DESCRIPTION
This PR optimizes a part of the `_recreate_raw_dataset` that currently can allocate significant memory for datasets with large numbers of versions. I also saw a large speedup in this section of the code post-refactor.

A `VersionedHDF5File.versions` method was added (a `VersionedHDF5` should know what versions it has), which should return the same thing as `versioned_hdf5.versions.all_versions` but be much less verbose and more convenient.

Partially addresses https://github.com/deshaw/versioned-hdf5/issues/298. Deleting datasets can still be costly in terms of memory because the operation requires 

1. Reconstructing the raw dataset, which entails keeping track of the raw chunks that need to be kept
2. Reconstructing the hashtable, which requires loading the inverse of the old hashtable as a new one gets built
3. Recreating the virtual datasets for the versions of the dataset we are keeping