### PR TITLE
Check dataset names against blocklist before committing

### DIFF
--- a/versioned_hdf5/tests/test_versions.py
+++ b/versioned_hdf5/tests/test_versions.py
@@ -254,3 +254,13 @@ def test_delete_version(h5file):
 
     assert versions.attrs['current_version'] == '__first_version__'
     assert list(versions) == ['__first_version__']
+
+
+def test_forbidden_dataset_name(h5file):
+    data = np.concatenate((np.ones((2*DEFAULT_CHUNK_SIZE,)),
+                           2*np.ones((DEFAULT_CHUNK_SIZE,)),
+                           3*np.ones((DEFAULT_CHUNK_SIZE,))))
+    v1 = create_version_group(h5file, 'v1')
+
+    with raises(ValueError):
+        commit_version(v1, {'versions': data})


### PR DESCRIPTION
This PR adds a list of forbidden dataset names that are checked when the user tries to commit a new version. If the user tries to save a dataset with one of these names, a `ValueError` is raised.

For this PR, `versions` has been added as a forbidden name, as it conflicts with `/_version_data/versions` leading to a cryptic and unhelpful error message.