### PR TITLE
Detect cases where unused chunk space can be written to

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -26,6 +26,7 @@ py.install_sources(
     'versioned_hdf5/hashtable.py',
     'versioned_hdf5/replay.py',
     'versioned_hdf5/slicetools.py',
+    'versioned_hdf5/utils.py',
     'versioned_hdf5/versions.py',
     'versioned_hdf5/wrappers.py',
   ],

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,4 @@ doctest_optionflags= NORMALIZE_WHITESPACE
 markers =
     setup_args : kwargs for setup fixture.
     slow: slow tests
+    append: tests of the append machinery

--- a/versioned_hdf5/backend.py
+++ b/versioned_hdf5/backend.py
@@ -1,18 +1,205 @@
-from typing import Dict, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 import numpy as np
-from h5py import VirtualLayout, VirtualSource, h5s
+from h5py import Dataset, File, Group, VirtualLayout, VirtualSource, h5s
 from h5py._hl.filters import guess_chunk
 from ndindex import ChunkSize, Slice, Tuple, ndindex
 from numpy.testing import assert_array_equal
 
 from .hashtable import Hashtable
+from .slicetools import (
+    get_shape,
+    get_vchunk_overlap,
+    partition,
+    spaceid_to_slice,
+    to_raw_index,
+    to_slice_tuple,
+)
+from .utils import AppendChunk, WriteChunk
 
 DEFAULT_CHUNK_SIZE = 2**12
 DATA_VERSION = 4
 # data_version 2 has broken hashtables, always need to rebuild
 # data_version 3 hash collisions for string arrays which, when concatenated, give the same string
 CORRUPT_DATA_VERSIONS = frozenset([2, 3])
+
+if TYPE_CHECKING:
+    from .wrappers import InMemoryDataset
+
+
+class SplitResult:
+    """Object which stores the result of splitting a dataset across the last chunk."""
+
+    def __init__(
+        self,
+        arr_to_append: np.ndarray,
+        arr_to_write: np.ndarray,
+        new_raw_last_chunk: Tuple,
+        new_raw_last_chunk_data: np.ndarray,
+    ):
+        """Init SplitResult.
+
+        Parameters
+        ----------
+        arr_to_append : np.ndarray
+            Array to be appended to the dataset
+        arr_to_write : np.ndarray
+            Array to be written into new chunks
+        new_raw_last_chunk : Tuple
+            Slice of the raw data containing the last chunk
+        new_raw_last_chunk_data : np.ndarray
+
+        """
+        self.arr_to_append = arr_to_append
+        self.arr_to_write = arr_to_write
+        self.new_raw_last_chunk = new_raw_last_chunk
+        self.new_raw_last_chunk_data = new_raw_last_chunk_data
+
+    def has_append_data(self) -> bool:
+        """Check whether there is data to append.
+
+        Returns
+        -------
+        bool
+            True if there is data to append, False otherwise
+        """
+        return self.arr_to_append.size > 0
+
+    def has_write_data(self) -> bool:
+        """Check whether there is data to write into a new chunk.
+
+        Returns
+        -------
+        bool
+            True if there is data to write into a new chunk, False otherwise
+        """
+        return self.arr_to_write.size > 0
+
+    def get_additional_rchunks_needed(self, chunk_size: int) -> int:
+        """Compute the number of additional chunks needed in the raw dataset.
+
+        Parameters
+        ----------
+        chunk_size : int
+            Number of elements in each chunk (along axis 0)
+
+        Returns
+        -------
+        int
+            Number of additional chunks of size chunk_size needed to store the data
+            that doesn't fit in the remaining free space in the dataset
+        """
+        return int(self.arr_to_write.shape[0] / chunk_size + 0.5)
+
+    def get_new_vshape(self, old_vshape: tuple[int, ...]) -> tuple[int, ...]:
+        """Get the new shape of the virtual dataset post-append.
+
+        Parameters
+        ----------
+        old_vshape : tuple[int, ...]
+            Previous shape of the dataset
+
+        Returns
+        -------
+        tuple[int, ...]
+            Shape of the dataset post-append
+        """
+        return (
+            (old_vshape[0] + self.arr_to_append.shape[0] + self.arr_to_write.shape[0]),
+            *old_vshape[1:],
+        )
+
+    def get_new_raw_shape(self, raw_data: Dataset) -> tuple:
+        """Get the new shape for the raw data post-append.
+
+        Parameters
+        ----------
+        raw_data : Dataset
+            Raw data which is to be appended to
+
+        Returns
+        -------
+        tuple
+            Shape of the raw data post-append
+        """
+        chunk_size = tuple(raw_data.attrs["chunks"])[0]
+        return (
+            raw_data.shape[0]
+            + self.get_additional_rchunks_needed(chunk_size) * chunk_size,
+            *raw_data.shape[1:],
+        )
+
+    def get_new_last_vchunk(self, slices: Dict[Tuple, Tuple]) -> Tuple:
+        """Get the last slice of the virtual dataset post-append.
+
+        Parameters
+        ----------
+        slices : Dict[Tuple, Tuple]
+            Mapping between {slices in virtual dataset: slices in raw dataset} which
+            make up the virtual dataset of the previous version.
+
+        Returns
+        -------
+        Tuple
+            Slices of the new version of the virtual dataset post-append
+        """
+        last_vchunk = list(slices)[-1]
+        dim0 = last_vchunk.args[0]
+        return Tuple(
+            Slice(dim0.start, dim0.stop + self.arr_to_append.shape[0]),
+            *last_vchunk.args[1:],
+        )
+
+    def get_new_last_rchunk(
+        self, raw_data: Dataset, slices: Dict[Tuple, Tuple]
+    ) -> Tuple:
+        """Get the last slice of the raw dataset post-append.
+
+        Parameters
+        ----------
+        raw_data : Dataset
+            Raw dataset where data will be written
+        slices : Dict[Tuple, Tuple]
+            Mapping between {slices in virtual dataset: slices in raw dataset} which
+            make up the virtual dataset of the previous version.
+
+        Returns
+        -------
+        Tuple
+            Last slice of the of the raw dataset post-append
+        """
+        chunk_size = tuple(raw_data.attrs["chunks"])[0]
+        last_chunk_start = raw_data.shape[0] - chunk_size
+        last_chunk_length = len(self.get_new_last_vchunk(slices).args[0])
+        last_chunk_end = last_chunk_start + last_chunk_length
+        return Tuple(
+            Slice(
+                last_chunk_start,
+                last_chunk_end,
+            ),
+            *[Slice(None, None) for _ in raw_data.shape[1:]],
+        )
+
+    def get_append_rchunk_slice(self, slices: Dict[Tuple, Tuple]) -> Tuple:
+        """Get the slice into the raw data where the new data will be appended into.
+
+        Parameters
+        ----------
+        slices : Dict[Tuple, Tuple]
+            Mapping between {slices in virtual dataset: slices in raw dataset} which
+            make up the virtual dataset of the previous version.
+
+        Returns
+        -------
+        Tuple
+            Slice of the raw dataset where the data is to be appended
+        """
+        last_rchunk = list(slices.values())[-1]
+        dim0 = last_rchunk.args[0]
+        return Tuple(
+            Slice(dim0.stop, dim0.stop + self.arr_to_append.shape[0]),
+            *last_rchunk.args[1:],
+        )
 
 
 def normalize_dtype(dtype):
