### PR TITLE
[InMemoryDataset redesign] Overhaul test_subchunk_map

### DIFF
--- a/versioned_hdf5/tests/test_subchunk_map.py
+++ b/versioned_hdf5/tests/test_subchunk_map.py
@@ -1,136 +1,135 @@
-from collections import defaultdict
+from __future__ import annotations
+
+from typing import Any
 
 import hypothesis
-import ndindex
 import numpy as np
 import pytest
 from hypothesis import given
 from hypothesis import strategies as st
 from hypothesis.extra import numpy as stnp
-from numpy.testing import assert_equal
+from numpy.testing import assert_array_equal
 
 from ..subchunk_map import as_subchunk_map
 
+max_examples = 10_000
 
-def non_negative_step_slices(size):
-    start = st.one_of(st.integers(min_value=-size, max_value=size - 1), st.none())
-    stop = st.one_of(st.integers(min_value=-size, max_value=size), st.none())
+
+def non_negative_step_slices(size: int):
+    start = st.one_of(st.integers(-size - 1, size + 1), st.none())
+    stop = st.one_of(st.integers(-size - 1, size + 1), st.none())
     # only non-negative steps (or None) are allowed
-    step = st.one_of(st.integers(min_value=1, max_value=size), st.none())
+    step = st.one_of(st.integers(1, size + 1), st.none())
     return st.builds(slice, start, stop, step)
 
 
