### PR TITLE
Improve read/writing performance for InMemoryDataset (PyInf#12655)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ ignore = [
 
 [project.optional-dependencies]
 dev = ["pre-commit>=3.6.0"]
-test = ["pytest", "pytest-env"]
+test = ["pytest", "pytest-env", "hypothesis"]
 doc = ["sphinx", "sphinx-multiversion", "myst-parser"]
 
 [tool.setuptools_scm]

--- a/versioned_hdf5/hashtable.py
+++ b/versioned_hdf5/hashtable.py
@@ -222,9 +222,12 @@ class Hashtable(MutableMapping):
                     "Chunking in more other than the first dimension"
                 )
             value = value.args[0]
-        if not isinstance(value, (slice, Slice)):
+        if isinstance(value, slice):
+            value = Slice(value.start, value.stop, value.step)
+        elif isinstance(value, Slice):
+            pass
+        else:
             raise TypeError("value must be a slice object")
-        value = Slice(value)
         if value.isempty():
             return
         if value.step not in [1, None]:

--- a/versioned_hdf5/tests/test_hashtable.py
+++ b/versioned_hdf5/tests/test_hashtable.py
@@ -136,7 +136,7 @@ def test_object_dtype_hashes_concatenated_values(tmp_path):
         )
 
 
-def test_verify_chunk_reuse_data_version_2(tmp_path):
+def test_verify_chunk_reuse_data_version_2(tmp_path, monkeypatch):
     """Test whether the issue with DATA_VERSION==2 would have been caught by
     _verify_new_chunk_reuse.
 
@@ -144,6 +144,8 @@ def test_verify_chunk_reuse_data_version_2(tmp_path):
     the encoded data, not the data itself, meaning that "b'hello'" would hash
     to the same value as b'hello'.
     """
+
+    monkeypatch.setenv("ENABLE_CHUNK_REUSE_VALIDATION", "1")
 
     def data_version_2_hash(self, data: np.ndarray):
         """
@@ -186,7 +188,7 @@ def test_verify_chunk_reuse_data_version_2(tmp_path):
                     group["values"] = np.concatenate((data2, data2))
 
 
-def test_verify_chunk_reuse_data_version_3(tmp_path):
+def test_verify_chunk_reuse_data_version_3(tmp_path, monkeypatch):
     """Test whether the issue with DATA_VERSION==3 would have been caught by
     _verify_new_chunk_reuse.
 
@@ -196,6 +198,8 @@ def test_verify_chunk_reuse_data_version_3(tmp_path):
     (because hashing each element in the array is equivalent to hashing
     the concatenated elements of the array).
     """
+
+    monkeypatch.setenv("ENABLE_CHUNK_REUSE_VALIDATION", "1")
 
     def data_version_3_hash(self, data: np.ndarray):
         """

--- a/versioned_hdf5/tests/test_wrappers.py
+++ b/versioned_hdf5/tests/test_wrappers.py
@@ -199,10 +199,6 @@ def test_as_subchunk_map_mask(data):
     _check_as_subchunk_map(chunks, idx, shape)
 
 
-def test_faoeritj():
-    _check_as_subchunk_map((5,), ndindex.ndindex(np.array([False, True])), (2,))
-
-
 def _check_as_subchunk_map(chunks, idx, shape):
     idx = idx.reduce(shape)
     if not isinstance(idx, ndindex.Tuple):

--- a/versioned_hdf5/tests/test_wrappers.py
+++ b/versioned_hdf5/tests/test_wrappers.py
@@ -232,3 +232,8 @@ def _check_as_subchunk_map(chunks, idx, shape):
                 assert_equal(ix1, ix2)
             else:
                 assert ix1 == ix2
+
+
+def test_empty_index():
+    # test we correctly handle empty index
+    _check_as_subchunk_map((5,), ndindex.Slice(1, 1), (2,))

--- a/versioned_hdf5/tests/test_wrappers.py
+++ b/versioned_hdf5/tests/test_wrappers.py
@@ -1,10 +1,16 @@
 import itertools
+from collections import defaultdict
 
+import ndindex
 import numpy as np
 import pytest
+import hypothesis
+from hypothesis import given, strategies as st
+from hypothesis.extra import numpy as stnp
 from numpy.testing import assert_equal
 
