### PR TITLE
Add additional non-python build dependencies for publish_docs CI job

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Setup Graphviz
         run: |
-          sudo apt install graphviz -y
+          sudo apt install graphviz libhdf5-dev mpi-default-dev -y
 
       - name: Install versioned-hdf5
         run: |


### PR DESCRIPTION
Previously, a new build dependency on cython was added, which meant that we added new build time dependencies on hdf5 and mpi. This PR adds these new dependencies to the `publish_docs` CI job so that the docs can be built, fixing it.