### PR TITLE
Clean up `pytest` config; make test workflow print `hdf5` config

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,6 +49,11 @@ jobs:
           set -xe
           pip install .
 
+      - name: Print hdf5 configuration
+        run: |
+          set -xe
+          h5cc -showconfig
+
       - name: Install versioned-hdf5 test packages
         run: |
           set -xe
@@ -57,4 +62,4 @@ jobs:
       - name: Run Tests
         run: |
           set -xe
-          pytest -v . --import-mode=importlib
+          pytest -v .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,3 +106,11 @@ profile = "black"
 
 [tool.pytest_env]
 ENABLE_CHUNK_REUSE_VALIDATION = 1
+
+[tool.pytest.ini_options]
+addopts = "--doctest-modules --ignore=analysis/ --import-mode=importlib"
+doctest_optionflags = "NORMALIZE_WHITESPACE"
+markers = [
+    "setup_args : kwargs for setup fixture.",
+    "slow: slow tests",
+]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,0 @@
-[pytest]
-addopts = --doctest-modules --ignore=analysis/
-doctest_optionflags= NORMALIZE_WHITESPACE
-markers =
-    setup_args : kwargs for setup fixture.
-    slow: slow tests


### PR DESCRIPTION
This PR cleans up the pytest config, and adds a bit of crucial debugging information for the test workflow:

1. The hdf5 config is now displayed before each test run starts
2. Automatically use `--import-mode=importlib` in the default pytest `addopts` options, so that we don't have to remember to always run `pytest --import-mode=importlib`.