### PR TITLE
Make `InMemoryDataset` close child instances if self is closed

### DIFF
--- a/versioned_hdf5/wrappers.py
+++ b/versioned_hdf5/wrappers.py
@@ -64,7 +64,12 @@ class InMemoryGroup(Group):
         super().__init__(bind)
 
     def close(self):
+        """Mark self and any subgroups as committed."""
         self._committed = True
+        for name in self:
+            obj = self[name]
+            if isinstance(obj, InMemoryGroup):
+                obj.close()
 
     # Based on Group.__repr__
     def __repr__(self):


### PR DESCRIPTION
This PR ensures that `InMemoryGroup` instances close child `InMemoryGroup` instances if they themselves get closed. This means that if a parent group gets committed, any child instance will too. Closes #318.