### PR TITLE
Sane mypy settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,3 +114,18 @@ markers = [
     "setup_args : kwargs for setup fixture.",
     "slow: slow tests",
 ]
+
+[tool.mypy]
+allow_incomplete_defs = true  # FIXME
+allow_untyped_decorators = false
+allow_untyped_defs = true  # FIXME
+ignore_missing_imports = true
+no_implicit_optional = true
+show_error_codes = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_unreachable = true
+
+[[tool.mypy.overrides]]
+module = ["*.tests.*"]
+allow_untyped_defs = true

--- a/versioned_hdf5/api.py
+++ b/versioned_hdf5/api.py
@@ -152,6 +152,11 @@ class VersionedHDF5File:
         """
         return self._versions.attrs["current_version"]
 
+    @current_version.setter
+    def current_version(self, version_name):
+        set_current_version(self.f, version_name)
+        self._version_cache.clear()
+
     @property
     def data_version_identifier(self) -> str:
         """Return the data version identifier.
@@ -179,11 +184,6 @@ class VersionedHDF5File:
             Version value to write to the file.
         """
         self.f["_version_data/versions"].attrs["data_version"] = version
-
-    @current_version.setter
-    def current_version(self, version_name):
-        set_current_version(self.f, version_name)
-        self._version_cache.clear()
 
     def get_version_by_name(self, version):
         if version.startswith("/"):

--- a/versioned_hdf5/backend.py
+++ b/versioned_hdf5/backend.py
@@ -320,7 +320,7 @@ def _verify_new_chunk_reuse(
         assert_array_equal(to_be_reused, to_be_written)
     except AssertionError as e:
         raise ValueError(
-            f"Hash {data_hash} of existing data chunk {reused_chunk} "
+            f"Hash {data_hash!r} of existing data chunk {reused_chunk} "
             f"matches the hash of new data chunk {chunk_being_written}, "
             "but data does not."
         ) from e


### PR DESCRIPTION
Bulk import sane settings for mypy from another project.

Downstream of this, mypy reports 21 errors, all nontrivial. 
Having a fully green mypy run would take substantially more effort and is out of scope for this PR.