### PR TITLE
Add append method for `InMemoryDataset`

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,4 @@ doctest_optionflags= NORMALIZE_WHITESPACE
 markers =
     setup_args : kwargs for setup fixture.
     slow: slow tests
+    append: tests targeting the append method

--- a/versioned_hdf5/api.py
+++ b/versioned_hdf5/api.py
@@ -13,9 +13,8 @@ import h5py
 import ndindex
 import numpy as np
 
-from .backend import CORRUPT_DATA_VERSIONS, DATA_VERSION, initialize
+from .backend import CORRUPT_DATA_VERSIONS, DATA_VERSION, get_data_map, initialize
 from .hashtable import Hashtable
-from .slicetools import spaceid_to_slice
 from .versions import (
     all_versions,
     commit_version,
@@ -474,13 +473,7 @@ class VersionedHDF5File:
             Mapping between the dataset's virtual slices and the slices of the
             underlying raw data
         """
-        slices = {}
-        for vs in self[version][name].virtual_sources():
-            src = spaceid_to_slice(vs.src_space)
-            vir = spaceid_to_slice(vs.vspace)
-            slices[vir] = src
-
-        return slices
+        return get_data_map(self.f, name, version)
 
     def _diff_data(
         self,

--- a/versioned_hdf5/backend.py
+++ b/versioned_hdf5/backend.py
@@ -374,6 +374,7 @@ def write_dataset_chunks(f, name, data_dict):
             if isinstance(data_s, (slice, tuple, Tuple, Slice)):
                 slices[chunk] = ndindex(data_s)
             elif isinstance(data_s, AppendData):
+                breakpoint()
                 # Write chunks to append to the raw data without writing a new chunk
                 if data_s.array.dtype != raw_data.dtype:
                     raise ValueError(
@@ -420,7 +421,7 @@ def write_dataset_chunks(f, name, data_dict):
                         chunk,
                         chunk_size,
                         data_to_write,
-                        validate_reused_chunks
+                        validate_reused_chunks,
                     )
                     continue
 
@@ -504,7 +505,7 @@ def update_hashtable(
     chunk: Tuple,
     chunk_size: int,
     data_to_write: Dict[Slice, np.ndarray],
-    validate_reused_chunks: bool
+    validate_reused_chunks: bool,
 ) -> int:
     """Update the hashtable with the new data hash, if necessary.
 

--- a/versioned_hdf5/backend.py
+++ b/versioned_hdf5/backend.py
@@ -532,15 +532,23 @@ def _is_occupied_space(
     """
     for version in f["_version_data/versions"]:
         # Ignore the root version or the current (uncommitted) version
-        if version == "__first_version__" or name not in f["_version_data/versions"]:
+        if (
+            version == "__first_version__"
+            or name not in f["_version_data/versions"][version]
+        ):
             continue
 
         for vindex, rindex in get_data_map(f, name, version).items():
-            assert len(vindex.args[0]) != len(rindex.args[0])
+            assert len(vindex.args[0]) == len(rindex.args[0])
 
             try:
-                index.as_subindex(rindex)
+                subindex = index.as_subindex(rindex)
             except ValueError:
+                continue
+
+            # index.as_subindex(rindex) can return 0-length subindices, but there's
+            # no overlap in that case
+            if len(subindex.args[0]) > 0:
                 return True
 
     return False

--- a/versioned_hdf5/backend.py
+++ b/versioned_hdf5/backend.py
@@ -375,7 +375,7 @@ def write_dataset_chunks(f, name, data_dict):
                 # Write chunks to append to the raw data without writing a new chunk
                 if data_s.array.dtype != raw_data.dtype:
                     raise ValueError(
-                        f"dtypes do not match ({data_s.dtype} != {raw_data.dtype})"
+                        f"dtypes do not match ({data_s.array.dtype} != {raw_data.dtype})"
                     )
 
                 # Calculate a new hash for this chunk using the extant data and the

--- a/versioned_hdf5/slicetools.py
+++ b/versioned_hdf5/slicetools.py
@@ -1,7 +1,5 @@
 from functools import lru_cache
-from typing import Dict
 
-import numpy as np
 from ndindex import Slice, Tuple
 
 
@@ -39,22 +37,3 @@ def hyperslab_to_slice(start, stride, count, block):
     end = start + (stride * (count - 1) + 1) * block
     stride = stride if block == 1 else 1
     return Slice(start, end, stride)
-
-
-class AppendChunk:
-    def __init__(
-        self,
-        target_vindex: Tuple,
-        target_rindex: Slice,
-        array: np.ndarray,
-        extant_vindex: Tuple,
-        extant_rindex: Slice,
-    ):
-        self.target_vindex = target_vindex
-        self.target_rindex = target_rindex
-        self.array = array
-        self.extant_vindex = extant_vindex
-        self.extant_rindex = extant_rindex
-
-    def get_concatenated_rindex(self) -> Slice:
-        return Slice(self.extant_rindex.start, self.target_rindex.stop)

--- a/versioned_hdf5/slicetools.py
+++ b/versioned_hdf5/slicetools.py
@@ -1,5 +1,7 @@
 from functools import lru_cache
+from typing import Dict
 
+import numpy as np
 from ndindex import Slice, Tuple
 
 
@@ -37,3 +39,22 @@ def hyperslab_to_slice(start, stride, count, block):
     end = start + (stride * (count - 1) + 1) * block
     stride = stride if block == 1 else 1
     return Slice(start, end, stride)
+
+
+class AppendChunk:
+    def __init__(
+        self,
+        target_vindex: Tuple,
+        target_rindex: Slice,
+        array: np.ndarray,
+        extant_vindex: Tuple,
+        extant_rindex: Slice,
+    ):
+        self.target_vindex = target_vindex
+        self.target_rindex = target_rindex
+        self.array = array
+        self.extant_vindex = extant_vindex
+        self.extant_rindex = extant_rindex
+
+    def get_concatenated_rindex(self) -> Slice:
+        return Slice(self.extant_rindex.start, self.target_rindex.stop)

--- a/versioned_hdf5/tests/test_api.py
+++ b/versioned_hdf5/tests/test_api.py
@@ -3343,52 +3343,7 @@ def test_append_multiple_vchunks_same_rchunk(tmp_path, chunk_size, nrows, ncols)
         assert_equal(cv["values"][:], np.concatenate((data, append)))
 
 
-def test_append_corrupted2(tmp_path):
-    path = tmp_path / "tmp.h5"
-
-    with h5py.File(path, "w") as f:
-        vf = VersionedHDF5File(f)
-        with vf.stage_version("r0") as sv:
-            sv.create_dataset(
-                "values",
-                data=np.arange(3),
-                chunks=(5,),
-                maxshape=(None,),
-            )
-
-    with h5py.File(path, "r+") as f:
-        vf = VersionedHDF5File(f)
-        with vf.stage_version("r1") as sv:
-            values = sv["values"]
-            values.append(np.array([1, 2]))
-
-    with h5py.File(path, "r") as f:
-        vf = VersionedHDF5File(f)
-        cv = vf[vf.current_version]
-        assert_equal(cv["values"][:], np.array([0, 1, 2, 1, 2]))
-
-    with h5py.File(path, "r+") as f:
-        vf = VersionedHDF5File(f)
-        with vf.stage_version("r2") as sv:
-            values = sv["values"]
-            values.resize((8,))
-            values[5:8] = np.arange(3)
-
-    with h5py.File(path, "r+") as f:
-        vf = VersionedHDF5File(f)
-        with vf.stage_version("r3") as sv:
-            values = sv["values"]
-            values.append(np.array([3, 4]))
-
-    with h5py.File(path, "r") as f:
-        vf = VersionedHDF5File(f)
-        cv = vf[vf.current_version]
-        assert_equal(
-            cv["values"][:],
-            np.array([0, 1, 2, 1, 2, 0, 1, 2, 3, 4]),
-        )
-
-
+@mark.append()
 def test_append_corrupted(tmp_path):
     path = tmp_path / "tmp.h5"
 
@@ -3412,6 +3367,7 @@ def test_append_corrupted(tmp_path):
         vf = VersionedHDF5File(f)
         cv = vf[vf.current_version]
         assert_equal(cv["values"][:], np.array([0, 1, 2, 1, 2]))
+        assert_equal(f["_version_data/values/raw_data"][:], np.array([0, 1, 2, 1, 2]))
 
     with h5py.File(path, "r+") as f:
         vf = VersionedHDF5File(f)
@@ -3424,6 +3380,7 @@ def test_append_corrupted(tmp_path):
             vf["r2"]["values"][:],
             np.array([0, 1, 2, 1, 2, 0, 1, 2]),
         )
+        assert_equal(f["_version_data/values/raw_data"][:], np.array([0, 1, 2, 1, 2]))
 
     with h5py.File(path, "r+") as f:
         vf = VersionedHDF5File(f)
@@ -3437,4 +3394,16 @@ def test_append_corrupted(tmp_path):
         assert_equal(
             cv["values"][:],
             np.array([0, 1, 2, 1, 2, 0, 1, 2, 3, 4]),
+        )
+        assert_equal(
+            f["_version_data/values/raw_data"][:],
+            np.array(
+                [
+                    0,
+                    1,
+                    2,
+                    1,
+                    2,
+                ]
+            ),
         )

--- a/versioned_hdf5/tests/test_api.py
+++ b/versioned_hdf5/tests/test_api.py
@@ -3159,3 +3159,85 @@ def test_append_two_chunk_append(tmp_path):
                 )
             ),
         )
+
+def test_append_multidim_random_axes(tmp_path):
+    """Test that appending random indices to a multidimensional dataset is successful."""
+    path = tmp_path / "tmp.h5"
+    rs = np.random.RandomState(0)
+
+    dims = 3
+    with h5py.File(path, "w") as f:
+        vf = VersionedHDF5File(f)
+        with vf.stage_version("v0") as sv:
+            for i in range(dims):
+                sv.create_dataset(
+                    f"axis{i}",
+                    dtype=np.dtype("int64"),
+                    shape=(0,),
+                    chunks=(10000,),
+                    maxshape=(None,),
+                )
+            sv.create_dataset(
+                "value",
+                dtype=np.dtype("int64"),
+                shape=tuple([0 for _ in range(dims)]),
+                chunks=tuple([20 for _ in range(dims)]),
+                maxshape=tuple([None for _ in range(dims)]),
+                fillvalue=0,
+            )
+            sv.create_dataset(
+                "mask",
+                dtype=np.dtype("int8"),
+                shape=tuple([0 for _ in range(dims)]),
+                chunks=tuple([20 for _ in range(dims)]),
+                maxshape=tuple([None for _ in range(dims)]),
+                fillvalue=2,
+            )
+
+    for i in range(1, 101):
+        with h5py.File(path, "r+") as f:
+            vf = VersionedHDF5File(f)
+            with vf.stage_version(f"v{i}") as sv:
+                new_axes = tuple(
+                    np.unique(rs.randint(30, size=5)) for _ in range(dims)
+                )
+                new_value = np.full(tuple(len(ax) for ax in new_axes), i)
+                new_mask = np.full(tuple(len(ax) for ax in new_axes), 0)
+
+                # figure out how existing axes map to new axes
+                new_indices = []
+                existing_indices = []
+                new_shape = []
+                for i in range(dims):
+                    axis_ds = sv[f"axis{i}"]
+                    all_axis, indices = np.unique(
+                        np.concatenate([axis_ds[:], new_axes[i]]),
+                        return_inverse=True,
+                    )
+                    existing_indices.append(tuple(indices[: len(axis_ds)]))
+                    new_indices.append(tuple(indices[len(axis_ds) :]))
+                    axis_ds.resize((len(all_axis),))
+                    axis_ds[:] = all_axis
+                    new_shape.append(len(all_axis))
+
+                new_indices = tuple(new_indices)
+                existing_indices = tuple(existing_indices)
+                new_shape = tuple(new_shape)
+
+                # merge value
+                value_ds = sv["value"]
+                all_data = np.full(new_shape, value_ds.fillvalue)
+                existing_data = value_ds[:]
+                all_data[np.ix_(*existing_indices)] = existing_data
+                all_data[np.ix_(*new_indices)] = new_value
+                value_ds.resize(new_shape)
+                value_ds[:] = all_data
+
+                # merge mask
+                mask_ds = sv["mask"]
+                all_mask = np.full(new_shape, mask_ds.fillvalue)
+                existing_mask = mask_ds[:]
+                all_mask[np.ix_(*existing_indices)] = existing_mask
+                all_mask[np.ix_(*new_indices)] = new_mask
+                mask_ds.resize(new_shape)
+                mask_ds[:] = all_mask

--- a/versioned_hdf5/tests/test_api.py
+++ b/versioned_hdf5/tests/test_api.py
@@ -3104,7 +3104,6 @@ def test_repeated_append(tmp_path):
             with vf.stage_version(f"r{i}") as sv:
                 sv["values"].append(np.arange(3))
 
-        breakpoint()
         assert_equal(
             vf["r0"]["values"][:],
             np.arange(5),
@@ -3126,8 +3125,8 @@ def test_repeated_append(tmp_path):
 
 
 @mark.append()
-def test_append_foo(tmp_path):
-    """Test that repeated appends in different versions correctly fill raw chunks."""
+def test_append_two_chunk_append(tmp_path):
+    """Test that appending to a two-chunk dataset executes correctly."""
     filename = tmp_path / "data.h5"
     chunk_size = 10
     chunks = (chunk_size,)
@@ -3144,7 +3143,6 @@ def test_append_foo(tmp_path):
         with vf.stage_version("r1") as sv:
             sv["values"].append(np.arange(3))
 
-        breakpoint()
         assert_equal(
             vf["r0"]["values"][:],
             np.array([0, 1, 2, 3, 4, 0, 1, 2, 0, 1, 2]),

--- a/versioned_hdf5/tests/test_api.py
+++ b/versioned_hdf5/tests/test_api.py
@@ -3345,6 +3345,7 @@ def test_append_multiple_vchunks_same_rchunk(tmp_path, chunk_size, nrows, ncols)
 
 @mark.append()
 def test_append_corrupted(tmp_path):
+    """Test a 1D append does not overwrite previous chunks of the raw dataset."""
     path = tmp_path / "tmp.h5"
 
     with h5py.File(path, "w") as f:
@@ -3397,13 +3398,67 @@ def test_append_corrupted(tmp_path):
         )
         assert_equal(
             f["_version_data/values/raw_data"][:],
-            np.array(
-                [
-                    0,
-                    1,
-                    2,
-                    1,
-                    2,
-                ]
-            ),
+            np.array([0, 1, 2, 1, 2, 0, 1, 2, 3, 4]),
+        )
+
+
+@mark.append()
+def test_append_corrupted_previous_chunks(tmp_path):
+    """Another test that appends do not corrupt previous chunks."""
+    path = tmp_path / "tmp.h5"
+
+    with h5py.File(path, "w") as f:
+        vf = VersionedHDF5File(f)
+        with vf.stage_version("r0") as sv:
+            sv.create_dataset(
+                "values",
+                data=np.arange(3),
+                chunks=(5,),
+                maxshape=(None,),
+            )
+
+    with h5py.File(path, "r+") as f:
+        vf = VersionedHDF5File(f)
+        with vf.stage_version("r1") as sv:
+            values = sv["values"]
+            values.append(np.array([1, 2]))
+
+    with h5py.File(path, "r") as f:
+        vf = VersionedHDF5File(f)
+        cv = vf[vf.current_version]
+        assert_equal(
+            cv["values"][:],
+            np.array([0, 1, 2, 1, 2]),
+        )
+        assert_equal(
+            f["_version_data/values/raw_data"][:],
+            np.array([0, 1, 2, 1, 2]),
+        )
+
+    with h5py.File(path, "r+") as f:
+        vf = VersionedHDF5File(f)
+        with vf.stage_version("r2") as sv:
+            values = sv["values"]
+            values.resize((3,))
+
+        assert_equal(
+            vf["r2"]["values"][:],
+            np.array([0, 1, 2]),
+        )
+        assert_equal(f["_version_data/values/raw_data"][:], np.array([0, 1, 2, 1, 2]))
+
+    with h5py.File(path, "r+") as f:
+        vf = VersionedHDF5File(f)
+        with vf.stage_version("r3") as sv:
+            values = sv["values"]
+            values.append(np.array([3, 4]))
+
+    with h5py.File(path, "r") as f:
+        vf = VersionedHDF5File(f)
+        # get older version, should not have changes
+        v1 = vf["r1"]
+        assert_equal(v1["values"][:], np.array([0, 1, 2, 1, 2]))
+        assert_equal(
+            f["_version_data/values/raw_data"][:],
+            np.array([0, 1, 2, 1, 2, 0, 1, 2, 3, 4]),
         )

--- a/versioned_hdf5/wrappers.py
+++ b/versioned_hdf5/wrappers.py
@@ -1025,26 +1025,13 @@ class InMemoryDataset(Dataset):
                     )
 
                 else:
-                    chunk_extant_rindex = old_data_dict[chunk_extant_vindex]
-
-                    # The data to be appended inside this chunk
-                    chunk_target_vindex = Tuple(
-                        Slice(old_shape[0], chunk.args[0].stop), *other_chunk_dims
-                    ).expand(self.shape)
-
-                    # Compute the raw indices to write
-                    n_dim0_elements = len(chunk_target_vindex.args[0])
-                    chunk_target_rindex = Slice(
-                        chunk_extant_rindex.stop,
-                        chunk_extant_rindex.stop + n_dim0_elements,
-                    )
-
                     new_data_dict[chunk] = AppendData(
-                        target_vindex=chunk_target_vindex,
-                        target_rindex=chunk_target_rindex,
+                        target_vindex=Tuple(
+                            Slice(old_shape[0], chunk.args[0].stop), *other_chunk_dims
+                        ).expand(self.shape),
                         array=arr[arr_index.raw],
                         extant_vindex=chunk_extant_vindex,
-                        extant_rindex=chunk_extant_rindex,
+                        extant_rindex=old_data_dict[chunk_extant_vindex],
                     )
 
         self.id.data_dict = new_data_dict

--- a/versioned_hdf5/wrappers.py
+++ b/versioned_hdf5/wrappers.py
@@ -1023,7 +1023,6 @@ class InMemoryDataset(Dataset):
                     new_data_dict[chunk] = np.concatenate(
                         (old_data_dict[chunk_extant_vindex], arr[arr_index.raw])
                     )
-
                 else:
                     new_data_dict[chunk] = AppendData(
                         target_vindex=Tuple(

--- a/versioned_hdf5/wrappers.py
+++ b/versioned_hdf5/wrappers.py
@@ -755,11 +755,13 @@ class InMemoryDataset(Dataset):
                     data.extant_rindex,
                     *[slice(0, len(i)) for i in chunk.args[1:]],
                 ).raw
-                arr_extant_index = data.extant_vindex.as_subindex(chunk)
+
+                # Get the part of idx covered by the extant data
+                arr_extant_index = data.extant_vindex.as_subindex(idx)
                 arr[arr_extant_index.raw] = self.id._read_chunk(raw_idx)
 
-                # Read the array which has yet to be appended
-                arr_append_index = data.target_vindex.as_subindex(chunk)
+                # Get the part of idx covered by the appended data
+                arr_append_index = data.target_vindex.as_subindex(idx)
                 arr[arr_append_index.raw] = data.array
                 continue
 


### PR DESCRIPTION
Following up from #313, this PR takes a different approach to implementing an `append` method:

- Calls to `append` are executed right away, rather than following a lazy execution approach as what was proposed in #313. This is the same scheme that the rest of the code base currently uses.
- Implementation is considerably more compact, touching much less code.

I still needed to add an `AppendData` object because `write_dataset_chunks` currently _only_ writes data into new chunks at commit time. `AppendData` instead stores the data to append, the raw indices where the data should be written to, and the corresponding virtual slice that it's a part of.