-from ..wrappers import InMemoryArrayDataset, InMemoryGroup, InMemorySparseDataset
+from ..wrappers import (InMemoryArrayDataset, InMemoryGroup,
+                        InMemorySparseDataset, as_subchunk_map)
 
 
 @pytest.fixture()
@@ -134,3 +140,67 @@ def test_group_repr(premade_group):
     assert repr(foo) in result
     assert repr(bar) in result
     assert repr(baz) in result
+
+
+def non_negative_step_slices(size):
+    start = st.one_of(st.integers(min_value=-size, max_value=size - 1), st.none())
+    stop = st.one_of(st.integers(min_value=-size, max_value=size), st.none())
+    # only non-negative steps (or None) are allowed
+    step = st.one_of(st.integers(min_value=1, max_value=size), st.none())
+    return st.builds(slice, start, stop, step)
+
+
+@given(st.data())
+@hypothesis.settings(database=None, max_examples=10_000, deadline=None)
+def test_as_subchunk_map(data):
+    ndim = data.draw(st.integers(1, 4), label="ndim")
+    shape = data.draw(st.tuples(*[st.integers(1, 100)] * ndim), label="shape")
+    chunks = data.draw(st.tuples(*[st.integers(5, 20)] * ndim), label="chunks")
+    has_fancy_idx = data.draw(st.booleans(), label="has_fancy_idx")
+    if has_fancy_idx:
+        fancy_idx_axis = data.draw(st.integers(0, ndim - 1), label="fancy_idx_axis")
+        fancy_idx = data.draw(stnp.arrays(np.intp, st.integers(0, shape[fancy_idx_axis] - 1),
+                                          elements=st.integers(0, shape[fancy_idx_axis] - 1),
+                                          unique=True),
+                              label="fancy_idx")
+        idx = ndindex.Tuple(*[data.draw(non_negative_step_slices(shape[dim]), label=f'idx{dim}') for dim in range(fancy_idx_axis)],
+                            fancy_idx,
+                            *[data.draw(non_negative_step_slices(shape[dim]), label=f'idx{dim}') for dim in range(fancy_idx_axis + 1, ndim)])
+    else:
+        idx = ndindex.Tuple(*[data.draw(non_negative_step_slices(shape[dim]), label=f'idx{dim}') for dim in range(ndim)])
+
+    idx = idx.reduce(shape)
+    if not isinstance(idx, ndindex.Tuple):
+        idx = ndindex.Tuple(idx)
+    chunk_size = ndindex.ChunkSize(chunks)
+
+    as_subchunk_map_dict = defaultdict(list)
+    for chunk, arr_subidx, chunk_subidx in as_subchunk_map(chunk_size, idx, shape):
+        as_subchunk_map_dict[chunk].append((arr_subidx, chunk_subidx))
+
+    as_subchunks_dict = defaultdict(list)
+    for chunk in chunk_size.as_subchunks(idx, shape):
+        arr_subidx = chunk.as_subindex(idx).raw
+        chunk_subidx = idx.as_subindex(chunk).raw
+        as_subchunks_dict[chunk].append((arr_subidx, chunk_subidx))
+
+    assert list(as_subchunk_map_dict.keys()) == list(as_subchunks_dict.keys())
+
+    for chunk in as_subchunk_map_dict:
+        assert len(as_subchunk_map_dict[chunk]) == len(as_subchunks_dict[chunk]) == 1
+        arr_subidx_1, chunk_subidx1 = as_subchunk_map_dict[chunk][0]
+        arr_subidx_2, chunk_subidx2 = as_subchunks_dict[chunk][0]
+
+        assert len(arr_subidx_1) == len(arr_subidx_2)
+        for ix1, ix2 in zip(arr_subidx_1, arr_subidx_2):
+            if isinstance(ix1, np.ndarray):
+                assert_equal(ix1, ix2)
+            else:
+                assert ix1 == ix2
+
+        assert len(chunk_subidx1) == len(chunk_subidx2)
+        for ix1, ix2 in zip(chunk_subidx1, chunk_subidx2):
+            if isinstance(ix1, np.ndarray):
+                assert_equal(ix1, ix2)
+            else:
+                assert ix1 == ix2

--- a/versioned_hdf5/wrappers.py
+++ b/versioned_hdf5/wrappers.py
@@ -536,6 +536,10 @@ def as_subchunk_map(chunk_size: ChunkSize, idx, shape: tuple):
     if len(shape) != len(chunk_size):
         raise ValueError("chunks dimensions must equal the array dimensions")
 
