### PR TITLE
Improve speed of reused chunk verification

### DIFF
--- a/versioned_hdf5/backend.py
+++ b/versioned_hdf5/backend.py
@@ -5,7 +5,7 @@ import numpy as np
 from h5py import VirtualLayout, VirtualSource, h5s
 from h5py._hl.filters import guess_chunk
 from ndindex import ChunkSize, Slice, Tuple, ndindex
-from numpy.testing import assert_array_equal
+
 
 from .hashtable import Hashtable
 
@@ -292,22 +292,19 @@ def _verify_new_chunk_reuse(
     # utf-8 strings. For this case, when the raw_data is changed, e.g.
     #      raw_data[some_slice] = chunk_being_written[another_slice]
     # the data that gets written is bytes. So in certain cases, just calling
-    # assert_array_equal doesn't work. Instead, we convert each element to a bytestring
+    # array_equal doesn't work. Instead, we convert each element to a bytestring
     # first.
     if reused_chunk.dtype == "O" and chunk_being_written.dtype == "O":
         to_be_written = _convert_to_bytes(chunk_being_written)
     else:
         to_be_written = chunk_being_written
 
-    assert_array_equal(
-        reused_chunk,
-        to_be_written,
-        err_msg=(
+    if not np.array_equal(reused_chunk, to_be_written):
+        raise ValueError(
             f"Hash {data_hash} of existing data chunk {reused_chunk} "
             f"matches the hash of new data chunk {chunk_being_written}, "
             "but data does not."
-        ),
-    )
+        )
 
 
 def _convert_to_bytes(arr: np.ndarray) -> np.ndarray:

--- a/versioned_hdf5/tests/test_api.py
+++ b/versioned_hdf5/tests/test_api.py
@@ -13,7 +13,7 @@ from numpy.testing import assert_equal
 from pytest import mark, raises
 
 from ..api import VersionedHDF5File
-from ..backend import DATA_VERSION, DEFAULT_CHUNK_SIZE
+from ..backend import DATA_VERSION, DEFAULT_CHUNK_SIZE, _verify_new_chunk_reuse
 from ..replay import delete_versions
 from ..versions import TIMESTAMP_FMT, all_versions
 from ..wrappers import (

--- a/versioned_hdf5/tests/test_hashtable.py
+++ b/versioned_hdf5/tests/test_hashtable.py
@@ -181,7 +181,7 @@ def test_verify_chunk_reuse_data_version_2(tmp_path):
                     chunks=(2,),
                 )
 
-            with raises(AssertionError):
+            with raises(ValueError):
                 with vf.stage_version("r1") as group:
                     group["values"] = np.concatenate((data2, data2))
 
@@ -232,7 +232,7 @@ def test_verify_chunk_reuse_data_version_3(tmp_path):
                     chunks=(100,),
                 )
 
-            with raises(AssertionError):
+            with raises(ValueError):
                 with vf.stage_version("r1") as group:
                     group["values"] = np.array([b"ab", b"", b"cd"], dtype=object)
                 with vf.stage_version("r2") as group:


### PR DESCRIPTION
This PR speeds up reused chunk verification by only constructing an error message if the chunk fails to verify. Here's the benchmark from #322 run on my local machine before the change:

```
  _     ._   __/__   _ _  _  _ _/_   Recorded: 16:22:16  Samples:  20605
 /_//_/// /_\ / //_// / //_'/ //     Duration: 20.741    CPU time: 22.223
/   _/                      v4.6.2

Program: /home/pdmurray/.pyenv/versions/vhdf/bin/pyinstrument verify_speed.py

20.739 <module>  verify_speed.py:1
├─ 19.710 _GeneratorContextManager.__exit__  contextlib.py:141
│  └─ 19.709 VersionedHDF5File.stage_version  ../../versioned-hdf5/versioned_hdf5/api.py:267
│     └─ 19.699 commit_version  ../../versioned-hdf5/versioned_hdf5/versions.py:71
│        ├─ 19.263 write_dataset  ../../versioned-hdf5/versioned_hdf5/backend.py:114
│        │  └─ 18.840 _verify_new_chunk_reuse  ../../versioned-hdf5/versioned_hdf5/backend.py:229
│        │     ├─ 18.278 _array_str_implementation  numpy/core/arrayprint.py:1595
│        │     │     [19 frames hidden]  numpy, <built-in>
│        │     └─ 0.270 inner  contextlib.py:78
│        └─ 0.382 create_virtual_dataset  ../../versioned-hdf5/versioned_hdf5/backend.py:413
└─ 0.405 InMemoryDataset.resize  ../../versioned-hdf5/versioned_hdf5/wrappers.py:609
```

And after:

