### PR TITLE
Explicitly add all hdf5 types to slicetools to fix local tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ ignore = [
 "test_*.py" = ["ANN001"]
 
 [project.optional-dependencies]
-dev = ["pre-commit>=3.6.0"]
+dev = ["pre-commit>=3.6.0", 'cython', 'meson-python', 'setuptools-scm']
 test = ["pytest", "pytest-env", "hypothesis"]
 doc = ["sphinx", "sphinx-multiversion", "myst-parser"]
 


### PR DESCRIPTION
This PR updates the list of typedefs included from `hdf5.h` in `slicetools.pyx` to match what `h5py` does in `h5py/api_types_hdf5.pxd`. I'm not exactly sure why adding these types resolved local testing problems, but there were clues that this was some kind of typing issue - see #352 for context. Closes #352.