### PR TITLE
Add support for docs version switcher

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,13 +1,14 @@
 name: Build docs
 on:
   pull_request:
-  workflow_call:
+  workflow_dispatch:
 
 jobs:
   build-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+
       - uses: actions/setup-python@v4
         with:
           python-version: 3.11
@@ -27,9 +28,3 @@ jobs:
           # when using act to run locally:
           # https://github.com/nektos/act/issues/1853
           TZ=UTC make html
-
-      - name: Upload docs
-        uses: actions/upload-artifact@v3
-        with:
-          name: docs
-          path: docs/_build/html/*

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -1,8 +1,10 @@
-name: Deploy static content to Pages
+name: Build and deploy docs to github pages
 
 on:
   push:
     branches: ["master"]
+  release:
+    types: [published]
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
@@ -18,21 +20,53 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build:
-    uses: deshaw/versioned-hdf5/.github/workflows/docs.yml@master
-
-  deploy:
+  build-and-deploy:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    needs: build
     steps:
-      - name: Download docs
-        uses: actions/download-artifact@v3
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v4
         with:
-          name: docs
-          path: docs
+          python-version: 3.11
+
+      - name: Setup Graphviz
+        run: |
+          sudo apt install graphviz -y
+
+      - name: Install versioned-hdf5
+        run: |
+          pip install .[doc]
+
+      - name: Update git tags for sphinx-multiversion
+        run: |
+          git fetch --tags
+
+      - name: Build docs
+        working-directory: docs
+        run: |
+          # Need to set timezone to avoid a sphinx/babel issue
+          # when using act to run locally:
+          # https://github.com/nektos/act/issues/1853
+          TZ=UTC sphinx-multiversion . _build/html
+
+      # sphinx-multiversion only builds docs for every tag;
+      # this redirects users who visit ./index.html ->
+      # ./master/index.html, which is the development branch docs.
+      - name: Write redirect to development branch
+        if: (github.event_name != 'pull_request')
+        run: |
+          echo "<!DOCTYPE html>
+                  <html>
+                    <head>
+                      <title>Redirecting to master branch</title>
+                      <meta charset='utf-8'>
+                      <meta http-equiv='refresh' content='0; url=./master/index.html'>
+                      <link rel='canonical' href='./master/index.html'>
+                    </head>
+                  </html>" >> docs/_build/html/index.html
 
       - name: Setup Pages
         uses: actions/configure-pages@v3
@@ -40,7 +74,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:
-          path: 'docs/'
+          path: 'docs/_build/html'
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/docs/_templates/versioning.html
+++ b/docs/_templates/versioning.html
@@ -1,0 +1,8 @@
+{% if versions %}
+<h3>{{ _('Versions') }}</h3>
+<ul>
+  {%- for item in versions %}
+  <li><a href="{{ item.url }}">{{ item.name }}</a></li>
+  {%- endfor %}
+</ul>
+{% endif %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,7 +36,16 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.graphviz",
     "sphinx.ext.intersphinx",
+    "sphinx_multiversion",
 ]
+
+# sphinx-multiversion configuration
+smv_tag_whitelist = r"^[0-9].[0-9].*$"
+smv_branch_whitelist = "master"
+smv_remote_whitelist = None
+smv_released_pattern = r"^tags/.*$"
+smv_outputdir_format = "{ref.name}"
+smv_prefer_remote_refs = False
 
 graphviz_output_format = "svg"
 
@@ -80,6 +89,16 @@ html_theme_options = {
     "font_size": "18px",
     "code_font_family": "'Menlo', 'DejaVu Sans Mono', 'Consolas', 'Bitstream Vera Sans Mono', monospace",
     "code_font_size": "0.85em",
+}
+
+html_sidebars = {
+    "**": [
+        "about.html",
+        "navigation.html",
+        "relations.html",
+        "searchbox.html",
+        "versioning.html",
+    ]
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ ignore = [
 [project.optional-dependencies]
 dev = ["pre-commit>=3.6.0"]
 test = ["pytest"]
-doc = ["sphinx", "myst-parser"]
+doc = ["sphinx", "sphinx-multiversion", "myst-parser"]
 
 [tool.setuptools_scm]
 


### PR DESCRIPTION
This PR builds and publishes docs for every published tag as well as the `master` branch. Closes #328.

Multiversion docs successfully deployed in my fork: https://github.com/peytondmurray/versioned-hdf5/actions/runs/9422101862/job/25957623096. See https://peytondmurray.github.io/versioned-hdf5 for the actual deployed documentation.