### PR TITLE
Make InMemoryGroup provide more informative reprs

### DIFF
--- a/versioned_hdf5/tests/test_wrappers.py
+++ b/versioned_hdf5/tests/test_wrappers.py
@@ -7,6 +7,12 @@ from numpy.testing import assert_equal
 from ..wrappers import InMemoryArrayDataset, InMemoryGroup, InMemorySparseDataset
 
 
+@pytest.fixture()
+def premade_group(h5file):
+    group = h5file.create_group("group")
+    return InMemoryGroup(group.id)
+
+
 def test_InMemoryArrayDataset(h5file):
     group = h5file.create_group("group")
     parent = InMemoryGroup(group.id)
@@ -107,3 +113,24 @@ def test_InMemoryArrayDataset_resize_multidimension(oldshape, newshape, h5file):
     )
     h5file["data"].resize(newshape)
     assert_equal(dataset[()], h5file["data"][()], str(newshape))
+
+
+def test_group_repr(premade_group):
+    """Test that repr(InMemoryGroup) also shows reprs of child objects."""
+    foo = premade_group.create_dataset(
+        "foo",
+        data=np.array([1, 2, 3, 4, 5, np.nan]),
+    )
+    bar = premade_group.create_dataset(
+        "bar",
+        data=np.array([1, 2, 3, 4, 5, np.nan]),
+    )
+    baz = premade_group.create_dataset(
+        "baz",
+        data=np.array([1, 2, 3, 4, 5, np.nan]),
+    )
+
+    result = repr(premade_group)
+    assert repr(foo) in result
+    assert repr(bar) in result
+    assert repr(baz) in result

--- a/versioned_hdf5/wrappers.py
+++ b/versioned_hdf5/wrappers.py
@@ -6,6 +6,7 @@ h5py license.
 """
 
 import posixpath
+import textwrap
 import warnings
 from collections import defaultdict
 from weakref import WeakValueDictionary
@@ -66,15 +67,16 @@ class InMemoryGroup(Group):
 
     # Based on Group.__repr__
     def __repr__(self):
-        namestr = ('"%s"' % self.name) if self.name is not None else "(anonymous)"
+        namestr = f'"{self.name}"' if self.name is not None else "(anonymous)"
         if not self:
-            r = "<Closed InMemoryGroup>"
-        elif self._committed:
-            r = "<Committed InMemoryGroup %s>" % namestr
-        else:
-            r = "<InMemoryGroup %s (%d members)>" % (namestr, len(self))
+            return "<Closed InMemoryGroup>"
+        if self._committed:
+            return f"<Committed InMemoryGroup {namestr}>"
 
-        return r
+        text = [f"<InMemoryGroup {namestr} ({len(list(self))} members)>"]
+        for item in self.values():
+            text.append(textwrap.indent(repr(item), prefix="  "))
+        return "\n".join(text)
 
     def _check_committed(self):
         if self._committed:


### PR DESCRIPTION
This PR makes `InMemoryGroup` reprs more informative, closing #316.

`h5py.Group` reprs don't by default show anything about their data hierarchy. This change makes `InMemoryGroup` reprs show their child objects as part of their repr, making them substantially more useful. For example, in the test written below, `repr(premade_group)` returns:

```
<InMemoryGroup "/group" (3 members)>
  <InMemoryArrayDataset "foo": shape (6,), type "<f8">
  <InMemoryArrayDataset "bar": shape (6,), type "<f8">
  <InMemoryArrayDataset "baz": shape (6,), type "<f8">
```

Later on, we might consider replacing `InMemoryDataset.keys()` and `InMemoryDataset.values()`, and `InMemoryDataset.items()` to return more informative string representations as well.