+    if idx.isempty(shape):
+        # abort early for empty index
+        return
+
     idx_len = len(idx.args)
 
     prefix_chunk_size = chunk_size[:idx_len]
@@ -570,6 +574,7 @@ def as_subchunk_map(chunk_size: ChunkSize, idx, shape: tuple):
             else:
                 chunk_idxs = tuple(range(start // n, (stop + n - 1) // n))
         elif isinstance(i, IntegerArray):
+            assert i.ndim == 1
             chunk_idxs = tuple(np.unique(i.array // n))
         elif isinstance(i, BooleanArray):
             if i.ndim != 1:


### PR DESCRIPTION
When we read from a multi-dimensional modified Dataset we incur a large overhead from repeatedly computing `as_subindex` operations:

```
In [1]: with h5py.File('data.h5', 'w') as f:
   ...:     vf = VersionedHDF5File(f)
   ...:     with vf.stage_version('v0') as sv:
   ...:         sv.create_dataset('values', data=np.arange(321 * 54321).reshape((321, 54321)), chunks=(10, 100), maxshape=(None, None))
   ...:
[PYFLYBY] from versioned_hdf5 import VersionedHDF5File
[PYFLYBY] import h5py
[PYFLYBY] import numpy as np

In [3]: %%pyinstrument
   ...: with h5py.File('data.h5', 'r+') as f:
   ...:     vf = VersionedHDF5File(f)
   ...:     with vf.stage_version('v1') as sv:
   ...:         values = sv['values']
   ...:         values.resize((432, 65432))
   ...:         _ = values[:321, :54321]
   ...:

  _     ._   __/__   _ _  _  _ _/_   Recorded: 16:24:37  Samples:  9780
 /_//_/// /_\ / //_// / //_'/ //     Duration: 12.679    CPU time: 12.134
/   _/                      v4.6.1

Program: /usr/local/bin/py

12.679 <module>  <ipython-input-3-2e35ebbdb6a4>:1
|- 5.686 DatasetWrapper.__getitem__  versioned_hdf5/wrappers.py:1267
|  `- 5.686 InMemoryDataset.__getitem__  versioned_hdf5/wrappers.py:757
|     `- 5.686 InMemoryDataset.get_index  versioned_hdf5/wrappers.py:655
|        |- 3.915 [self]  versioned_hdf5/wrappers.py
|        |- 1.104 InMemoryDatasetID._read_chunk  versioned_hdf5/wrappers.py:1385
|        |  `- 1.077 Dataset.__getitem__  h5py/_hl/dataset.py:749
|        |     |- 0.550 Reader.read  <built-in>
|        |     `- 0.429 Dataset._fast_reader  h5py/_hl/dataset.py:527
|        |        `- 0.426 [self]  h5py/_hl/dataset.py
|        `- 0.368 where  <__array_function__ internals>:177
|              [2 frames hidden]  <__array_function__ internals>, <buil...
|- 3.405 _GeneratorContextManager.__exit__  contextlib.py:141
|  `- 3.405 VersionedHDF5File.stage_version  versioned_hdf5/api.py:267
|     `- 3.403 commit_version  versioned_hdf5/versions.py:71
|        |- 2.132 create_virtual_dataset  versioned_hdf5/backend.py:427
|        |  |- 0.706 [self]  versioned_hdf5/backend.py
|        |  |- 0.459 select  h5py/_hl/selections.py:19
|        |  |  `- 0.346 [self]  h5py/_hl/selections.py
|        |  |- 0.409 Group.create_virtual_dataset  h5py/_hl/group.py:188
|        |  |  `- 0.319 VirtualLayout.make_dataset  h5py/_hl/vds.py:228
|        |  `- 0.194 Dataset.shape  h5py/_hl/dataset.py:467
|        |     `- 0.185 [self]  h5py/_hl/dataset.py
|        `- 1.170 write_dataset_chunks  versioned_hdf5/backend.py:344
|           |- 0.572 Hashtable.hash  versioned_hdf5/hashtable.py:116
|           |  `- 0.401 openssl_sha256  <built-in>
|           `- 0.247 [self]  versioned_hdf5/backend.py
|- 2.632 InMemoryDataset.resize  versioned_hdf5/wrappers.py:609
|  |- 1.110 InMemoryDatasetID.data_dict  versioned_hdf5/wrappers.py:1298
|  |  |- 0.586 <dictcomp>  versioned_hdf5/wrappers.py:1327
|  |  |  `- 0.508 spaceid_to_slice  versioned_hdf5/slicetools.py:6
|  |  |     `- 0.422 [self]  versioned_hdf5/slicetools.py
|  |  |- 0.267 <listcomp>  versioned_hdf5/wrappers.py:1317
|  |  |  `- 0.254 [self]  versioned_hdf5/wrappers.py
|  |  `- 0.192 [self]  versioned_hdf5/wrappers.py
|  |- 0.818 InMemoryDataset.get_index  versioned_hdf5/wrappers.py:655
|  |  `- 0.818 InMemoryDataset.__getitem__  h5py/_hl/dataset.py:749
|  |     `- 0.817 Reader.read  <built-in>
|  `- 0.601 [self]  versioned_hdf5/wrappers.py
|- 0.666 _GeneratorContextManager.__enter__  contextlib.py:132
|  `- 0.666 VersionedHDF5File.stage_version  versioned_hdf5/api.py:267
|     `- 0.665 create_version_group  versioned_hdf5/versions.py:22
|        `- 0.663 Group.visititems  h5py/_hl/group.py:635
|           |- 0.494 proxy  h5py/_hl/group.py:660
|           |  |- 0.298 _get  versioned_hdf5/versions.py:57
|           |  |  `- 0.227 InMemoryGroup.__setitem__  versioned_hdf5/wrappers.py:110
|           |  |     `- 0.227 InMemoryGroup._add_to_data  versioned_hdf5/wrappers.py:114
|           |  |        `- 0.227 InMemoryDataset.__init__  versioned_hdf5/wrappers.py:503
|           |  `- 0.175 Group.__getitem__  h5py/_hl/group.py:348
|           `- 0.169 [self]  h5py/_hl/group.py
`- 0.282 File.__exit__  h5py/_hl/files.py:601
   `- 0.282 File.close  h5py/_hl/files.py:576
```

We can significantly simplify this by computing the "subindexes" for each axis individually and then combine all combinations:

```
In [3]: %%pyinstrument
   ...: with h5py.File('data.h5', 'r+') as f:
   ...:     vf = VersionedHDF5File(f)
   ...:     with vf.stage_version('v1') as sv:
   ...:         values = sv['values']
   ...:         values.resize((432, 65432))
   ...:         _ = values[:321, :54321]
   ...:

  _     ._   __/__   _ _  _  _ _/_   Recorded: 16:33:49  Samples:  4283
 /_//_/// /_\ / //_// / //_'/ //     Duration: 5.811     CPU time: 5.766
/   _/                      v4.6.1

Program: /usr/local/python/python-3.11/std/bin/py

5.811 <module>  <ipython-input-3-2e35ebbdb6a4>:1
|- 2.372 _GeneratorContextManager.__exit__  contextlib.py:141
|  `- 2.372 VersionedHDF5File.stage_version  versioned_hdf5/api.py:267
|     `- 2.370 commit_version  versioned_hdf5/versions.py:71
|        |- 1.445 create_virtual_dataset  versioned_hdf5/backend.py:426
|        |  |- 0.448 [self]  versioned_hdf5/backend.py
|        |  |- 0.304 select  h5py/_hl/selections.py:19
|        |  |  |- 0.222 [self]  h5py/_hl/selections.py
|        |  |  `- 0.059 SimpleSelection.__init__  h5py/_hl/selections.py:227
|        |  |- 0.278 Group.create_virtual_dataset  h5py/_hl/group.py:188
|        |  |  |- 0.216 VirtualLayout.make_dataset  h5py/_hl/vds.py:228
|        |  |  `- 0.062 Dataset.__init__  h5py/_hl/dataset.py:641
|        |  |- 0.113 Dataset.shape  h5py/_hl/dataset.py:467
|        |  |  `- 0.107 [self]  h5py/_hl/dataset.py
|        |  `- 0.098 <dictcomp>  versioned_hdf5/backend.py:434
|        |- 0.838 write_dataset_chunks  versioned_hdf5/backend.py:343
|        |  |- 0.472 Hashtable.hash  versioned_hdf5/hashtable.py:116
|        |  |  |- 0.357 openssl_sha256  <built-in>
|        |  |  `- 0.076 [self]  versioned_hdf5/hashtable.py
|        |  |- 0.106 [self]  versioned_hdf5/backend.py
|        |  |- 0.071 Hashtable.__contains__  <frozen _collections_abc>:778
|        |  |  `- 0.063 Hashtable.__getitem__  versioned_hdf5/hashtable.py:205
|        |  |     `- 0.060 [self]  versioned_hdf5/hashtable.py
|        |  `- 0.061 Dataset.__setitem__  h5py/_hl/dataset.py:858
|        `- 0.079 [self]  versioned_hdf5/versions.py
|- 1.581 InMemoryDataset.resize  versioned_hdf5/wrappers.py:723
|  |- 0.874 InMemoryDatasetID.data_dict  versioned_hdf5/wrappers.py:1408
|  |  |- 0.478 <dictcomp>  versioned_hdf5/wrappers.py:1437
|  |  |  `- 0.423 spaceid_to_slice  versioned_hdf5/slicetools.py:6
|  |  |     `- 0.357 [self]  versioned_hdf5/slicetools.py
|  |  |- 0.191 <listcomp>  versioned_hdf5/wrappers.py:1427
|  |  |  `- 0.181 [self]  versioned_hdf5/wrappers.py
|  |  `- 0.138 [self]  versioned_hdf5/wrappers.py
|  |- 0.264 InMemoryDataset.get_index  versioned_hdf5/wrappers.py:772
|  |  `- 0.264 InMemoryDataset.__getitem__  h5py/_hl/dataset.py:749
|  |     `- 0.263 Reader.read  <built-in>
|  |- 0.240 [self]  versioned_hdf5/wrappers.py
|  `- 0.161 as_subchunk_map  versioned_hdf5/wrappers.py:496
|     `- 0.131 [self]  versioned_hdf5/wrappers.py
|- 1.318 DatasetWrapper.__getitem__  versioned_hdf5/wrappers.py:1377
|  `- 1.318 InMemoryDataset.__getitem__  versioned_hdf5/wrappers.py:872
|     `- 1.318 InMemoryDataset.get_index  versioned_hdf5/wrappers.py:772
|        |- 0.592 InMemoryDatasetID._read_chunk  versioned_hdf5/wrappers.py:1495
|        |  `- 0.569 Dataset.__getitem__  h5py/_hl/dataset.py:749
|        |     |- 0.285 Reader.read  <built-in>
|        |     `- 0.224 Dataset._fast_reader  h5py/_hl/dataset.py:527
|        |        `- 0.223 [self]  h5py/_hl/dataset.py
|        |- 0.472 [self]  versioned_hdf5/wrappers.py
|        `- 0.162 as_subchunk_map  versioned_hdf5/wrappers.py:496
|           `- 0.119 [self]  versioned_hdf5/wrappers.py
|- 0.402 _GeneratorContextManager.__enter__  contextlib.py:132
|  `- 0.402 VersionedHDF5File.stage_version  versioned_hdf5/api.py:267
|     `- 0.401 create_version_group  versioned_hdf5/versions.py:22
|        `- 0.401 Group.visititems  h5py/_hl/group.py:635
|           |- 0.319 proxy  h5py/_hl/group.py:660
|           |  |- 0.207 _get  versioned_hdf5/versions.py:57
|           |  |  `- 0.161 InMemoryGroup.__setitem__  versioned_hdf5/wrappers.py:111
|           |  |     `- 0.161 InMemoryGroup._add_to_data  versioned_hdf5/wrappers.py:115
|           |  |        `- 0.161 InMemoryDataset.__init__  versioned_hdf5/wrappers.py:617
|           |  |           `- 0.080 KeysViewHDF5.__iter__  <frozen _collections_abc>:835
|           |  |              `- 0.080 AttributeManager.__iter__  h5py/_hl/attrs.py:257
|           |  |                 `- 0.062 [self]  h5py/_hl/attrs.py
|           |  `- 0.092 Group.__getitem__  h5py/_hl/group.py:348
|           |     `- 0.065 [self]  h5py/_hl/group.py
|           `- 0.082 [self]  h5py/_hl/group.py
`- 0.136 File.__exit__  h5py/_hl/files.py:601
   `- 0.136 File.close  h5py/_hl/files.py:576
```