### PR TITLE
Add version dunder back in using importlib.metadata

### DIFF
--- a/versioned_hdf5/__init__.py
+++ b/versioned_hdf5/__init__.py
@@ -1,4 +1,8 @@
+from importlib.metadata import version
+
 from .api import VersionedHDF5File
 from .replay import delete_version, delete_versions, modify_metadata
+
+__version__ = version(__package__)
 
 __all__ = ["VersionedHDF5File", "delete_version", "delete_versions", "modify_metadata"]


### PR DESCRIPTION
This PR adds a `__version__` dunder back in after it was removed when switching to meson-python. Closes #342.

Tested locally using `pip install -ve .` and using `pip install .`.