### PR TITLE
Release prep v1.8.0

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -11,7 +11,7 @@ on:
         default: false
 
 jobs:
-  build-package:
+  build-sdist:
     name: Build package
     runs-on: ubuntu-latest
     steps:
@@ -23,23 +23,34 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Install native dependencies
+        run: |
+          set -xe
+          sudo apt update -y
+          sudo apt install -y hdf5-tools libhdf5-dev mpi-default-dev
+
       - name: 🚀 Install build dependencies
         run: |
-          python -m pip install build
+          python -m pip install build twine
 
       - name: 📦 Build the sdist and wheel
         run: |
-          python -m build
+          python -m build --sdist -o wheelhouse
 
-      - name: ⤴️  Upload artifact
-        uses: actions/upload-artifact@v3
+      - name: List and check sdist
+        run: |
+          ls -lh wheelhouse/
+          twine check wheelhouse/*
+
+      - name: Upload sdist
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels
-          path: dist/*.tar.gz
+          name: wheels-sdist
+          path: ./wheelhouse/*.tar.gz
 
   publish:
     name: Publish Python packages on PyPI
-    needs: [build-package]
+    needs: [build-sdist]
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -47,21 +58,26 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - name: ⤵️  Download artifacts
-        uses: actions/download-artifact@v3
+      - name: Retrieve wheels and sdist
+        uses: actions/download-artifact@v4
         with:
-          name: wheels
-          path: dist
+          pattern: wheels-*
+          merge-multiple: true
+          path: wheels/
+
+      - name: print artifacts
+        run: |
+          ls -l wheels/
 
       - name: 🧪 Publish to PyPI Testing
         uses: pypa/gh-action-pypi-publish@release/v1
         if: ${{ inputs.test_pypi }}
         with:
           repository-url: https://test.pypi.org/legacy/
-          packages-dir: dist
+          packages-dir: wheels
 
       - name: 🎉 Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         if: ${{ !inputs.test_pypi }}
         with:
-          packages-dir: dist
+          packages-dir: wheels

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,26 @@
 Versioned HDF5 Change Log
 =========================
 
+## 1.8.0 (2024-08-09)
+
+### Major Changes
+
+- `slicetools` has been reimplemented in Cython, providing a significant speedup
+- Only sdist will be published from here on out due to the dependency on MPI.
+- Improved read/write performance for `InMemoryDataset`
+
+### Minor Changes
+- Force the master branch to be targeted when building docs
+- `__version__` dunder added back in
+- Update build workflows to test with `numpy==1.24` in addition to `numpy>=2`
+- Chunk reuse verification fixed for string dtype arrays
+- Cleaned up `pytest` configuration; added additional debugging output in test CI job
+- Fixed a bug where `InMemoryGroup` child groups were not closed when the parent
+  group is closed
+- Nondefault compression handling is now supported
+- Performance improvements to Hashtable initialization
+- Various refinements to the documentation
+
 ## 1.7.0 (2024-06-10)
 
 ### Major Changes


### PR DESCRIPTION
This PR adds cibuildwheel into the `pypi_publish.yml` workflow to allow us to build on all platforms.

The changelog has also been updated in preparation for 1.8.0.