### PR TITLE
Faster and correct chunk reuse logging

### DIFF
--- a/versioned_hdf5/api.py
+++ b/versioned_hdf5/api.py
@@ -7,7 +7,7 @@ change.
 import datetime
 import logging
 from contextlib import contextmanager
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Dict, List, Tuple
 
 import h5py
 import ndindex
@@ -313,9 +313,6 @@ class VersionedHDF5File:
                 compression_opts=group.compression_opts,
                 timestamp=timestamp,
             )
-
-            self._log_version_diff_stats(old_current, self.current_version)
-
         except:
             delete_version(self.f, version_name, old_current)
             raise
@@ -343,72 +340,6 @@ class VersionedHDF5File:
                 f'<VersionedHDF5File object "{self.f.filename}" (mode'
                 f" {self.f.mode})>"
             )
-
-    def _get_hashes(self, name: str) -> Set[bytes]:
-        """Get a set of hashes for the chunks in the dataset.
-
-        Parameters
-        ----------
-        name : str
-            Name of the dataset for which hashes are to be generated
-
-        Returns
-        -------
-        Set[bytes]
-            A set of hashes for the dataset
-        """
-        with Hashtable(self.f, name) as hashtable:
-            return set(hashtable.keys())
-
-    def _log_version_diff_stats(
-        self,
-        old_version: Optional[str] = None,
-        new_version: Optional[str] = None,
-    ):
-        """Log some stats about differences between two versions.
-
-        Parameters
-        ----------
-        old_version : Optional[str]
-            Old version of the data to compare
-        new_version : Optional[str]
-            New version of the data to compare
-        """
-        old_datasets, new_datasets = {}, {}
-        if old_version in self:
-            old_datasets = self[old_version].datasets()
-        if new_version in self:
-            new_datasets = self[new_version].datasets()
-
-        msg = [""]
-        for name in sorted(set(old_datasets.keys()) | set(new_datasets.keys())):
-            old_dataset = old_datasets.get(name, None)
-            new_dataset = new_datasets.get(name, None)
-
-            old_hashes, new_hashes = set(), set()
-            old_shape, new_shape = None, None
-            old_chunks, new_chunks = None, None
-
-            if old_dataset:
-                old_shape = old_dataset.shape
-                old_chunks = old_dataset.chunks
-                old_hashes = self._get_hashes(name)
-
-            if new_dataset:
-                new_shape = new_dataset.shape
-                new_chunks = new_dataset.chunks
-                new_hashes = self._get_hashes(name)
-
-            chunks_reused = len(old_hashes & new_hashes)
-            new_chunks_written = len(new_hashes - old_hashes)
-
-            msg.append(
-                f"  {name}: Shape: {old_shape} -> {new_shape}; "
-                f"Chunks: {old_chunks} -> {new_chunks}; "
-                f"New chunks written: {new_chunks_written}; "
-                f"Number of chunks reused: {chunks_reused}"
-            )
-        logger.debug("\n".join(msg))
 
     def rebuild_hashtables(self):
         """Delete and rebuild *all* existing hashtables for the raw datasets."""

--- a/versioned_hdf5/tests/test_api.py
+++ b/versioned_hdf5/tests/test_api.py
@@ -2023,14 +2023,12 @@ def test_stage_version_log_stats(tmp_path, caplog):
             )
 
         assert caplog.records
-        assert str(bar_shape_r0) in caplog.records[-1].getMessage()
-        assert str(bar_chunks_r0) in caplog.records[-1].getMessage()
-        assert str(baz_shape_r0) in caplog.records[-1].getMessage()
-        assert str(baz_chunks_r0) in caplog.records[-1].getMessage()
+        assert 'bar: New chunks written: 2; Number of chunks reused: 151' in caplog.records[-2].getMessage()
+        assert 'baz: New chunks written: 1; Number of chunks reused: 4' in caplog.records[-1].getMessage()
 
         with vf.stage_version("r1") as sv:
             bar_shape_r1 = (3, 15222, 2)
-            baz_shape_r1 = (1, (4) * 10, 2)
+            baz_shape_r1 = (1, 40, 2)
 
             bar = sv["bar"]
             bar.resize(bar_shape_r1)
@@ -2038,8 +2036,8 @@ def test_stage_version_log_stats(tmp_path, caplog):
             baz.resize(baz_shape_r1)
             baz[:, -10:, :] = np.full((1, 10, 2), 3)
 
-        assert str(bar_shape_r1) in caplog.records[-1].getMessage()
-        assert str(baz_shape_r1) in caplog.records[-1].getMessage()
+        assert 'bar: New chunks written: 2; Number of chunks reused: 151' in caplog.records[-2].getMessage()
+        assert 'baz: New chunks written: 1; Number of chunks reused: 4' in caplog.records[-1].getMessage()
 
 
 def test_data_version_identifier_valid(tmp_path, caplog):

--- a/versioned_hdf5/versions.py
+++ b/versioned_hdf5/versions.py
@@ -146,7 +146,7 @@ def commit_version(
         if isinstance(data, dict):
             if chunks[name] is not None:
                 raise NotImplementedError("Specifying chunk size with dict data")
-            slices = write_dataset_chunks(f, name, data, shape=shape)
+            slices = write_dataset_chunks(f, name, data)
         elif isinstance(data, InMemorySparseDataset):
             write_dataset(
                 f,
@@ -157,7 +157,7 @@ def commit_version(
                 compression_opts=compression_opts[name],
                 fillvalue=fillvalue,
             )
-            slices = write_dataset_chunks(f, name, data.data_dict, shape=data.shape)
+            slices = write_dataset_chunks(f, name, data.data_dict)
         else:
             slices = write_dataset(
                 f,


### PR DESCRIPTION
Closes #323.

The logic in `_log_version_diff_stats` is currently not correct since it just compares the new `hashtable` with itself. This ends up always logging that all chunks were reused, which is obviously not correct. Furthermore, the size of the hashtable also does not necessarily correlate with the number of chunks reused for a dataset version.

It is also fairly slow since loading the hashtable is expensive if it drops out of the lru_cache (and unnecessary anyway, as discussed above). The calculations also happen regardless of the logging level, which means that they are mostly wasted anyway.

This change simplifies the logging of version diff stats by doing it directly when the dataset is written and when we can observe the number of added reused/chunks.