### PR TITLE
Improve the exceptions raised by `create_dataset`

### DIFF
--- a/versioned_hdf5/wrappers.py
+++ b/versioned_hdf5/wrappers.py
@@ -16,8 +16,9 @@ from typing import Iterable
 from weakref import WeakValueDictionary
 
 import numpy as np
-from h5py import Dataset, Datatype, Empty, Group, h5a, h5d, h5g, h5i, h5p, h5r, h5s, h5t
+from h5py import Dataset, Datatype, Empty, Group
 from h5py import __version__ as h5py_version
+from h5py import h5a, h5d, h5g, h5i, h5p, h5r, h5s, h5t
 from h5py._hl import filters
 from h5py._hl.base import guess_dtype, phil, with_phil
 from h5py._hl.dataset import _LEGACY_GZIP_COMPRESSION_VALS

--- a/versioned_hdf5/wrappers.py
+++ b/versioned_hdf5/wrappers.py
@@ -208,7 +208,7 @@ class InMemoryGroup(Group):
         name,
         shape=None,
         dtype=None,
-        data: np.ndarray | None = None,
+        data: Optional[np.ndarray] = None,
         fillvalue=None,
         **kwds,
     ):
@@ -381,21 +381,21 @@ class InMemoryGroup(Group):
 
 
 def _make_new_dset(
-    shape: int | tuple[int, ...] | None = None,
-    dtype: np.dtype | None = None,
-    data: np.ndarray | None = None,
-    chunks: tuple[int, ...] | None = None,
-    compression: int | str | bool | None = None,
-    shuffle: bool | None = None,
-    fletcher32: bool | None = None,
-    maxshape: tuple[int, ...] | None = None,
-    compression_opts: int | tuple[int, ...] | None = None,
-    fillvalue: int | str | float | None = None,
-    scaleoffset: bool | int | None = None,
-    track_times: bool | None = None,
-    external: Iterable[tuple[str, int, int]] | None = None,
-    track_order: bool | None = None,
-    dcpl: h5p.PropDCID | None = None,
+    shape: Optional[Union[int, tuple[int, ...]]] = None,
+    dtype: Optional[np.dtype] = None,
+    data: Optional[np.ndarray] = None,
+    chunks: Optional[tuple[int, ...]] = None,
+    compression: Optional[Union[int, str, bool]] = None,
+    shuffle: Optional[bool] = None,
+    fletcher32: Optional[bool] = None,
+    maxshape: Optional[tuple[int, ...]] = None,
+    compression_opts: Optional[Union[int, tuple[int, ...]]] = None,
+    fillvalue: Optional[Union[int, str, float]] = None,
+    scaleoffset: Optional[Union[bool, int]] = None,
+    track_times: Optional[bool] = None,
+    external: Optional[Iterable[tuple[str, int, int]]] = None,
+    track_order: Optional[bool] = None,
+    dcpl: Optional[h5p.PropDCID] = None,
 ) -> np.ndarray:
     """Create a new low-level dataset identifier.
 


### PR DESCRIPTION
This PR improves exceptions that are raised by `create_dataset`, in many cases to include information about what the offending arguments passed to the function were. The PR also adds type annotations and documentation for `_make_new_dset`.

Closes #331.