### PR TITLE
Make the tests workflow update before installing native deps

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,12 +20,8 @@ jobs:
       - name: Install libhdf5-dev
         run: |
           set -xe
-          sudo apt install -y libhdf5-dev
-
-      - name: Install mpi-default-dev
-        run: |
-          set -xe
-          sudo apt install -y mpi-default-dev
+          sudo apt update -y
+          sudo apt install -y libhdf5-dev mpi-default-dev
 
       - name: Install versioned-hdf5
         run: |

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -38,6 +38,7 @@ jobs:
 
       - name: Setup Graphviz
         run: |
+          sudo apt update -y
           sudo apt install graphviz libhdf5-dev mpi-default-dev -y
 
       - name: Install versioned-hdf5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,20 +15,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install hdf5-tools
+      - name: Install native dependencies
         run: |
           set -xe
-          sudo apt install -y hdf5-tools
-
-      - name: Install libhdf5-dev
-        run: |
-          set -xe
-          sudo apt install -y libhdf5-dev
-
-      - name: Install mpi-default-dev
-        run: |
-          set -xe
-          sudo apt install -y mpi-default-dev
+          sudo apt update -y
+          sudo apt install -y hdf5-tools libhdf5-dev mpi-default-dev
 
       - name: Install target numpy version
         if: matrix.numpy-version != 'latest'


### PR DESCRIPTION
This PR makes the workflow first run `apt update` before attempting to installing native dependencies; currently workflows are broken because `libhdf5` fails to install:

```
Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/c/curl/libcurl4-openssl-dev_7.81.0-1ubuntu1.16_amd64.deb  404  Not Found 
```

This PR should resolve this issue.