```
  _     ._   __/__   _ _  _  _ _/_   Recorded: 16:21:46  Samples:  1950
 /_//_/// /_\ / //_// / //_'/ //     Duration: 2.034     CPU time: 3.639
/   _/                      v4.6.2

Program: /home/pdmurray/.pyenv/versions/vhdf/bin/pyinstrument verify_speed.py

2.032 <module>  verify_speed.py:1
├─ 1.105 _GeneratorContextManager.__exit__  contextlib.py:141
│  └─ 1.105 VersionedHDF5File.stage_version  ../../versioned-hdf5/versioned_hdf5/api.py:267
│     ├─ 1.080 commit_version  ../../versioned-hdf5/versioned_hdf5/versions.py:71
│     │  ├─ 0.614 write_dataset  ../../versioned-hdf5/versioned_hdf5/backend.py:114
│     │  │  ├─ 0.267 _verify_new_chunk_reuse  ../../versioned-hdf5/versioned_hdf5/backend.py:229
│     │  │  │  ├─ 0.119 Dataset.__getitem__  h5py/_hl/dataset.py:742
│     │  │  │  │     [4 frames hidden]  h5py
│     │  │  │  ├─ 0.074 Tuple.__init__  ndindex/ndindex.py:159
│     │  │  │  │     [4 frames hidden]  ndindex
│     │  │  │  ├─ 0.043 array_equal  numpy/core/numeric.py:2378
│     │  │  │  │     [2 frames hidden]  numpy
│     │  │  │  └─ 0.024 [self]  ../../versioned-hdf5/versioned_hdf5/backend.py
│     │  │  ├─ 0.101 Hashtable.__init__  ../../versioned-hdf5/versioned_hdf5/hashtable.py:51
│     │  │  │  └─ 0.093 Hashtable._load_hashtable  ../../versioned-hdf5/versioned_hdf5/hashtable.py:194
│     │  │  │     ├─ 0.053 Dataset.__getitem__  h5py/_hl/dataset.py:742
│     │  │  │     └─ 0.037 [self]  ../../versioned-hdf5/versioned_hdf5/hashtable.py
│     │  │  ├─ 0.081 ChunkSize.indices  ndindex/chunking.py:100
│     │  │  │     [4 frames hidden]  ndindex
│     │  │  ├─ 0.045 Hashtable.hash  ../../versioned-hdf5/versioned_hdf5/hashtable.py:116
│     │  │  │  └─ 0.021 openssl_sha256  <built-in>
│     │  │  ├─ 0.028 Hashtable.__contains__  <frozen _collections_abc>:811
│     │  │  │  └─ 0.027 Hashtable.__getitem__  ../../versioned-hdf5/versioned_hdf5/hashtable.py:205
│     │  │  └─ 0.027 Hashtable.__getitem__  ../../versioned-hdf5/versioned_hdf5/hashtable.py:205
│     │  ├─ 0.401 create_virtual_dataset  ../../versioned-hdf5/versioned_hdf5/backend.py:410
│     │  │  ├─ 0.076 Group.create_virtual_dataset  h5py/_hl/group.py:188
│     │  │  │     [3 frames hidden]  h5py
│     │  │  ├─ 0.065 [self]  ../../versioned-hdf5/versioned_hdf5/backend.py
│     │  │  ├─ 0.059 Slice.reduce  ndindex/slice.py:212
│     │  │  │     [4 frames hidden]  ndindex
│     │  │  ├─ 0.052 Tuple.__init__  ndindex/ndindex.py:159
│     │  │  │     [2 frames hidden]  ndindex
│     │  │  ├─ 0.043 select  h5py/_hl/selections.py:19
│     │  │  │     [2 frames hidden]  h5py
│     │  │  └─ 0.021 Dataset.shape  h5py/_hl/dataset.py:462
│     │  └─ 0.043 AttributeManager.__getitem__  h5py/_hl/attrs.py:52
│     │        [2 frames hidden]  h5py
│     └─ 0.021 InMemoryGroup.datasets  ../../versioned-hdf5/versioned_hdf5/wrappers.py:266
├─ 0.398 InMemoryDataset.resize  ../../versioned-hdf5/versioned_hdf5/wrappers.py:609
│  ├─ 0.199 InMemoryDatasetID.data_dict  ../../versioned-hdf5/versioned_hdf5/wrappers.py:1299
│  │  └─ 0.182 spaceid_to_slice  ../../versioned-hdf5/versioned_hdf5/slicetools.py:6
│  │     ├─ 0.123 Tuple.__init__  ndindex/ndindex.py:159
│  │     │     [3 frames hidden]  ndindex
│  │     └─ 0.055 [self]  ../../versioned-hdf5/versioned_hdf5/slicetools.py
│  └─ 0.180 ChunkSize.as_subchunks  ndindex/chunking.py:143
│        [10 frames hidden]  ndindex
├─ 0.149 _GeneratorContextManager.__enter__  contextlib.py:132
│  └─ 0.149 VersionedHDF5File.stage_version  ../../versioned-hdf5/versioned_hdf5/api.py:267
│     └─ 0.141 create_version_group  ../../versioned-hdf5/versioned_hdf5/versions.py:22
│        ├─ 0.069 Group.visititems  h5py/_hl/group.py:642
│        │     [3 frames hidden]  h5py
│        │        0.046 proxy  h5py/_hl/group.py:670
│        │        └─ 0.032 _get  ../../versioned-hdf5/versioned_hdf5/versions.py:57
│        └─ 0.054 AttributeManager.__setitem__  h5py/_hl/attrs.py:96
│              [3 frames hidden]  h5py
├─ 0.140 [self]  verify_speed.py
├─ 0.131 <module>  h5py/__init__.py:1
│     [11 frames hidden]  h5py, numpy
├─ 0.050 DatasetWrapper.__getitem__  ../../versioned-hdf5/versioned_hdf5/wrappers.py:1268
│  └─ 0.050 InMemoryDataset.__getitem__  ../../versioned-hdf5/versioned_hdf5/wrappers.py:758
│     └─ 0.050 InMemoryDataset.get_index  ../../versioned-hdf5/versioned_hdf5/wrappers.py:656
│        └─ 0.032 Tuple.expand  ndindex/tuple.py:453
└─ 0.029 <module>  ../../versioned-hdf5/versioned_hdf5/__init__.py:1
   └─ 0.021 <module>  ../../versioned-hdf5/versioned_hdf5/api.py:1
```

No additional tests were added here because verification raises a `ValueError` if it fails, so we can be sure that the string will not be constructed unless that error is raised. We already have a few tests that check that a `ValueError` gets raised if appropriate.

Closes https://github.com/deshaw/versioned-hdf5/issues/322.