@@ -168,6 +355,7 @@ def write_dataset(
             raise ValueError(f"fillvalues do not match ({fillvalue} != {ds.fillvalue})")
     if data.dtype != ds.dtype:
         raise ValueError(f"dtypes do not match ({data.dtype} != {ds.dtype})")
+
     # TODO: Handle more than one dimension
     old_shape = ds.shape
     slices = {}
@@ -192,7 +380,6 @@ def write_dataset(
                         chunk_being_written=data_s,
                         slices_to_write=slices_to_write,
                     )
-
                 else:
                     idx = hashtable.largest_index
                     raw_slice = Slice(
@@ -201,6 +388,10 @@ def write_dataset(
                     slices[data_slice] = raw_slice
                     hashtable[data_hash] = raw_slice
                     slices_to_write[raw_slice] = data_slice
+
+                    # Keep track of the last index written to in the raw dataset
+                    # for this chunk; future appends are simplified by this
+                    ds.attrs["last_element"] = raw_slice.stop
 
             ds.resize((old_shape[0] + len(slices_to_write) * chunk_size,) + chunks[1:])
             for raw_slice, data_slice in slices_to_write.items():
@@ -316,11 +507,39 @@ def _convert_to_bytes(arr: np.ndarray) -> np.ndarray:
         return np.vectorize(lambda i: bytes(i, encoding="utf-8"))(arr)
 
 
-def write_dataset_chunks(f, name, data_dict, shape=None):
-    """
+def write_dataset_chunks(
+    f: File,
+    name: str,
+    data_dict: Dict[Tuple, Union[Tuple, np.ndarray]],
+    shape: Optional[tuple] = None,
+) -> Dict[Tuple, Tuple]:
+    """Write chunks in data_dict to the raw data.
+
     data_dict should be a dictionary mapping chunk_size index to either an
     array for that chunk, or a slice into the raw data for that chunk
 
+    Parameters
+    ----------
+    f : File
+
+    name : str
+
+    data_dict : Dict[Tuple, Union[Slice, np.ndarray]]
+        Mapping between indices in the virtual dataset and either
+
+            1. Slices along the first dimension of the raw dataset
+               (other dimensions are implicit, and depend on the
+               shape of the virtual dataset); or
+            2. A new numpy array to write to the raw data for the
+               slice in the virtual dataset
+
+    shape : Optional[tuple]
+
+
+    Returns
+    -------
+    Dict[Tuple, Tuple]
+        Mapping between slices in the virtual dataset to slices in the raw dataset
     """
     if name not in f["_version_data"]:
         raise NotImplementedError(
@@ -345,6 +564,10 @@ def write_dataset_chunks(f, name, data_dict, shape=None):
         for chunk, data_s in data_dict.items():
             if isinstance(data_s, (slice, tuple, Tuple, Slice)):
                 slices[chunk] = ndindex(data_s)
+            elif isinstance(data_s, AppendChunk):
+                slices[chunk] = data_s.write_to_raw(hashtable, raw_data)
+            elif isinstance(data_s, WriteChunk):
+                slices.update(data_s.write_to_raw(hashtable, raw_data))
             else:
                 if data_s.dtype != raw_data.dtype:
                     raise ValueError(
@@ -374,6 +597,7 @@ def write_dataset_chunks(f, name, data_dict, shape=None):
                     slices[chunk] = raw_slice
                     hashtable[data_hash] = raw_slice
                     data_to_write[raw_slice] = data_s
+                    raw_data.attrs["last_element"] = raw_slice.stop
 
     assert None not in slices.values()
     old_shape = raw_data.shape
@@ -381,6 +605,8 @@ def write_dataset_chunks(f, name, data_dict, shape=None):
     for raw_slice, data_s in data_to_write.items():
         c = (raw_slice.raw,) + tuple(slice(0, i) for i in data_s.shape[1:])
         raw_data[c] = data_s
+
+    # TODO: should this return Tuple (not Slice) elements?
     return slices
 
 
@@ -392,7 +618,18 @@ def create_virtual_dataset(
 
     raw_data = f["_version_data"][name]["raw_data"]
     raw_data_shape = raw_data.shape
-    slices = {c: s.reduce() for c, s in slices.items()}
+
+    # Reduce the raw chunks, and strip out any extra dimensions (if any rchunks
+    # are Tuples). The shape of the raw data corresponding to a given virtual
+    # chunk is implied by the shape of the virtual chunk
+    new_slices = {}
+    for vchunk, rchunk in slices.items():
+        reduced_rchunk = rchunk.reduce()
+        if isinstance(reduced_rchunk, Tuple):
+            new_slices[vchunk] = reduced_rchunk.args[0]
+        else:
+            new_slices[vchunk] = reduced_rchunk
+    slices = new_slices
 
     if len(raw_data) == 0:
         layout = VirtualLayout(shape=(0,), dtype=raw_data.dtype)
@@ -461,6 +698,9 @@ def create_virtual_dataset(
             )
         fillvalue = None
 
+    # Note that due to a bug in Group.create_virtual_dataset, empty virtual datasets are
+    # not actually virtual. See https://github.com/h5py/h5py/issues/1660
+    # for the relevant discussion.
     virtual_data = f["_version_data/versions"][version_name].create_virtual_dataset(
         name, layout, fillvalue=fillvalue
     )
@@ -471,3 +711,914 @@ def create_virtual_dataset(
     virtual_data.attrs["raw_data"] = raw_data.name
     virtual_data.attrs["chunks"] = raw_data.chunks
     return virtual_data
+
+
+class WriteOperation:
+    """Base class for dataset manipulations."""
+
+    def apply(
+        self,
+        f: File,
+        name: str,
+        version: str,
+        slices: Dict[Tuple, Tuple],
+        shape: tuple[int, ...],
+    ) -> tuple[Dict[Tuple, Tuple], tuple[int, ...]]:
+        """Apply the operation to the chunks in memory.
+
+        Parameters
+        ----------
+        f : File
+            File containing the dataset to write to
+        name : str
+            Name of the dataset
+        version : str
+            Version of the dataset to write to
+        slices : Dict[Tuple, Tuple]
+            Mapping between {slices in virtual dataset: slices in raw dataset}
+            in the virtual datset initially
+        shape: tuple[int, ...]
+            Current shape of the data
+
+        Returns
+        -------
+        tuple[Dict[Tuple, Tuple], tuple[int, ...]]
+            Mapping between {slices in virtual dataset: slices in raw dataset}
+            operated on by this function; and shape of the current dataset
+        """
+        raise NotImplementedError
+
+    def write_raw(
+        self, f, name, chunks, shape
+    ) -> tuple[Dict[Tuple, Tuple], tuple[int, ...]]:
+        return write_dataset_chunks(f, name, chunks, shape), shape
+
+
+class ResizeOperation(WriteOperation):
+    def __init__(
+        self,
+        shape: tuple[int, ...],
+        chunks: ChunkSize,
+        fillvalue: Union[int, float, str],
+        dtype: np.dtype,
+    ):
+        self.shape = shape
+        self.chunks = chunks
+        self.fillvalue = fillvalue
+        self.dtype = dtype
+
+    def apply(
+        self,
+        f: File,
+        name: str,
+        _version: str,
+        slices: Dict[Tuple, Tuple],
+        _shape: tuple[int, ...],
+    ) -> tuple[Dict[Tuple, Tuple], tuple[int, ...]]:
+        """Reshape the existing slices to the new shape.
+
+        Does not work like numpy's reshape - data is not shuffled to fit the new shape.
+        Instead, data in the existing shape that falls outside the new shape is lost,
+        and new elements in the new shape are filled with `self.fillvalue`.
+
+        Parameters
+        ----------
+        f : File
+            File containing the dataset to write to
+        name : str
+            Name of the dataset
+        _version : str
+            Version of the dataset to write to; unused (this is provided by the
+            slices dict)
+        slices : Dict[Tuple, Tuple]
+            Mapping between {slices in virtual dataset: slices in raw dataset}
+            in the virtual datset initially
+        _shape: tuple[int, ...]
+            Current shape of the data; unused (old shape is irrelevant, we are
+            reshaping here)
+
+        Returns
+        -------
+        tuple[Dict[Tuple, Tuple], tuple[int, ...]]
+            Mapping between {slices in virtual dataset: slices in raw dataset}
+            which were written by this function; and shape of the current dataset
+        """
+        new_shape_index = Tuple(*[Slice(0, i) for i in self.shape])
+        raw_data: Dataset = f["_version_data"][name]["raw_data"]  # type: ignore
+
+        # Keep a copy of the old slices; it will be needed later to compute
+        # the chunks modified by the reshape operation
+        current_slices = slices.copy()
+
+        new_slices = {}
+        for vchunk in partition(new_shape_index, self.chunks):
+            # If the new virtual chunk is in the old set of slices, just use the same
+            # raw data the virtual chunk is already mapped to. Pop it out of the slices
+            # dict so that we don't need to iterate over it when computing parts of the
+            # dataset with the new shape.
+            if vchunk in current_slices:
+                new_slices[vchunk] = current_slices.pop(vchunk)
+
+            # Otherwise compute the overlap of the new vchunk and the old vchunks, and
+            # then compute what the raw data should be.
+            else:
+                new_slices[vchunk] = arr_from_chunks(
+                    current_slices,
+                    raw_data,
+                    vchunk,
+                    self.shape,
+                )
+
+        return new_slices, self.shape
+
+    def __repr__(self) -> str:
+        return f"ResizeOperation: {self.shape}"
+
+
+class SetOperation(WriteOperation):
+    """Operation which indexes the dataset to write data."""
+
+    def __init__(self, index: Tuple, arr: np.ndarray):
+        """Initialize a SetOperation.
+
+        Parameters
+        ----------
+        index : Tuple
+            Virtual dataset index where ``arr`` is to be written
+        arr : np.ndarray
+            Array to write to the dataset
+        """
+        self.index = index
+        self.arr = arr
+
+    def __repr__(self):
+        return f"SetOperation: {self.index} = {self.arr}"
+
+    def apply(
+        self,
+        f: File,
+        name: str,
+        _version: str,
+        slices: Dict[Tuple, Tuple],
+        shape: tuple[int, ...],
+    ) -> tuple[Dict[Tuple, Tuple], tuple[int, ...]]:
+        """Write the stored data to the dataset in chunks.
+
+        Parameters
+        ----------
+        f : File
+            File containing the dataset to write to
+        name : str
+            Name of the dataset
+        version : str
+            Version of the dataset to write to; unused (this is provided by the
+            slices dict)
+        slices : Dict[Tuple, Tuple]
+            Mapping between {slices in virtual dataset: slices in raw dataset}
+            in the virtual datset initially
+        shape: tuple[int, ...]
+            Current shape of the data
+
+        Returns
+        -------
+        tuple[Dict[Tuple, Tuple], tuple[int, ...]]
+            Mapping between {slices in virtual dataset: slices in raw dataset}
+            which were written by this function; and shape of the current dataset
+        """
+        # Ensure each element of the index is a slice. Reduce the index
+        # onto the shape of the current dataset to remove NoneType or Eliipsis
+        # index shape args.
+        index = to_slice_tuple(ndindex(self.index).expand(shape))
+
+        # If the shape of the array doesn't match the shape of the
+        # index to assign the array to, broadcast it first.
+        index_shape = tuple(len(dim) for dim in index.args)
+        if self.arr.shape != index_shape:
+            arr = np.broadcast_to(self.arr, index_shape)
+        else:
+            arr = self.arr
+
+        raw_data: Dataset = f["_version_data"][name]["raw_data"]
+
+        new_chunks = get_updated_chunks(
+            slices,
+            index,
+            arr,
+            shape,
+            raw_data,
+        )
+
+        return new_chunks, shape
+
+
+class AppendOperation(WriteOperation):
+    """Operation which appends data to a dataset."""
+
+    def __init__(self, value: np.ndarray):
+        """Initialize a WriteOperation.
+
+        Parameters
+        ----------
+        value : np.ndarray
+            Array to append to the dataset
+        """
+        self.value = value
+
+    def __repr__(self):
+        return f"AppendOperation: {self.value}"
+
+    def apply(
+        self,
+        f: File,
+        name: str,
+        version: str,
+        slices: Dict[Tuple, Tuple],
+        shape: tuple[int, ...],
+    ) -> tuple[Dict[Tuple, Tuple], tuple[int, ...]]:
+        """Append data to the raw dataset.
+
+        1. Split the data into a part which can fit in the last chunk, and a part which
+           can't.
+        2. Compute the hash of the last virtual chunk with the new data appended.
+        3. Add either the hashed raw slice (if in the hashtable, and therefore the raw data)
+           or the new slice to the slice dict.
+        4. If the data to append doesn't fit in the unused space in the last chunk, write
+           any additional data into new chunk(s).
+
+        Parameters
+        ----------
+        f : File
+            File where the data is to be written
+        version : str
+            Version of the version to appending data to
+        name : str
+            Name of the dataset to append data to
+        arr : np.ndarray
+            Data to append to the dataset
+        slices : Dict[Tuple, Tuple]
+            Slices of the virtual dataset that is being appended to; maps {slices in
+            virtual dataset: slices in raw dataset}. If only one append
+            operation is being carried out, this is the value returned by.
+            `get_previous_version_slices(f, version_name, name)`. If multiple WriteOperation
+            operations are being carried out, these slices represent the result of all the
+            write operations applied to the virtual dataset
+        shape : tuple[int, ...]
+            Shape of the dataset pre-append
+
+        Returns
+        -------
+        Tuple[Dict[Tuple, Tuple], tuple[int, ...]]
+            Mapping between {slices in virtual dataset: slices in raw dataset}
+            which were written by this function; and shape of the current dataset
+        """
+        if not slices:
+            raise ValueError("Cannot append to empty dataset.")
+
+        raw_data: Dataset = f["_version_data"][name]["raw_data"]
+
+        if raw_data.dtype != self.value.dtype:
+            raise ValueError(
+                f"dtypes of raw data ({raw_data.dtype}) does not match data to append "
+                f"({self.value.dtype})"
+            )
+
+        # Get the slices from the previous version; they are reused here
+        last_virtual_slice = list(sorted(slices, key=lambda obj: obj.args[0].start))[-1]
+
+        # Split the data to append into a part which fits in the last
+        # chunk of the raw data, and the part that doesn't
+        split = split_across_unused(f, name, self.value)
+
+        # If there's empty space in the last chunk of the raw data, append as much
+        # data as will fit
+        if split.has_append_data():
+            with Hashtable(f, name) as hashtable:
+                # Get the new virtual and raw last chunks
+                vchunk = split.get_new_last_vchunk(slices)
+                rchunk = split.get_new_last_rchunk(raw_data, slices)
+
+                # Get the indices to write the new data into
+                append_slice = split.get_append_rchunk_slice(slices)
+
+                # Remove the last chunk of the virtual dataset; we are
+                # replacing it with the chunk containing the appended data
+                del slices[last_virtual_slice]
+
+                # If the hash of the data is already in the hash table,
+                # just reuse the hashed slice. Otherwise, update the
+                # hash table with the new data hash and write the data
+                # to the raw dataset.
+                data_hash = hashtable.hash(split.new_raw_last_chunk_data)
+                if data_hash in hashtable:
+                    slices[vchunk] = hashtable[data_hash]
+                else:
+                    # Update the slices mapping
+                    slices[vchunk] = rchunk
+
+                    # Update the hashtable
+                    hashtable[data_hash] = rchunk
+
+                    # Write the data
+                    raw_data[append_slice.raw] = split.arr_to_append
+
+                    # Keep track of the last index written to in the raw dataset;
+                    # future appends are simplified by this
+                    raw_data.attrs["last_element"] = rchunk.args[0].stop
+
+        if split.has_write_data():
+            if split.has_append_data():
+                last_virtual_index = (
+                    last_virtual_slice.args[0].stop + split.arr_to_append.shape[0]
+                )
+            else:
+                last_virtual_index = last_virtual_slice.args[0].stop
+
+            virtual_slice_to_write = Tuple(
+                Slice(
+                    last_virtual_index,
+                    last_virtual_index + split.arr_to_write.shape[0],
+                ),
+                *[Slice(None, None) for _ in last_virtual_slice.args[1:]],
+            )
+
+            slices.update(
+                write_to_dataset(
+                    f,
+                    version,
+                    name,
+                    virtual_slice_to_write,
+                    split.arr_to_write,
+                )
+            )
+
+        return slices, split.get_new_vshape(shape)
+
+    def apply2(
+        self,
+        f: File,
+        name: str,
+        version: str,
+        slices: Dict[Tuple, Tuple],
+        shape: tuple[int, ...],
+    ) -> tuple[Dict[Tuple, Tuple], tuple[int, ...]]:
+        """Append data to the raw dataset.
+
+        1. Split the data into a part which can fit in the last chunk, and a part which
+           can't.
+        2. Compute the hash of the last virtual chunk with the new data appended.
+        3. Add either the hashed raw slice (if in the hashtable, and therefore the raw data)
+           or the new slice to the slice dict.
+        4. If the data to append doesn't fit in the unused space in the last chunk, write
+           any additional data into new chunk(s).
+
+        Parameters
+        ----------
+        f : File
+            File where the data is to be written
+        version : str
+            Version of the version to appending data to
+        name : str
+            Name of the dataset to append data to
+        arr : np.ndarray
+            Data to append to the dataset
+        slices : Dict[Tuple, Tuple]
+            Slices of the virtual dataset that is being appended to; maps {slices in
+            virtual dataset: slices in raw dataset}. If only one append
+            operation is being carried out, this is the value returned by.
+            `get_previous_version_slices(f, version_name, name)`. If multiple WriteOperation
+            operations are being carried out, these slices represent the result of all the
+            write operations applied to the virtual dataset
+        shape : tuple[int, ...]
+            Shape of the dataset pre-append
+
+        Returns
+        -------
+        Tuple[Dict[Tuple, Tuple], tuple[int, ...]]
+            Mapping between {slices in virtual dataset: slices in raw dataset}
+            which were written by this function; and shape of the current dataset
+        """
+        if not slices:
+            raise ValueError("Cannot append to empty dataset.")
+
+        raw_data: Dataset = f["_version_data"][name]["raw_data"]
+
+        if raw_data.dtype != self.value.dtype:
+            raise ValueError(
+                f"dtypes of raw data ({raw_data.dtype}) does not match data to append "
+                f"({self.value.dtype})"
+            )
+
+        # Get the slices from the previous version; they are reused here
+        last_virtual_slice = list(sorted(slices, key=lambda obj: obj.args[0].start))[-1]
+
+        # Split the data to append into a part which fits in the last
+        # chunk of the raw data, and the part that doesn't
+        split = split_across_unused(f, name, self.value)
+
+        # If there's empty space in the last chunk of the raw data, append as much
+        # data as will fit
+        if split.has_append_data():
+            # Get the new virtual and raw last chunks
+            vchunk = split.get_new_last_vchunk(slices)
+            # rchunk = split.get_new_last_rchunk(raw_data, slices)
+
+            # Get the indices to write the new data into
+            append_slice = split.get_append_rchunk_slice(slices)
+
+            # Remove the last chunk of the virtual dataset; we are
+            # replacing it with the chunk containing the appended data
+            del slices[last_virtual_slice]
+
+            slices[vchunk] = AppendChunk(
+                target_raw_index=append_slice,
+                target_raw_data=split.arr_to_append,
+                raw_last_chunk=split.new_raw_last_chunk,
+                raw_last_chunk_data=split.new_raw_last_chunk_data,
+                # rchunk=rchunk,
+            )
+
+        if split.has_write_data():
+            if split.has_append_data():
+                last_virtual_index = (
+                    last_virtual_slice.args[0].stop + split.arr_to_append.shape[0]
+                )
+            else:
+                last_virtual_index = last_virtual_slice.args[0].stop
+
+            virtual_slice_to_write = Tuple(
+                Slice(
+                    last_virtual_index,
+                    last_virtual_index + split.arr_to_write.shape[0],
+                ),
+                *[Slice(None, None) for _ in last_virtual_slice.args[1:]],
+            )
+
+            slices[virtual_slice_to_write] = split.arr_to_write
+
+        return slices, split.get_new_vshape(shape)
+
+
+def write_dataset_operations(
+    f: File,
+    version_name: str,
+    name: str,
+    dataset: "InMemoryDataset",
+) -> tuple[Dict[Tuple, Tuple], tuple[int, ...]]:
+    chunks, shape = write_operations(f, version_name, name, dataset._operations)
+    result = write_dataset_chunks(f, name, chunks, shape)
+    dataset._operations.clear()
+    return result, shape
+
+
+def write_operations(
+    f: File, version_name: str, name: str, operations: List[WriteOperation]
+) -> tuple[Dict[Tuple, Tuple], tuple[int, ...]]:
+    """Carry out a sequence of write operations on the file.
+
+    If no operations are pending, just return the previous version slices and shape.
+
+    Parameters
+    ----------
+    f : File
+        File to write
+    version_name : str
+        Version name of the data to be written
+    name : str
+        Name of the dataset to be written
+    operations : List[WriteOperation]
+        List of write operations to perform
+
+    Returns
+    -------
+    tuple[Dict[Tuple, Tuple], tuple[int, ...]]
+        (Slices map, shape of virtual dataset post-write)
+
+        The slices map is a mapping from {virtual dataset slice: raw dataset slice}.
+        The virtual dataset is created elsewhere using the slices return here.
+    """
+    if name not in f["_version_data"]:
+        raise NotImplementedError(
+            "Use write_dataset() if the dataset does not yet exist"
+        )
+
+    slices = get_previous_version_slices(f, version_name, name)
+    shape = get_previous_version_shape(f, version_name, name)
+
+    for operation in operations:
+        slices, shape = operation.apply(f, name, version_name, slices, shape)
+
+    sorted_slices = dict(sorted(list(slices.items()), key=lambda s: s[0].args[0].start))
+
+    return sorted_slices, shape
+
+
+def last_raw_used_chunk(f: File, name: str) -> Tuple:
+    """Get the part of the last chunk in the raw dataset used by a virtual dataset.
+
+    Parameters
+    ----------
+    f : File
+        File for which the used part of the last chunk is to be retrieved
+    name : str
+        Name of the dataset
+
+    Returns
+    -------
+    Tuple
+        Slice of the last chunk in the raw dataset that is used by a virtual dataset
+    """
+    raw_data: Dataset = f["_version_data"][name]["raw_data"]
+    chunks: tuple = raw_data.attrs["chunks"]
+    if "last_element" in raw_data.attrs:
+        last_chunk_start = raw_data.shape[0] - chunks[0]
+        return Tuple(
+            Slice(
+                last_chunk_start,
+                last_chunk_start + raw_data.attrs["last_element"],
+            ),
+            *(Slice(0, i) for i in raw_data.shape[1:]),
+        )
+    raise ValueError("Cannot find the last written element in the raw data.")
+
+
+def get_space_remaining(f: File, name: str) -> int:
+    """Get the number of unused elements in the last raw chunk along axis 0.
+
+    Parameters
+    ----------
+    f : File
+        File for which the remaining space in the last raw chunk is to be retrieved
+    name : str
+        Name of the dataset
+
+    Returns
+    -------
+    int
+        Number of unused elements in the last chunk
+    """
+    raw_data: Dataset = f["_version_data"][name]["raw_data"]
+    last_element: Optional[int] = raw_data.attrs.get("last_element", None)
+    if last_element is None:
+        raise ValueError("Cannot find the last written element in the raw data.")
+
+    return raw_data.shape[0] - last_element
+
+
+def write_to_dataset(
+    f: File,
+    version_name: str,
+    name: str,
+    virtual_slice: Tuple,
+    data: Union[np.ndarray, Tuple],
+) -> Dict[Tuple, Tuple]:
+    """Write data into new chunks at the end of the dataset.
+
+    Parameters
+    ----------
+    f : File
+        File where data should be written
+    version_name : str
+        Version name for which data is to be written
+    name : str
+        Name of the dataset being modified
+    virtual_slice : Tuple
+        Slice of the virtual dataset the data is to be written into
+    data : Union[np.ndarray, Tuple]
+        Data to be written. If it is a Tuple, this is a slice of the raw dataset.
+
+    Returns
+    -------
+    Dict[Tuple, Tuple]
+        Mapping between {slices in virtual dataset: slices in raw dataset} which were
+        written by this function.
+    """
+    raw_data: Dataset = f["_version_data"][name]["raw_data"]
+    chunk_size = raw_data.chunks[0]
+
+    if isinstance(data, np.ndarray) and raw_data.dtype != data.dtype:
+        raise ValueError(
+            f"dtype of raw data ({raw_data.dtype}) does not match data to append "
+            f"({data.dtype})"
+        )
+
+    slices: Dict[Tuple, Tuple] = {}
+    with Hashtable(f, name) as hashtable:
+        for data_slice, vchunk in zip(
+            partition(data, raw_data.chunks),
+            partition(virtual_slice, raw_data.chunks),
+        ):
+            arr = data[data_slice.raw]
+            data_hash = hashtable.hash(arr)
+
+            if data_hash in hashtable:
+                slices[vchunk] = hashtable[data_hash]
+            else:
+                new_chunk_axis_size = raw_data.shape[0] + len(data_slice.args[0])
+
+                rchunk = Tuple(
+                    Slice(
+                        raw_data.shape[0],
+                        new_chunk_axis_size,
+                    ),
+                    *[Slice(None, None) for _ in raw_data.shape[1:]],
+                )
+
+                # Resize the dataset to include a new chunk
+                raw_data.resize(raw_data.shape[0] + chunk_size, axis=0)
+
+                # Map the virtual chunk to the raw data chunk
+                slices[vchunk] = rchunk
+
+                # Map the data hash to the raw data chunk
+                hashtable[data_hash] = rchunk
+
+                # Set the value of the raw data chunk to the chunk of the new data being written
+                raw_data[rchunk.raw] = data[data_slice.raw]
+
+                # Update the last element attribute of the raw dataset
+                raw_data.attrs["last_element"] = rchunk.args[0].stop
+
+    return slices
+
+
+def get_previous_version_slices(
+    f: File,
+    version_name: str,
+    name: str,
+) -> Dict[Tuple, Tuple]:
+    """Get the slices from the previous version.
+
+    Ensures the slices are sorted in the order they appear along axis 0 of the virtual
+    dataset.
+
+    Parameters
+    ----------
+    f : File
+        File where the slices are to be retrieved
+    version_name : str
+        Name of the version for which the previous version slices are to be retrieved
+    name : str
+        Name of the dataset
+
+    Returns
+    -------
+    Dict[Tuple, Tuple]
+        Mapping between {indices in virtual dataset: indices in raw dataset} which
+        make up the virtual dataset of the previous version.
+    """
+    prev_version = get_previous_version(f, version_name, name)
+    slices = []
+
+    # Due to a bug in Group.create_virtual_dataset, empty virtual datasets are not actually
+    # virtual. See https://github.com/h5py/h5py/issues/1660 for the relevant discussion.
+    # Here we first check if it's virtual to avoid calling virtual_sources if it isn't.
+    if prev_version.is_virtual:
+        for source in prev_version.virtual_sources():
+            slices.append(
+                (spaceid_to_slice(source.vspace), spaceid_to_slice(source.src_space))
+            )
+
+    return dict(sorted(slices, key=lambda s: s[0].args[0].start))
+
+
+def get_previous_version(
+    f: File,
+    version_name: str,
+    name: str,
+) -> Dataset:
+    versions: Group = f["_version_data"]["versions"]
+    prev_version_name: str = versions[version_name].attrs["prev_version"]
+    return versions[prev_version_name][name]
+
+
+def get_previous_version_shape(
+    f: File,
+    version_name: str,
+    name: str,
+) -> tuple[int, ...]:
+    prev_version = get_previous_version(f, version_name, name)
+    if prev_version.shape is not None:
+        return prev_version.shape
+
+    raise ValueError("Shape of a dataset is None")
+
+
+def split_across_unused(
+    f: File,
+    name: str,
+    arr: np.ndarray,
+) -> SplitResult:
+    """Split arr into a part that fits into unused space, and the part that doesn't.
+
+    If there is any space remaining in the last chunk in the raw_data, arr will be
+    broken into a piece that fits in that last chunk. If arr is larger than the
+    remaining unused space, there will also be a piece that needs to be written into
+    a new chunk.
+
+    Parameters
+    ----------
+    f : File
+        File to operate on
+    name : str
+        Name of the dataset to split arr into the last chunk of
+    arr : np.ndarray
+        Numpy array to try to cram into the final chunk
+
+    Returns
+    -------
+    SplitWhatFitsResult
+        Result of what fits into the last chunk of the raw data
+    """
+    raw_data: Dataset = f["_version_data"][name]["raw_data"]
+
+    # Find the last used chunk of the raw data, and the empty space still left in the
+    # last used chunk
+    raw_last_used_chunk = last_raw_used_chunk(f, name)
+
+    # Append as many as we can; that's either the amount that fits in the remaining
+    # space, or the size of the array to be appended, whichever is smaller
+    n_to_append = min(get_space_remaining(f, name), arr.shape[0])
+
+    # Break the data into the part that will fit in the last raw chunk,
+    # and the part that will need to be written to new chunks.
+    vslice_to_append = Tuple(
+        Slice(None, n_to_append),
+        *[Slice(None, None) for _ in arr.shape[1:]],
+    )
+    vslice_remaining = Tuple(
+        Slice(n_to_append, None),
+        *[Slice(None, None) for _ in arr.shape[1:]],
+    )
+    arr_to_append = arr[vslice_to_append.raw]
+    arr_to_write = arr[vslice_remaining.raw]
+
+    # Compute the new size of the last used chunk
+    new_raw_last_chunk = Tuple(
+        Slice(
+            raw_last_used_chunk.args[0].start,
+            raw_last_used_chunk.args[0].stop + arr_to_append.shape[0],
+        ),
+        *[Slice(None, None) for _ in raw_data.shape[1:]],
+    )
+
+    # Since we're appending to the last chunk, we need to grab the last
+    # chunk, append the data, then hash it.
+    new_raw_last_chunk_data = np.concatenate(
+        (
+            raw_data[raw_last_used_chunk.raw],
+            arr_to_append,
+        )
+    )
+
+    return SplitResult(
+        arr_to_append,
+        arr_to_write,
+        new_raw_last_chunk,
+        new_raw_last_chunk_data,
+    )
+
+
+def get_updated_chunks(
+    slices: Dict[Tuple, Tuple],
+    index: Tuple,
+    arr: np.ndarray,
+    shape: tuple[int, ...],
+    raw_data: Dataset,
+) -> Dict[Tuple, Union[Tuple, np.ndarray]]:
+    """Get the new chunks of the virtual dataset after arr is written to index.
+
+    Parameters
+    ----------
+    slices : Dict[Tuple, Union[Tuple, np.ndarray]]
+        Mapping between existing {slices in virtual dataset: slices in raw dataset}.
+        Must be of size chunk_size along axis 0.
+    index : Tuple
+        (Contiguous) virtual indices for which arr is to be set
+    arr : np.ndarray
+        Values to set at `index` indices in the virtual dataset
+    raw_data : Dataset
+        Raw data
+
+    Returns
+    -------
+    Dict[Tuple, Union[Tuple, np.ndarray]]
+        Mapping between {slices in virtual dataset: slices in raw dataset}
+        _after_ the data is written (which will be done elsewhere, in
+        write_dataset_chunks). These slices are of size chunk_size.
+    """
+    new_chunks = {}
+
+    # Get new chunks that `index` touches that aren't in the slices dict
+    chunker = ChunkSize(raw_data.chunks)
+    for vchunk in chunker.as_subchunks(index, shape):
+        if vchunk not in slices:
+            arr_overlap, relative_overlap = get_vchunk_overlap(vchunk, index)
+
+            # Overwrite the part of the chunk that `index` touches with the
+            # corresponding part of `arr`
+            data = np.full(
+                get_shape(vchunk, shape),
+                fill_value=raw_data.fillvalue,
+                dtype=raw_data.dtype,
+            )
+            data[relative_overlap.raw] = arr[arr_overlap.raw]
+            new_chunks[vchunk] = data
+
+    # Handle preexisting slices
+    for vchunk, rchunk in slices.items():
+        arr_overlap, relative_overlap = get_vchunk_overlap(vchunk, index)
+
+        if arr_overlap.isempty():
+            # There's no overlap between the index being set and this chunk;
+            # reuse the existing raw slice or data
+            new_chunks[vchunk] = rchunk
+        else:
+            if isinstance(rchunk, Tuple):
+                # The index to set (partially) overlaps a chunk that points
+                # to the raw dataset; copy the raw data, then overwrite the
+                # indices that overlap with the new data
+                overlap_data = raw_data[rchunk.raw]
+                overlap_data[relative_overlap.raw] = arr[arr_overlap.raw]
+                new_chunks[vchunk] = overlap_data
+            elif isinstance(rchunk, np.ndarray):
+                # The index to set (partially) overlaps a chunk that was
+                # set in a different InMemoryDataset.__setitem__ call;
+                # take the previous __setitem__ data, and overwrite the
+                # indices that overlap with the new data
+                overlap_data = rchunk
+                overlap_data[relative_overlap.raw] = arr[arr_overlap.raw]
+                new_chunks[vchunk] = overlap_data
+            elif isinstance(rchunk, AppendChunk):
+                # The index to set (partially) overlaps a chunk that was
+                # appended to in a different InMemoryDataset.append call;
+                # For certain cases where the __setitem__ hits only the
+                # indices that are being appended, it might be possible
+                # to modify the AppendChunk in place. However this behavior
+                # will be harder to maintain and probably not necessary. For
+                # now just blow out the AppendChunk and write a new chunk.
+                overlap_data = rchunk.new_raw_last_chunk_data
+                overlap_data[relative_overlap.raw] = arr[arr_overlap.raw]
+                breakpoint()
+                new_chunks[vchunk] = overlap_data
+            elif isinstance(rchunk, WriteChunk):
+                raise NotImplementedError
+
+    return new_chunks
+
+
+def arr_from_chunks(chunks, raw_data, index, shape) -> np.ndarray:
+    """Get the resulting array that spans `index` from the given chunks.
+
+          +---index.as_subindex(vchunk)----+  <-- Referenced with respect to beginning of vchunk
+          |                                |
+          +------------ vchunk ------------+
+          |                                |
+        +------------ arr -------------------------+
+        |                                          |
+        +-+-------- index -----------------+-------+
+          |                                |
+          +----vchunk.as_subindex(index)---+  <-- Referenced with respect to beginning of index
+
+
+    Parameters
+    ----------
+    chunks :
+
+    raw_data :
+
+    index :
+
+    shape :
+
+
+    Returns
+    -------
+    np.ndarray
+        Note that if `chunks` doesn't cover all parts of `index`, unset values will
+        be filled with `raw_data.fillvalue`, NOT what is actually in the raw data
+    """
+    index = to_slice_tuple(index)
+    arr = np.full(get_shape(index, shape), raw_data.fillvalue, dtype=raw_data.dtype)
+
+    for vchunk, rchunk in chunks.items():
+        arr_overlap, relative_overlap = get_vchunk_overlap(vchunk, index)
+
+        # |__________|         vchunk
+        #         |________|   index
+        #         ^  ^
+        # overlap of index and vchunk in vspace; find overlap in rspace,
+        # set the subset of arr indices to the rspace subset that overlaps
+        if not arr_overlap.isempty():
+            if isinstance(rchunk, Tuple):
+                # Ensure the raw chunk is a Tuple of Slice instances
+                rchunk = to_slice_tuple(rchunk)
+                raw_index = to_raw_index(rchunk, relative_overlap)
+                arr[arr_overlap.raw] = raw_data[raw_index.raw]
+            elif isinstance(rchunk, np.ndarray):
+                arr[arr_overlap.raw] = rchunk[relative_overlap.raw]
+            elif isinstance(rchunk, AppendChunk):
+                arr[arr_overlap.raw] = rchunk.new_raw_last_chunk_data[
+                    relative_overlap.raw
+                ]
+
+    return arr

--- a/versioned_hdf5/backend.py
+++ b/versioned_hdf5/backend.py
@@ -130,7 +130,12 @@ class SplitResult:
         )
 
     def get_new_last_vchunk(self, slices: Dict[Tuple, Tuple]) -> Tuple:
-        """Get the last slice of the virtual dataset post-append.
+        """Get the last chunk of the virtual dataset post-append.
+
+        This gets the last chunk of the virtual dataset where the data which can fit
+        in the last raw chunk is being appended to. Note that there may also be data
+        written into a brand new raw chunk, but the virtual chunk associated with
+        that is not what is returned here.
 
         Parameters
         ----------
@@ -153,7 +158,12 @@ class SplitResult:
     def get_new_last_rchunk(
         self, raw_data: Dataset, slices: Dict[Tuple, Tuple]
     ) -> Tuple:
-        """Get the last slice of the raw dataset post-append.
+        """Get the last chunk of the raw dataset post-append.
+
+        This gets the last chunk of the raw dataset where the data which can fit
+        in the last raw chunk is being appended to. Note that there may also be data
+        written into a brand new raw chunk, but the raw chunk containing that new
+        data is not what is returned here.
 
         Parameters
         ----------
@@ -1039,6 +1049,25 @@ def write_dataset_operations(
     name: str,
     dataset: "InMemoryDataset",
 ) -> tuple[Dict[Tuple, Tuple], tuple[int, ...]]:
+    """Write any pending dataset operations to the file before clearing them.
+
+    Parameters
+    ----------
+    f : File
+        File to write the data to
+    version_name : str
+        Version name to write the data to
+    name : str
+        Dataset name to write the data to
+    dataset : InMemoryDataset
+        Dataset containing pending operations to write to the file
+
+    Returns
+    -------
+    tuple[Dict[Tuple, Tuple], tuple[int, ...]]
+        Mapping between virtual dataset chunks and raw dataset chunks, and
+        shape of the new virtual dataset
+    """
     chunks, shape = write_operations(f, version_name, name, dataset._operations)
     result = write_dataset_chunks(f, name, chunks, shape)
     dataset._operations.clear()

--- a/versioned_hdf5/backend.py
+++ b/versioned_hdf5/backend.py
@@ -248,7 +248,10 @@ def create_base_dataset(
         shape = data.shape
     else:
         shape = (shape,) if isinstance(shape, int) else tuple(shape)
-        if data is not None and (np.prod(shape, dtype=np.ulonglong) != np.prod(data.shape, dtype=np.ulonglong)):
+        if data is not None and (
+            np.prod(shape, dtype=np.ulonglong)
+            != np.prod(data.shape, dtype=np.ulonglong)
+        ):
             raise ValueError("Shape tuple is incompatible with data")
 
     ndims = len(shape)
@@ -1104,10 +1107,7 @@ def last_raw_used_chunk(f: File, name: str) -> Tuple:
     if "last_element" in raw_data.attrs:
         last_chunk_start = raw_data.shape[0] - chunks[0]
         return Tuple(
-            Slice(
-                last_chunk_start,
-                last_chunk_start + raw_data.attrs["last_element"],
-            ),
+            Slice(last_chunk_start, raw_data.attrs["last_element"]),
             *(Slice(0, i) for i in raw_data.shape[1:]),
         )
     raise ValueError("Cannot find the last written element in the raw data.")

--- a/versioned_hdf5/slicetools.py
+++ b/versioned_hdf5/slicetools.py
@@ -1,6 +1,9 @@
 from functools import lru_cache
+from typing import Iterator, Optional, Union
 
-from ndindex import Slice, Tuple
+import numpy as np
+from ndindex import ChunkSize, Integer, Slice, Tuple
+from ndindex.ndindex import NDIndex
 
 
 def spaceid_to_slice(space):
@@ -37,3 +40,228 @@ def hyperslab_to_slice(start, stride, count, block):
     end = start + (stride * (count - 1) + 1) * block
     stride = stride if block == 1 else 1
     return Slice(start, end, stride)
+
+
+def to_slice_tuple(index: Tuple) -> Tuple:
+    """Make an ndindex.Tuple into a ndindex.Tuple of slices.
+
+    ndindex.Integer doesn't support the same methods that ndindex.Slice does. This function ensures
+    that indices which are ndindex.Integer are converted into ndindex.Slice first, so that we can
+    use a common API.
+
+    Parameters
+    ----------
+    index : Tuple
+        Tuple index to convert. Slice dimensions are left as-is; Tuple dimensions are converted to
+        single-element slices.
+
+    Returns
+    -------
+    Tuple
+        Tuple of Slice instance; Integer dimensions are converted to single-element Slice instances.
+    """
+    result = []
+    for dim in index.args:
+        if isinstance(dim, Integer):
+            result.append(Slice(dim.raw, dim.raw + 1))
+        elif isinstance(dim, Slice):
+            result.append(dim)
+        else:
+            raise TypeError(f"Cannot convert type of {dim} to a Slice.")
+
+    return Tuple(*result)
+
+
+def index_relative_to(index: Tuple, other: Tuple) -> Tuple:
+    """Compute the index relative to the start of another index.
+
+    Parameters
+    ----------
+    index : Tuple
+        A Tuple index
+    other : Tuple
+        Another Tuple index
+
+    Returns
+    -------
+    Tuple
+        The first index, adjusted to be relative to the second
+
+    Examples
+    --------
+        index:          ---------------
+
+        other:     --------------------------
+
+
+                   ^    ^              ^
+                   index starts at other[5]
+                   index stops at other[20]
+
+        thus index_relative_to(index, other) -> Tuple(Slice(5, 20))
+    """
+    relative = []
+    for dim1, dim2 in zip(index.args, other.args):
+        relative.append(Slice(dim1.start - dim2.start, dim1.stop - dim2.start))
+    return Tuple(*relative)
+
+
+def to_raw_index(rchunk: Tuple, relative_index: Tuple) -> Tuple:
+    """Convert a relative virtual index to a raw slice.
+
+    The use case for this function is if you have a raw chunk and a corresponding virtual chunk,
+    and you want to get a subchunk of the virtual chunk and its corresponding raw indices,
+    you'll first need to compute the relative indices of the virtual chunk; then you'd use
+    to_raw_index to get the raw indices of the subchunk.
+
+    Parameters
+    ----------
+    rchunk : Tuple
+        Raw index defining the boundaries of a chunk of the raw dataset
+    relative_index : Tuple
+        Arbitrary slice of a dataset; indices are relative to the start of the
+        a chunk. Since this is relative to the start of a chunk, it is neither a virtual
+        nor a raw index.
+
+    Returns
+    -------
+    Tuple
+        Slice of the raw dataset computed using the relative index
+
+    Examples
+    --------
+        rchunk:   Slice(5, 25)
+        relative_index: Slice(3, 5)
+        to_raw_index(rchunk, relative_index) -> Tuple(Slice(8, 10))
+
+        The call to `to_raw_index` should be read as "Return elements 3-5 of rchunk."
+    """
+    raw_indices = []
+    for rdim, relative_dim in zip(rchunk.args, relative_index.args):
+        offset = rdim.start
+        if not (
+            rdim.start <= offset + relative_dim.start <= rdim.stop
+            and rdim.start <= offset + relative_dim.stop <= rdim.stop
+        ):
+            raise ValueError(
+                f"Cannot convert elements {relative_index} to a raw index "
+                f"without exceeding the bounds of the raw chunk: {rchunk}"
+            )
+
+        raw_indices.append(
+            Slice(relative_dim.start + offset, relative_dim.stop + offset)
+        )
+    return Tuple(*raw_indices)
+
+
+def get_vchunk_overlap(vchunk: NDIndex, index: NDIndex) -> tuple[Tuple, Tuple]:
+    """Get the overlap of the index with the vchunk.
+
+    Here, ``index`` represents an arbitrary slice which may or may not overlap
+    a virtual chunk ``vchunk_data``, defined by the index ``vchunk``.
+
+      +---index.as_subindex(vchunk)----+  <-- Referenced with respect to beginning of vchunk
+      |                                |
+      +------------ vchunk ------------+
+      |                                |
+    +------------ arr -------------------------+
+    |                                          |
+    +-+-------- index -----------------+-------+
+      |                                |
+      +----vchunk.as_subindex(index)---+  <-- Referenced with respect to beginning of index
+
+
+
+
+    Examples
+    --------
+    Assume we are trying to write an array ``arr`` to an index ``index``. Then for
+    a given virtual slice ``vchunk``, ``get_vchunk_overlap(vchunk, index)``
+    returns the indices in ``arr`` that overlap with the virtual slice, and the indices
+    of the virtual chunk to write to the new virtual slice.
+
+    arr_overlap, relative_overlap = get_vchunk_overlap(vchunk, index)
+
+    Elements of arr that overlap:
+        arr[arr_overlap.raw]
+
+    Elements of the virtual chunk ``vchunk_data`` to overwrite:
+        vchunk_data[relative_overlap.raw]
+
+    Parameters
+    ----------
+    vchunk : NDIndex
+        Chunk of virtual data
+    index : NDIndex
+        Arbitrary index in the virtual dataset
+
+    Returns
+    -------
+    tuple(Tuple, Tuple)
+        (Indices of ``arr`` which overlap, indices of ``vchunk_data`` which overlap)
+    """
+    return vchunk.as_subindex(index), index.as_subindex(vchunk)
+
+
+def get_shape(index: Tuple, shape: Optional[tuple[int, ...]] = None) -> tuple[int, ...]:
+    """Get the size of the index along each dimension.
+
+    If the shape has any indefinite boundaries e.g. NoneType, Ellipsis,
+    these will be defined by `shape`.
+
+    Parameters
+    ----------
+    index : Tuple
+        Index which defines a shape
+
+    shape : Optional[tuple[int, ...]]
+        Shape to resolve any indefinite boundaries on. If None,
+        an exception will be raised if there are any unresolved
+        boundaries in `index`
+
+    Returns
+    -------
+    tuple[int, ...]
+        Shape of the region defined by index, after applying the
+        index to an array of shape `shape`
+    """
+    if shape is not None:
+        index = index.expand(shape)
+
+    return tuple([len(dim) for dim in index.args])
+
+
+def partition(
+    obj: Union[np.ndarray, Tuple],
+    chunks: Union[int, tuple[int, ...], ChunkSize],
+) -> Iterator[Tuple]:
+    """Break an array or a Tuple of slices into chunks of the given chunk size.
+
+    Parameters
+    ----------
+    obj : Union[np.ndarray, Tuple]
+        Array or Tuple index to partition
+    chunks : Union[int, tuple[int, ...], ChunkSize]
+        If this is an int, this is the size of each partitioned chunk.
+        If it is a tuple of ints or a ChunkSize, consider the indices of the
+        object the shape of the chunks. Multidimensional chunks should supply
+        a tuple giving the chunk size in each dimension.
+
+    Returns
+    -------
+    Iterator[Tuple]
+        A list of slices of arr that make up the chunks
+    """
+    if isinstance(obj, np.ndarray):
+        index = Tuple(*[Slice(0, dim) for dim in obj.shape])
+        shape = obj.shape
+    else:
+        index = to_slice_tuple(obj)
+        shape = tuple(dim.stop for dim in index.args)
+
+    if isinstance(chunks, (int, np.integer)):
+        chunks = (chunks,)
+    elif isinstance(chunks, ChunkSize):
+        chunks = tuple(chunks)
+
+    yield from ChunkSize(chunks).as_subchunks(index, shape)

--- a/versioned_hdf5/tests/test_api.py
+++ b/versioned_hdf5/tests/test_api.py
@@ -2697,7 +2697,7 @@ def test_make_empty_dataset(tmp_path):
         assert_equal(cv["values"][:], np.array([]))
 
 
-@mark.append
+@pytest.mark.append()
 def test_append_small_dataset(tmp_path):
     """Test that a small dataset can be appended to an existing dataset.
 
@@ -2740,6 +2740,7 @@ def test_append_small_dataset(tmp_path):
         assert raw_data.attrs["last_element"] == 4
 
 
+@pytest.mark.append()
 def test_append_small_dataset_inmemorydataset(tmp_path):
     """Test that the InMemoryDataset created by an append has the right structure.
 
@@ -2777,7 +2778,7 @@ def test_append_small_dataset_inmemorydataset(tmp_path):
             )
 
 
-@mark.append
+@pytest.mark.append()
 def test_append_big_dataset(tmp_path):
     """Test that a big dataset can be appended to an existing dataset.
 

--- a/versioned_hdf5/utils.py
+++ b/versioned_hdf5/utils.py
@@ -1,0 +1,119 @@
+from typing import Dict
+
+import h5py
+import numpy as np
+from ndindex import Slice, Tuple
+
+from .hashtable import Hashtable
+from .slicetools import partition
+
+
+class Chunk:
+    pass
+
+
+class AppendChunk(Chunk):
+    def __init__(
+        self,
+        target_raw_index: Tuple,
+        target_raw_data: np.ndarray,
+        raw_last_chunk: Tuple,
+        raw_last_chunk_data: np.ndarray,
+    ):
+        """Instantiate an AppendChunk.
+
+        Parameters
+        ----------
+        target_raw_index : Tuple
+            Indices in rspace where target_raw_data is to be written
+        target_raw_data : np.ndarray
+            Raw data to write (this is only the part being appended)
+        raw_last_chunk : Tuple
+            Index of the last chunk of the raw_data post-append
+        raw_last_chunk_data : np.ndarray
+            Data of the last chunk of the raw_data post-append
+        """
+        # Check the hash of this before writing to the raw data
+        self.new_raw_last_chunk_data = raw_last_chunk_data
+        self.new_raw_last_chunk = raw_last_chunk
+
+        # Write this after checking the hash
+        self.target_raw_index = target_raw_index
+        self.target_raw_data = target_raw_data
+
+    def write_to_raw(self, hashtable: Hashtable, raw_data: h5py.Dataset) -> Tuple:
+        # If the hash of the data is already in the hash table,
+        # just reuse the hashed slice. Otherwise, update the
+        # hash table with the new data hash and write the data
+        # to the raw dataset.
+        data_hash = hashtable.hash(self.new_raw_last_chunk_data)
+        if data_hash in hashtable:
+            return hashtable[data_hash]
+
+        # Update the hashtable
+        hashtable[data_hash] = self.new_raw_last_chunk_data
+
+        # Write only the data to append
+        raw_data[self.target_raw_index.raw] = self.target_raw_data
+
+        # Keep track of the last index written to in the raw dataset;
+        # future appends are simplified by this
+        raw_data.attrs["last_element"] = self.rchunk.args[0].stop
+
+        # Return the last raw chunk
+        return self.new_raw_last_chunk_data
+
+
+class WriteChunk(Chunk):
+    def __init__(self, vchunk: Tuple, data: np.ndarray):
+        self.vchunk = vchunk
+        self.data = data
+
+    def write_to_raw(
+        self, hashtable: Hashtable, raw_data: h5py.Dataset
+    ) -> Dict[Tuple, Tuple]:
+        chunk_size = raw_data.chunks[0]
+
+        if isinstance(self.data, np.ndarray) and raw_data.dtype != self.data.dtype:
+            raise ValueError(
+                f"dtype of raw data ({raw_data.dtype}) does not match data to append "
+                f"({self.data.dtype})"
+            )
+
+        chunks: Dict[Tuple, Tuple] = {}
+        for data_slice, vchunk in zip(
+            partition(self.data, raw_data.chunks),
+            partition(self.vchunk, raw_data.chunks),
+        ):
+            arr = self.data[data_slice.raw]
+            data_hash = hashtable.hash(arr)
+
+            if data_hash in hashtable:
+                chunks[vchunk] = hashtable[data_hash]
+            else:
+                new_chunk_axis_size = raw_data.shape[0] + len(data_slice.args[0])
+
+                rchunk = Tuple(
+                    Slice(
+                        raw_data.shape[0],
+                        new_chunk_axis_size,
+                    ),
+                    *[Slice(None, None) for _ in raw_data.shape[1:]],
+                )
+
+                # Resize the dataset to include a new chunk
+                raw_data.resize(raw_data.shape[0] + chunk_size, axis=0)
+
+                # Map the virtual chunk to the raw data chunk
+                chunks[vchunk] = rchunk
+
+                # Map the data hash to the raw data chunk
+                hashtable[data_hash] = rchunk
+
+                # Set the value of the raw data chunk to the chunk of the new data being written
+                raw_data[rchunk.raw] = self.data[data_slice.raw]
+
+                # Update the last element attribute of the raw dataset
+                raw_data.attrs["last_element"] = rchunk.args[0].stop
+
+        return chunks

--- a/versioned_hdf5/utils.py
+++ b/versioned_hdf5/utils.py
@@ -47,9 +47,9 @@ class AppendChunk(Chunk):
         return "\n".join(
             [
                 f"Data to append: {self.target_raw_data}",
-                f"Index to append to: {self.target_raw_index}",
-                f"New last chunk: {self.new_raw_last_chunk_data}",
-                f"New last chunk index: {self.new_raw_last_chunk}",
+                f"Raw index to append to: {self.target_raw_index}",
+                f"New raw last chunk: {self.new_raw_last_chunk_data}",
+                f"New raw last chunk index: {self.new_raw_last_chunk}",
             ]
         )
 

--- a/versioned_hdf5/versions.py
+++ b/versioned_hdf5/versions.py
@@ -148,7 +148,6 @@ def commit_version(
                     data_copy.attrs[k] = v
                 continue
 
-            breakpoint()
             slices, shape = write_dataset_operations(f, version_name, name, data)
 
         elif isinstance(data, dict):

--- a/versioned_hdf5/versions.py
+++ b/versioned_hdf5/versions.py
@@ -148,6 +148,7 @@ def commit_version(
                     data_copy.attrs[k] = v
                 continue
 
+            breakpoint()
             slices, shape = write_dataset_operations(f, version_name, name, data)
 
         elif isinstance(data, dict):


### PR DESCRIPTION
This PR adds an `.append()` method to allow `InMemoryDataset` objects to append data to any unused space in the last chunk. If no free space exists, data is written as usual into a new chunk.

Closes #295.

## Changes

- Refactored the `data_dict` system that previously kept track of the slices in an `InMemoryDataset`. Previously the `data_dict` was a member which lived on the low level `InMemoryDatasetID` object, and contained mappings between slices in the virtual dataset and slices in the raw dataset. After careful consideration, it doesn't seem necessary to keep the data on this lower level object, we can just keep it on the InMemoryDataset, significantly reducing the conceptual complexity of the data model.

Previously, when the user called `InMemoryDataset.resize` or `InMemoryDataset.__setitem__`, the `data_dict` mapping would keep track of slices that changed as they changed; when exiting the `stage_version` context manager for a version, this `data_dict` was then used to both

1. Write new data to the underlying `raw_data` referenced by the virtual dataset
2. Provide the virtual slices that made up the new version of the dataset

This system has been replaced with a more explicit scheme with defers all computation until execution exits the `stage_version` context manager. With the new scheme, the user can manipulate data in three ways:

1. `InMemoryDataset.__setitem__`
2. `InMemoryDataset.resize`
3. `InMemoryDataset.append`

In all cases, when the user calls one of these methods the `InMemoryDataset` keeps track of the manipulation done by the user. When the `stage_version` context is exited, all computations are resolved then. Therefore we should expect to see some of the computation time that would otherwise be spent inside the context manager to be reduced, but with a corresponding increase when the context manager is exited.

- `InMemoryDataset` now keeps track of the last element written to its corresponding `raw_data`, which is needed for `append` operations
- `backend.create_virtual_dataset` can now accept either `Slice` objects or `Tuple` objects in the values of the `slices` parameter
- Added `SetOperation`, `ResizeOperation`, and `AppendOperation` helper classes which are used to keep track of the deferred operations on `InMemoryDataset` objects
- Added an `AppendChunk` class to help with deferring writes when the user calls `.append`. A similar scheme would simplify the code for `__setitem__` and `resize` calls, but I've left that refactor for another PR.
- Added a `partition` method which partitions a `ndindex.Tuple` or `np.ndarray` object into chunks of a requested size. I realize that there's already an `ndindex` function which does this, but the syntax is arcane. Parts of this PR took a long time to comprehend, so I'm trying to reduce the maintenance burden going forward.
- Added a few functions in `slicetools.py`:
  - `to_slice_tuple`: convert `Tuple` of arbitrary `ndindex` types to `Tuple` of `Slice` types, so that `obj.args[0].start` etc doesn't fail
  - `to_raw_index`: convert a relative (virtual) index to an index in a raw chunk
  - `get_vchunk_overlap`: helper to get the overlap of an arbitrary virtual chunk and an index into a virtual dataset
  - `get_shape`: helper which gets the size of an index along each dimension