### PR TITLE
Make create_virtual_dataset handle zero-length raw_data correctly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ ignore = [
 
 [tool.ruff.per-file-ignores]
 "__init__.py" = ["F401"]
+"test_*.py" = ["ANN001"]
 
 [project.optional-dependencies]
 dev = ["pre-commit>=3.6.0"]

--- a/versioned_hdf5/backend.py
+++ b/versioned_hdf5/backend.py
@@ -398,10 +398,7 @@ def create_virtual_dataset(
     slices = {c: s.reduce() for c, s in slices.items()}
 
     if len(raw_data) == 0:
-        shape = ()
-        layout = VirtualLayout((1,), dtype=raw_data.dtype)
-        vs = VirtualSource(".", name=raw_data.name, shape=(1,), dtype=raw_data.dtype)
-        layout[0] = vs[()]
+        layout = VirtualLayout(shape=(0,), dtype=raw_data.dtype)
     else:
         # Chunks in the raw dataset are expanded along the first dimension only.
         # Since the chunks are pointed to by virtual datasets, it doesn't make


### PR DESCRIPTION
## Summary

This PR makes `create_virtual_dataset` correctly handle the case where the raw data is empty, returning an empty virtual dataset.

Closes #314.

## Changes

- If the raw data for a dataset is empty, the virtual dataset is also empty instead of being shape `(1,)` (??)
- Added tests of both the backend (to see if zero-length raw datasets are correctly handled) and of the API (to cover the reproducer submitted with the original issue)
- Added ANN001 (missing type annotations) to the list of rules to ignore in for test functions. These are either parametrizations or pytest fixtures.

I'm still not entirely sure why it is necessary to close/open the file descriptor between each operation to reproduce this issue, but it must be something to do with flushing writes to the file. @ArvidJB any ideas?