### PR TITLE
Add option to disable verify_chunk_reuse

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -175,6 +175,12 @@ version groups. The relevant modules are `versioned_hdf5.backend` and
 it to the raw data for the given dataset. The data in each chunk of the
 dataset is SHA256 hashed, and the hash is looked up in the hashtable dataset.
 If it already exists in the raw data, that chunk in the raw data is reused.
+
+To enable a check that the reused chunk matches the data that the user is
+intending to write, set the following environment variable:
+`ENABLE_CHUNK_REUSE_VALIDATION = 1`. This option is enabled during tests, but
+is disabled by default for better performance.
+
 The hashtable maps `SHA256 hash -> (start, stop)` where `(start, stop)` gives
 a slice range for the chunk in the raw dataset (chunks in the `raw_data`
 dataset are concatenated along the first axis only). All chunks that do not

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,10 +95,13 @@ ignore = [
 
 [project.optional-dependencies]
 dev = ["pre-commit>=3.6.0"]
-test = ["pytest"]
+test = ["pytest", "pytest-env"]
 doc = ["sphinx", "sphinx-multiversion", "myst-parser"]
 
 [tool.setuptools_scm]
 
 [tool.isort]
 profile = "black"
+
+[tool.pytest_env]
+ENABLE_CHUNK_REUSE_VALIDATION = 1

--- a/versioned_hdf5/api.py
+++ b/versioned_hdf5/api.py
@@ -266,7 +266,7 @@ class VersionedHDF5File:
 
     @contextmanager
     def stage_version(
-        self, version_name: str, prev_version=None, make_current=True, timestamp=None
+        self, version_name: str, prev_version=None, make_current=True, timestamp=None, verify_chunk_reuse=True,
     ):
         """
         Return a context manager to stage a new version
@@ -312,6 +312,7 @@ class VersionedHDF5File:
                 compression=group.compression,
                 compression_opts=group.compression_opts,
                 timestamp=timestamp,
+                verify_chunk_reuse=verify_chunk_reuse,
             )
         except:
             delete_version(self.f, version_name, old_current)

--- a/versioned_hdf5/api.py
+++ b/versioned_hdf5/api.py
@@ -266,7 +266,11 @@ class VersionedHDF5File:
 
     @contextmanager
     def stage_version(
-        self, version_name: str, prev_version=None, make_current=True, timestamp=None, verify_chunk_reuse=True,
+        self,
+        version_name: str,
+        prev_version=None,
+        make_current=True,
+        timestamp=None,
     ):
         """
         Return a context manager to stage a new version
@@ -312,7 +316,6 @@ class VersionedHDF5File:
                 compression=group.compression,
                 compression_opts=group.compression_opts,
                 timestamp=timestamp,
-                verify_chunk_reuse=verify_chunk_reuse,
             )
         except:
             delete_version(self.f, version_name, old_current)