-@pytest.mark.slow
-@given(st.data())
-@hypothesis.settings(database=None, max_examples=10_000, deadline=None)
-def test_as_subchunk_map(data):
-    ndim = data.draw(st.integers(1, 4), label="ndim")
-    shape = data.draw(st.tuples(*[st.integers(1, 100)] * ndim), label="shape")
-    chunks = data.draw(st.tuples(*[st.integers(5, 20)] * ndim), label="chunks")
-    idx = ndindex.Tuple(
-        *[
-            data.draw(non_negative_step_slices(shape[dim]), label=f"idx{dim}")
-            for dim in range(ndim)
-        ]
+@st.composite
+def basic_idx_st(draw, shape: tuple[int, ...]) -> Any:
+    """Hypothesis draw of slice and integer indexes"""
+    nidx = draw(st.integers(0, len(shape)))
+    idx_st = st.tuples(
+        *(
+            # FIXME we should push the scalar use case into non_negative_step_slices
+            # However ndindex fails when mixing scalars and slices and array indices
+            # https://github.com/Quansight-Labs/ndindex/issues/188
+            st.one_of(
+                non_negative_step_slices(size),
+                st.integers(-size, size - 1),
+            )
+            # Note: ... is not supported
+            for size in shape[:nidx]
+        )
     )
+    return draw(idx_st)
 
-    _check_as_subchunk_map(chunks, idx, shape)
 
-
-@pytest.mark.slow
-@given(st.data())
-@hypothesis.settings(database=None, max_examples=10_000, deadline=None)
-def test_as_subchunk_map_fancy_idx(data):
-    ndim = data.draw(st.integers(1, 4), label="ndim")
-    shape = data.draw(st.tuples(*[st.integers(1, 100)] * ndim), label="shape")
-    chunks = data.draw(st.tuples(*[st.integers(5, 20)] * ndim), label="chunks")
-    fancy_idx_axis = data.draw(st.integers(0, ndim - 1), label="fancy_idx_axis")
-    fancy_idx = data.draw(
-        stnp.arrays(
-            np.intp,
-            st.integers(0, shape[fancy_idx_axis] - 1),
-            elements=st.integers(0, shape[fancy_idx_axis] - 1),
-            unique=True,
-        ),
-        label="fancy_idx",
+@st.composite
+def fancy_idx_st(draw, shape: tuple[int, ...]) -> Any:
+    """A single axis is indexed by a NDArray[np.intp], whose elements can be negative,
+    non-unique, and not in order.
+    All other axes are indexed by slices.
+    """
+    fancy_idx_axis = draw(st.integers(0, len(shape) - 1))
+    size = shape[fancy_idx_axis]
+    fancy_idx = stnp.arrays(
+        np.intp,
+        shape=st.integers(0, size * 2),
+        elements=st.integers(-size, size - 1),
+        unique=False,
     )
-    idx = ndindex.Tuple(
-        *[
-            data.draw(non_negative_step_slices(shape[dim]), label=f"idx{dim}")
-            for dim in range(fancy_idx_axis)
-        ],
+    idx_st = st.tuples(
+        *[non_negative_step_slices(shape[dim]) for dim in range(fancy_idx_axis)],
         fancy_idx,
         *[
-            data.draw(non_negative_step_slices(shape[dim]), label=f"idx{dim}")
-            for dim in range(fancy_idx_axis + 1, ndim)
+            non_negative_step_slices(shape[dim])
+            for dim in range(fancy_idx_axis + 1, len(shape))
         ],
     )
+    return draw(idx_st)
 
-    _check_as_subchunk_map(chunks, idx, shape)
 
-
-@pytest.mark.slow
-@given(st.data())
-@hypothesis.settings(database=None, max_examples=10_000, deadline=None)
-def test_as_subchunk_map_mask(data):
-    ndim = data.draw(st.integers(1, 4), label="ndim")
-    shape = data.draw(st.tuples(*[st.integers(1, 100)] * ndim), label="shape")
-    chunks = data.draw(st.tuples(*[st.integers(5, 20)] * ndim), label="chunks")
-    mask_idx_axis = data.draw(st.integers(0, ndim - 1), label="mask_idx_axis")
-    mask_idx = data.draw(
-        stnp.arrays(np.bool_, shape[mask_idx_axis], elements=st.booleans()),
-        label="mask_idx",
-    )
-    idx = ndindex.Tuple(
-        *[
-            data.draw(non_negative_step_slices(shape[dim]), label=f"idx{dim}")
-            for dim in range(mask_idx_axis)
-        ],
+@st.composite
+def mask_idx_st(draw, shape: tuple[int, ...]) -> Any:
+    """A single axis is indexed by a NDArray[np.bool], whereas all other axes
+    may be indexed by slices.
+    """
+    ndim = len(shape)
+    mask_idx_axis = draw(st.integers(0, ndim - 1))
+    mask_idx = stnp.arrays(np.bool_, shape[mask_idx_axis], elements=st.booleans())
+    idx_st = st.tuples(
+        *[non_negative_step_slices(shape[dim]) for dim in range(mask_idx_axis)],
         mask_idx,
         *[
-            data.draw(non_negative_step_slices(shape[dim]), label=f"idx{dim}")
+            non_negative_step_slices(shape[dim])
             for dim in range(mask_idx_axis + 1, ndim)
         ],
     )
-
-    _check_as_subchunk_map(chunks, idx, shape)
-
-
-def _check_as_subchunk_map(chunks, idx, shape):
-    idx = idx.reduce(shape)
-    if not isinstance(idx, ndindex.Tuple):
-        idx = ndindex.Tuple(idx)
-    chunk_size = ndindex.ChunkSize(chunks)
-
-    as_subchunk_map_dict = defaultdict(list)
-    for chunk, arr_subidx, chunk_subidx in as_subchunk_map(chunk_size, idx, shape):
-        as_subchunk_map_dict[chunk].append((arr_subidx, chunk_subidx))
-    as_subchunks_dict = defaultdict(list)
-    for chunk in chunk_size.as_subchunks(idx, shape):
-        arr_subidx = chunk.as_subindex(idx).raw
-        chunk_subidx = idx.as_subindex(chunk).raw
-        as_subchunks_dict[chunk].append((arr_subidx, chunk_subidx))
-    assert list(as_subchunk_map_dict.keys()) == list(as_subchunks_dict.keys())
-    for chunk in as_subchunk_map_dict:
-        assert len(as_subchunk_map_dict[chunk]) == len(as_subchunks_dict[chunk]) == 1
-        arr_subidx_1, chunk_subidx1 = as_subchunk_map_dict[chunk][0]
-        arr_subidx_2, chunk_subidx2 = as_subchunks_dict[chunk][0]
-
-        assert len(arr_subidx_1) == len(arr_subidx_2)
-        for ix1, ix2 in zip(arr_subidx_1, arr_subidx_2):
-            if isinstance(ix1, np.ndarray):
-                assert_equal(ix1, ix2)
-            else:
-                assert ix1 == ix2
-
-        assert len(chunk_subidx1) == len(chunk_subidx2)
-        for ix1, ix2 in zip(chunk_subidx1, chunk_subidx2):
-            if isinstance(ix1, np.ndarray):
-                assert_equal(ix1, ix2)
-            else:
-                assert ix1 == ix2
+    return draw(idx_st)
 
 
-def test_empty_index():
-    # test we correctly handle empty index
-    _check_as_subchunk_map((5,), ndindex.Slice(1, 1), (2,))
+@st.composite
+def idx_chunks_shape_st(
+    draw, max_ndim: int = 4
+) -> tuple[Any, tuple[int, ...], tuple[int, ...]]:
+    shape_st = st.lists(st.integers(1, 20), min_size=1, max_size=max_ndim)
+    shape = tuple(draw(shape_st))
+
+    chunks_st = st.tuples(*[st.integers(1, s + 1) for s in shape])
+    chunks = draw(chunks_st)
+
+    idx_st = st.one_of(
+        basic_idx_st(shape),
+        fancy_idx_st(shape),
+        mask_idx_st(shape),
+    )
+    idx = draw(idx_st)
+
+    return idx, chunks, shape
+
+
+@pytest.mark.slow
+@given(idx_chunks_shape_st())
+@hypothesis.settings(max_examples=max_examples, deadline=None)
+def test_as_subchunk_map(args):
+    idx, chunks, shape = args
+
+    source = np.arange(1, np.prod(shape) + 1, dtype=np.int32).reshape(shape)
+    expect = source[idx]
+    actual = np.zeros_like(expect)
+
+    for chunk_idx, arr_subidx, chunk_subidx in as_subchunk_map(chunks, idx, shape):
+        chunk_idx = chunk_idx.raw
+
+        # Test that chunk_idx selects whole chunks
+        assert isinstance(chunk_idx, tuple)
+        assert len(chunk_idx) == len(chunks)
+        for i, c, d in zip(chunk_idx, chunks, shape):
+            assert isinstance(i, slice)
+            assert i.start % c == 0
+            assert i.stop == min(i.start + c, d)
+            assert i.step == 1
+
+        assert not actual[arr_subidx].any(), "overlapping arr_subidx"
+        actual[arr_subidx] = source[chunk_idx][chunk_subidx]
+
+    assert_array_equal(actual, expect)


### PR DESCRIPTION
Rework test_subchunk_map:
- Remove dependency from ndindex. Don't assume that ndindex does the right thing.
- Rework the hypothesis strategy so that it's separate from the test. This is propaedeutic to reuse the same strategy later on in different tests.
- Add use case of scalar indices (it was completely missing!)
- Add use case of slice start, stop, and/or step exceeding array size
- Add use case of index shorter than ndim
- Add use case of chunk size = 1
- Add use case of integer array indices with repeated elements, possibly larger than original array
