### PR TITLE
Add tests to the meson.build file so that editable installs can test

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -6,6 +6,20 @@ project(
 py = import('python').find_installation()
 py.install_sources(
   [
+    'versioned_hdf5/tests/__init__.py',
+    'versioned_hdf5/tests/conftest.py',
+    'versioned_hdf5/tests/test_api.py',
+    'versioned_hdf5/tests/test_backend.py',
+    'versioned_hdf5/tests/test_hashtable.py',
+    'versioned_hdf5/tests/test_replay.py',
+    'versioned_hdf5/tests/test_slicetools.py',
+    'versioned_hdf5/tests/test_versions.py',
+    'versioned_hdf5/tests/test_wrappers.py',
+  ],
+  subdir: 'versioned_hdf5/tests',
+)
+py.install_sources(
+  [
     'versioned_hdf5/__init__.py',
     'versioned_hdf5/api.py',
     'versioned_hdf5/backend.py',


### PR DESCRIPTION
This PR adds tests to install as part of the `meson.build` file in order for it to be possible to install the package in editable mode and still be able to run tests.