### PR TITLE
resize: read the entire Dataset

### DIFF
--- a/versioned_hdf5/wrappers.py
+++ b/versioned_hdf5/wrappers.py
@@ -638,6 +638,7 @@ class InMemoryDataset(Dataset):
         can_read_direct = self.id.can_read_direct
 
         old_shape_idx = Tuple(*[Slice(0, i) for i in old_shape])
+        old_data = self.get_index(old_shape_idx.raw, can_read_direct=can_read_direct)
         new_data_dict = {}
         for chunk in self.chunks.as_subchunks(old_shape_idx, size):
             if chunk in data_dict:
@@ -645,9 +646,7 @@ class InMemoryDataset(Dataset):
             else:
                 data = np.full(chunk.newshape(size), self.fillvalue, dtype=self.dtype)
                 index = old_shape_idx.as_subindex(chunk)
-                data[index.raw] = self.get_index(
-                    chunk.raw, can_read_direct=can_read_direct
-                )
+                data[index.raw] = old_data[chunk.raw]
                 new_data_dict[chunk] = data
 
         self.id.data_dict = new_data_dict


### PR DESCRIPTION
By reading the entire current Dataset into a numpy array we can improve the `resize` performance even further. Consider the example from #325:
```
import shutil

import tempfile

import h5py
import numpy as np
from deshaw.constants.dirs import DIR_cluster_tmp

from versioned_hdf5 import VersionedHDF5File

if __name__ == '__main__':
    # create temp dir path to be cleaned up on exit
    dir = tempfile.mkdtemp(dir=DIR_cluster_tmp())
    path = f'{dir}/data.h5'
    try:
        i = 200
        j = 50_000

        with h5py.File(path, 'w') as f:
            vf = VersionedHDF5File(f)
            with vf.stage_version('r0') as sv:
                sv.create_dataset('values', data=np.zeros((i, j)), chunks=(10, 100))

            for v in range(1, 101):
                with vf.stage_version(f'r{v}') as sv:
                    # every version we grow in both i and j direction
                    new_i = i + 1
                    new_j = j + 500

                    # grow dataset and fill new entries with zeros
                    dataset = sv['values']
                    dataset.resize((new_i, new_j))
                    dataset[i:new_i, :j] = 0
                    dataset[:i, j:new_j] = 0
                    dataset[i:new_i, j:new_j] = 0

                i, j = new_i, new_j
    finally:
        shutil.rmtree(dir)
```

Prior to #326 it took 1709s. With the optimizations in #326 it takes 978s. With the changes in this commit it now takes only 629s.

Closes #329.