--- a/versioned_hdf5/backend.py
+++ b/versioned_hdf5/backend.py
@@ -179,6 +179,10 @@ def write_dataset(
     slices_to_write = {}
     chunk_size = chunks[0]
 
+    validate_reused_chunks = os.environ.get(
+        "ENABLE_CHUNK_REUSE_VALIDATION", "false"
+    ).lower() in ("1", "true")
+
     with Hashtable(f, name) as hashtable:
         old_chunks = hashtable.largest_index
         chunks_reused = 0
@@ -192,9 +196,7 @@ def write_dataset(
                     hashed_slice = hashtable[data_hash]
                     slices[data_slice] = hashed_slice
 
-                    if os.environ.get(
-                        "ENABLE_CHUNK_REUSE_VALIDATION", "false"
-                    ).lower() in ("1", "true"):
+                    if validate_reused_chunks:
                         _verify_new_chunk_reuse(
                             raw_dataset=ds,
                             new_data=data,
@@ -353,6 +355,10 @@ def write_dataset_chunks(f, name, data_dict):
     chunks = tuple(raw_data.attrs["chunks"])
     chunk_size = chunks[0]
 
+    validate_reused_chunks = os.environ.get(
+        "ENABLE_CHUNK_REUSE_VALIDATION", "false"
+    ).lower() in ("1", "true")
+
     with Hashtable(f, name) as hashtable:
         old_chunks = hashtable.largest_index
         chunks_reused = 0
@@ -377,9 +383,7 @@ def write_dataset_chunks(f, name, data_dict):
                     hashed_slice = hashtable[data_hash]
                     slices[chunk] = hashed_slice
 
-                    if os.environ.get(
-                        "ENABLE_CHUNK_REUSE_VALIDATION", "false"
-                    ).lower() in ("1", "true"):
+                    if validate_reused_chunks:
                         _verify_new_chunk_reuse(
                             raw_dataset=raw_data,
                             new_data=data_s,

--- a/versioned_hdf5/backend.py
+++ b/versioned_hdf5/backend.py
@@ -120,6 +120,7 @@ def write_dataset(
     compression=None,
     compression_opts=None,
     fillvalue=None,
+    verify_chunk_reuse=True,
 ):
     if name not in f["_version_data"]:
         return create_base_dataset(
@@ -188,14 +189,15 @@ def write_dataset(
                     hashed_slice = hashtable[data_hash]
                     slices[data_slice] = hashed_slice
 
-                    _verify_new_chunk_reuse(
-                        raw_dataset=ds,
-                        new_data=data,
-                        data_hash=data_hash,
-                        hashed_slice=hashed_slice,
-                        chunk_being_written=data_s,
-                        slices_to_write=slices_to_write,
-                    )
+                    if verify_chunk_reuse:
+                        _verify_new_chunk_reuse(
+                            raw_dataset=ds,
+                            new_data=data,
+                            data_hash=data_hash,
+                            hashed_slice=hashed_slice,
+                            chunk_being_written=data_s,
+                            slices_to_write=slices_to_write,
+                        )
 
                     chunks_reused += 1
 
@@ -331,7 +333,7 @@ def _convert_to_bytes(arr: np.ndarray) -> np.ndarray:
         return np.vectorize(lambda i: bytes(i, encoding="utf-8"))(arr)
 
 
-def write_dataset_chunks(f, name, data_dict):
+def write_dataset_chunks(f, name, data_dict, verify_chunk_reuse=True):
     """
     data_dict should be a dictionary mapping chunk_size index to either an
     array for that chunk, or a slice into the raw data for that chunk
@@ -370,14 +372,15 @@ def write_dataset_chunks(f, name, data_dict):
                     hashed_slice = hashtable[data_hash]
                     slices[chunk] = hashed_slice
 
-                    _verify_new_chunk_reuse(
-                        raw_dataset=raw_data,
-                        new_data=data_s,
-                        data_hash=data_hash,
-                        hashed_slice=hashed_slice,
-                        chunk_being_written=data_s,
-                        data_to_write=data_to_write,
-                    )
+                    if verify_chunk_reuse:
+                        _verify_new_chunk_reuse(
+                            raw_dataset=raw_data,
+                            new_data=data_s,
+                            data_hash=data_hash,
+                            hashed_slice=hashed_slice,
+                            chunk_being_written=data_s,
+                            data_to_write=data_to_write,
+                        )
 
                     chunks_reused += 1
 

--- a/versioned_hdf5/versions.py
+++ b/versioned_hdf5/versions.py
@@ -77,6 +77,7 @@ def commit_version(
     compression=None,
     compression_opts=None,
     timestamp=None,
+    verify_chunk_reuse=True,
 ):
     """
     Create a new version.
@@ -146,7 +147,7 @@ def commit_version(
         if isinstance(data, dict):
             if chunks[name] is not None:
                 raise NotImplementedError("Specifying chunk size with dict data")
-            slices = write_dataset_chunks(f, name, data)
+            slices = write_dataset_chunks(f, name, data, verify_chunk_reuse=verify_chunk_reuse)
         elif isinstance(data, InMemorySparseDataset):
             write_dataset(
                 f,
@@ -156,8 +157,9 @@ def commit_version(
                 compression=compression[name],
                 compression_opts=compression_opts[name],
                 fillvalue=fillvalue,
+                verify_chunk_reuse=verify_chunk_reuse,
             )
-            slices = write_dataset_chunks(f, name, data.data_dict)
+            slices = write_dataset_chunks(f, name, data.data_dict, verify_chunk_reuse=verify_chunk_reuse)
         else:
             slices = write_dataset(
                 f,
@@ -167,6 +169,7 @@ def commit_version(
                 compression=compression[name],
                 compression_opts=compression_opts[name],
                 fillvalue=fillvalue,
+                verify_chunk_reuse=verify_chunk_reuse,
             )
         if shape is None:
             if isinstance(data, dict):

--- a/versioned_hdf5/versions.py
+++ b/versioned_hdf5/versions.py
@@ -77,7 +77,6 @@ def commit_version(
     compression=None,
     compression_opts=None,
     timestamp=None,
-    verify_chunk_reuse=True,
 ):
     """
     Create a new version.
@@ -147,7 +146,7 @@ def commit_version(
         if isinstance(data, dict):
             if chunks[name] is not None:
                 raise NotImplementedError("Specifying chunk size with dict data")
-            slices = write_dataset_chunks(f, name, data, verify_chunk_reuse=verify_chunk_reuse)
+            slices = write_dataset_chunks(f, name, data)
         elif isinstance(data, InMemorySparseDataset):
             write_dataset(
                 f,
@@ -157,9 +156,8 @@ def commit_version(
                 compression=compression[name],
                 compression_opts=compression_opts[name],
                 fillvalue=fillvalue,
-                verify_chunk_reuse=verify_chunk_reuse,
             )
-            slices = write_dataset_chunks(f, name, data.data_dict, verify_chunk_reuse=verify_chunk_reuse)
+            slices = write_dataset_chunks(f, name, data.data_dict)
         else:
             slices = write_dataset(
                 f,
@@ -169,7 +167,6 @@ def commit_version(
                 compression=compression[name],
                 compression_opts=compression_opts[name],
                 fillvalue=fillvalue,
-                verify_chunk_reuse=verify_chunk_reuse,
             )
         if shape is None:
             if isinstance(data, dict):


### PR DESCRIPTION
Currently, the verify_chunk_reuse check is relatively slow, see #336. This commit adds an option to disable it by an additional argument to `stage_version(..., verify_chunk_reuse=False)`.