### PR TITLE
Remove APIs deprecated in numpy 2.0; add testing in CI

### DIFF
--- a/versioned_hdf5/backend.py
+++ b/versioned_hdf5/backend.py
@@ -48,7 +48,7 @@ def create_base_dataset(f, name, *, shape=None, data=None, dtype=None,
         shape = data.shape
     else:
         shape = (shape,) if isinstance(shape, int) else tuple(shape)
-        if data is not None and (np.product(shape, dtype=np.ulonglong) != np.product(data.shape, dtype=np.ulonglong)):
+        if data is not None and (np.prod(shape, dtype=np.ulonglong) != np.product(data.shape, dtype=np.ulonglong)):
             raise ValueError("Shape tuple is incompatible with data")
 
     ndims = len(shape)

--- a/versioned_hdf5/tests/test_api.py
+++ b/versioned_hdf5/tests/test_api.py
@@ -542,7 +542,7 @@ def test_resize_multiple_dimensions(tmp_path, h5file):
     chunks = (10, 10, 10)
     for i, (oldshape, newshape) in\
             enumerate(itertools.combinations_with_replacement(itertools.product(shapes, repeat=3), 2)):
-        data = np.arange(np.product(oldshape)).reshape(oldshape)
+        data = np.arange(np.prod(oldshape)).reshape(oldshape)
         # Get the ground truth from h5py
         vfile.f.create_dataset(f'data{i}', data=data, fillvalue=-1, chunks=chunks,
                                maxshape=(None, None, None))

--- a/versioned_hdf5/tests/test_wrappers.py
+++ b/versioned_hdf5/tests/test_wrappers.py
@@ -86,7 +86,7 @@ def test_InMemorySparseDataset_getitem(h5file):
 @pytest.mark.slow
 def test_InMemoryArrayDataset_resize_multidimension(oldshape, newshape, h5file):
     # Test semantics against raw HDF5
-    a = np.arange(np.product(oldshape)).reshape(oldshape)
+    a = np.arange(np.prod(oldshape)).reshape(oldshape)
 
     group = h5file.create_group('group')
     parent = InMemoryGroup(group.id)

--- a/versioned_hdf5/wrappers.py
+++ b/versioned_hdf5/wrappers.py
@@ -374,7 +374,7 @@ def _make_new_dset(shape=None, dtype=None, data=None, chunks=None,
         shape = data.shape
     else:
         shape = (shape,) if isinstance(shape, int) else tuple(shape)
-        if data is not None and (np.product(shape, dtype=np.ulonglong) != np.product(data.shape, dtype=np.ulonglong)):
+        if data is not None and (np.prod(shape, dtype=np.ulonglong) != np.product(data.shape, dtype=np.ulonglong)):
             raise ValueError("Shape tuple is incompatible with data")
 
     if isinstance(maxshape, int):
@@ -711,7 +711,7 @@ class InMemoryDataset(Dataset):
                 if val.ndim > 1:
                     tmp = np.empty(shape=val.shape[:-1], dtype=object)
                     tmp.ravel()[:] = [i for i in val.reshape(
-                        (np.product(val.shape[:-1], dtype=np.ulonglong), val.shape[-1]))]
+                        (np.prod(val.shape[:-1], dtype=np.ulonglong), val.shape[-1]))]
                 else:
                     tmp = np.array([None], dtype=object)
                     tmp[0] = val


### PR DESCRIPTION
This PR removes functions removed in numpy 2.0. TODO: also add testing against numpy 2.0 in CI.

Closes #303.