### PR TITLE
[InMemoryDataset redesign] Read many slices at once with the HDF5 C API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ requires = [
     "meson-python",
     "setuptools_scm",
     "Cython >= 3.0.10",
+    "numpy",
 ]
 build-backend = "mesonpy"
 

--- a/versioned_hdf5/meson.build
+++ b/versioned_hdf5/meson.build
@@ -11,6 +11,16 @@ py.install_sources(
     subdir: 'versioned_hdf5',
 )
 
+# Adapted from https://numpy.org/doc/2.1/reference/random/examples/cython/meson.build.html
+# Note:
+# numpy 2.x -> site-packages/numpy/_core/include
+# numpy 1.x -> site-packages/numpy/core/include
+npy_include_path = run_command(
+    py,
+    ['-c', 'import numpy; print(numpy.get_include())'],
+    check: true
+).stdout().strip()
+
 compiled_deps = [
     dependency('hdf5'),
     dependency('mpi'),
@@ -22,6 +32,7 @@ py.extension_module(
     install: true,
     subdir: 'versioned_hdf5',
     dependencies: compiled_deps,
+    include_directories: [npy_include_path],
     cython_args: ['--cplus'],
     override_options : ['cython_language=cpp'],
 )

--- a/versioned_hdf5/slicetools.pyx
+++ b/versioned_hdf5/slicetools.pyx
@@ -2,9 +2,17 @@ import sys
 from functools import lru_cache
 
 import cython
+import h5py
+
+cimport numpy as np
+
+import numpy as np
+from cython import void
 from h5py import h5s
 from h5py._hl.base import phil
+from h5py.h5t import py_create
 from ndindex import Slice, Tuple
+from numpy.typing import ArrayLike
 
 from libc.stddef cimport ptrdiff_t, size_t
 from libc.stdio cimport FILE, fclose
@@ -24,17 +32,29 @@ cdef extern from "hdf5.h":
     ctypedef int hbool_t
     ctypedef int herr_t
     ctypedef int htri_t
-    ctypedef long long hsize_t
-    ctypedef signed long long hssize_t
+    ctypedef long long hsize_t  # as per C99, uint64 or wider
+    ctypedef signed long long hssize_t  # as per C99, int64 or wider
     ctypedef signed long long haddr_t
     ctypedef long int off_t
+
+    cdef herr_t H5Dread(
+        hid_t dset_id,
+        hid_t mem_type_id,
+        hid_t mem_space_id,
+        hid_t file_space_id,
+        hid_t dxpl_id,
+        void* buf,
+    ) nogil
 
     cdef hid_t H5E_DEFAULT = 0
     cdef herr_t H5Eprint(hid_t stack_id, FILE* stream) nogil
 
+    cdef hid_t H5I_INVALID_HID = -1
+
+    cdef hid_t H5P_DEFAULT = 0
     # virtual Dataset functions
-    cdef hid_t H5Pget_virtual_vspace(hid_t dcpl_id, size_t index)
-    cdef hid_t H5Pget_virtual_srcspace(hid_t dcpl_id, size_t index)
+    cdef hid_t H5Pget_virtual_vspace(hid_t dcpl_id, size_t index) nogil
+    cdef hid_t H5Pget_virtual_srcspace(hid_t dcpl_id, size_t index) nogil
 
     ctypedef enum H5S_sel_type:
         H5S_SEL_ERROR = -1,  # Error
@@ -44,17 +64,51 @@ cdef extern from "hdf5.h":
         H5S_SEL_ALL = 3,  # Entire extent selected
         H5S_SEL_N = 4  # THIS MUST BE LAST
 
+    ctypedef enum H5S_seloper_t:
+        H5S_SELECT_NOOP = -1,
+        H5S_SELECT_SET = 0,
+        H5S_SELECT_OR,
+        H5S_SELECT_AND,
+        H5S_SELECT_XOR,
+        H5S_SELECT_NOTB,
+        H5S_SELECT_NOTA,
+        H5S_SELECT_APPEND,
+        H5S_SELECT_PREPEND,
+        H5S_SELECT_INVALID    # Must be the last one
+
     cdef H5S_sel_type H5Sget_select_type(
         hid_t space_id
-    ) except H5S_sel_type.H5S_SEL_ERROR
-    cdef int H5Sget_simple_extent_ndims(hid_t space_id)
+    ) except H5S_sel_type.H5S_SEL_ERROR nogil
+    cdef herr_t H5Sclose(hid_t space_id) nogil
+    cdef int H5Sget_simple_extent_ndims(hid_t space_id) nogil
+    cdef hid_t H5Screate_simple	(
+        int rank,
+        const hsize_t* dims,
+        const hsize_t* maxdims,
+    ) nogil
     cdef htri_t H5Sget_regular_hyperslab(
         hid_t spaceid,
         hsize_t* start,
         hsize_t* stride,
         hsize_t* count,
         hsize_t* block,
-    )
+    ) nogil
+    cdef herr_t H5Sselect_hyperslab(
+        hid_t space_id,
+        H5S_seloper_t op,
+        const hsize_t* start,
+        const hsize_t* stride,
+        const hsize_t* count,
+        const hsize_t* block,
+    ) nogil
+
+
+np.import_array()
+
+# Numpy equivalents of Cython types
+np_hsize_t = np.ulonglong
+np_hssize_t = np.longlong
+np_haddr_t = np.longlong
 
 
 def spaceid_to_slice(space) -> Tuple:
@@ -146,6 +200,7 @@ cdef _spaceid_to_slice(space_id: hid_t):
     else:
         raise NotImplementedError("Point selections are not yet supported")
 
+
 cpdef build_data_dict(dcpl, raw_data_name: str):
     """
     Function to build the "data_dict" of a versioned virtual dataset.
@@ -201,3 +256,436 @@ cdef Exception HDF5Error():
     fclose(stream)
     msg = buf.decode("utf-8", errors="replace")
     return RuntimeError(msg)
+
+
+cpdef void read_many_slices(
+    src: np.ndarray | h5py.Dataset,
+    np.ndarray dst,
+    src_start: ArrayLike,
+    dst_start: ArrayLike,
+    count: ArrayLike,
+    src_stride: ArrayLike | None = None,
+    dst_stride: ArrayLike | None = None,
+    fast: bool | None = None,
+):
+    """Transfer multiple n-dimensional slices of data from src to dst::
+
+        dst[dst_idx0] = src[src_idx0]
+        dst[dst_idx1] = src[src_idx1]
+        ...
+
+    where all indices are tuples of slices.
+
+    Parameters
+    ----------
+    src: np.ndarray | h5py.Dataset
+        The source data to read from
+    dst: np.ndarray
+        The destination array to write to.
+        It must be C-contiguous and of the same dtype and dimensionality as src.
+    src_start: array-like
+        The starting coordinates, a.k.a. offsets, of the slices in src.
+        It must be a 2D array or array-like (e.g. list of lists) with the same number of
+        rows as there are selections and as many columns as there are dimensions in src.
+    dst_start: array-like
+        The starting coordinates of the slices in dst.
+        Same format as src_start.
+    count: array-like
+        The number of elements to read and write in each dimension.
+        Same format as src_start.
+    src_stride: array-like, optional
+        The stride, a.k.a. step, of the slices when reading from src, in points.
+        Note that this differs from numpy.ndarray.strides, which is in bytes.
+        Same format as src_start. If omitted, default to 1.
+    dst_stride: array-like, optional
+        The stride of the slices when writing to dst.
+        Same format as src_start. If omitted, default to 1.
+    fast: bool, optional
+        If True, use the hdf5 C API directly to read the data if possible.
+        If False, use pure Python numpy syntax to slice src and dst.
+        If omitted, determine automatically.
+
+    For example, if src and dst are 2D and strides are omitted or always 1,
+    the areas of data to be copied will be::
+
+        dst[
+            dst_start[i, 0]:dst_start[i, 0] + count[i, 0],
+            dst_start[i, 1]:dst_start[i, 1] + count[i, 1],
+        ] = src[
+            src_start[i, 0]:src_start[i, 0] + count[i, 0],
+            src_start[i, 1]:src_start[i, 1] + count[i, 1],
+        ]
+
+    where i is the row of each of the coordinates arrays.
+
+    Coordinates arrays can alternatively be 1D arrays, with one point per dimension;
+    they will be broadcasted against the other arrays.
+    For example, you may use a 1D array for count if you want all selected areas to have
+    the same shape.
+
+    Scalar selections
+    -----------------
+    If dst has less dimensions than src, you should present a reshaped view of dst
+    to this function.
+
+    e.g. to execute::
+
+        dst[2:3, 4:6] = src[6:7, 8, 9:11]
+
+    where dst.ndim == 2 and src.ndim == 3, you should call::
+
+        read_many_slices(
+            src,
+            dst[:, None, :],
+            src_start=[[6, 8, 9]],
+            dst_start=[[2, 0, 4]],
+            count=[[1, 1, 2]],
+        )
+
+    Note that the same hack is not possible when src is a h5py.Dataset and has less
+    dimensions than dst, as src[:, None, :] would load the whole dataset into memory.
+
+    TODO support src.ndim < dst.ndim. It would take some extra logic
+    and an extra parameter to inform where the extra dimensions are.
+
+    Performance notes
+    -----------------
+    When reading from h5py, this function calls::
+
+        H5Sselect_hyperslab(file_id, H5S_SELECT_SET, ...)
+        H5Sselect_hyperslab(mem_id, H5S_SELECT_SET, ...)
+        H5DRead(...)
+
+    once per input row; see _read_many_slices_fast.
+
+    This is much faster than calling H5Sselect_hyperslab(..., H5S_SELECT_OR, ...) once
+    per input row followed by a single call to H5DRead, a.k.a. hyperslab fusion,
+    due to a known issue in libhdf5:
+    https://forum.hdfgroup.org/t/union-of-non-consecutive-hyperslabs-is-very-slow/5062
+
+    The downside of this approach is that if your selections access the same chunk more
+    than once, they have to be contiguous or else the chunk may fall out of the
+    internal cache of libhdf5. This can also happen with contiguous selections that span
+    multiple chunks.
+    """
+    # Begin input validation and preprocessing
+
+    ndim = dst.ndim
+    if ndim < 1:
+        raise ValueError("must operate on at least one dimension")
+    if dst.dtype != src.dtype or ndim != src.ndim or not dst.flags.writeable:
+        raise ValueError(
+            "dst must be a writeable numpy array of the same dtype and dimensionality "
+            "as src"
+        )
+    if dst.size == 0 or not all(src.shape):
+        return
+
+    cdef bint bfast
+    if fast is False:
+        bfast = False
+    else:
+        bfast = isinstance(src, h5py.Dataset) and src._fast_read_ok
+        if fast and not bfast:
+            raise ValueError("fast transfer is not possible with this source")
+
+    if bfast and not dst.flags.c_contiguous:
+        # TODO we could support non-C-contiguous arrays by doing
+        # arithmetics with starts and strides
+        raise NotImplementedError("dst must be C-contiguous for fast mode")
+
+    src_start = _preproc_many_slices_idx(src_start, ndim, bfast)
+    dst_start = _preproc_many_slices_idx(dst_start, ndim, bfast)
+    count = _preproc_many_slices_idx(count, ndim, bfast)
+
+    if src_stride is None:
+        src_stride = np.ones(ndim, dtype=np_hsize_t)
+    else:
+        src_stride = _preproc_many_slices_idx(src_stride, ndim, bfast)
+    if dst_stride is None:
+        dst_stride = np.ones(ndim, dtype=np_hsize_t)
+    else:
+        dst_stride = _preproc_many_slices_idx(dst_stride, ndim, bfast)
+
+    for arr in (src_start, dst_start, count, src_stride, dst_stride):
+        if arr.size == 0:
+            return
+
+    # dummy makes sure to coerce into the correct number of dimensions when
+    # all indices are 1D arrays.
+    # This raises if the arrays have mismatched number of rows or dimensions, or if
+    # there's a wrong number of columns...
+    dummy = np.empty((1, ndim))
+    _, src_start, dst_start, count, src_stride, dst_stride = np.broadcast_arrays(
+        dummy, src_start, dst_start, count, src_stride, dst_stride
+    )
+    # ...*unless* ndim=1, in which case we need to test explicitly
+    if src_start.shape[1] != ndim:
+        raise ValueError("Coordinates arrays must have as many columns as src.ndim")
+
+    cdef np.ndarray src_shape = np.array(src.shape, dtype=np_hsize_t)
+    cdef np.npy_intp[1] ndim_ptr = {ndim}
+    cdef np.ndarray dst_shape = np.PyArray_SimpleNewFromData(
+        1, ndim_ptr, np.NPY_INTP, <void*>dst.shape
+    ).astype(np_hsize_t)  # On 32 bit platforms, sizeof(hsize_t) == 8; sizeof(int) == 4
+
+    clipped_count = _clip_count(
+        src_shape,
+        dst_shape,
+        src_start,
+        dst_start,
+        count,
+        src_stride,
+        dst_stride,
+    )
+
+    # End of input validation and preprocessing
+
+    if bfast:
+        _read_many_slices_fast(
+            src,
+            dst,
+            <hsize_t*>dst_shape.data,
+            src_start,
+            dst_start,
+            clipped_count,
+            src_stride,
+            dst_stride,
+        )
+    else:
+        _read_many_slices_slow(
+            src,
+            dst,
+            src_start,
+            dst_start,
+            clipped_count,
+            src_stride,
+            dst_stride,
+        )
+
+
+cdef np.ndarray _preproc_many_slices_idx(obj: ArrayLike, hsize_t ndim, bint fast):
+    """Helper of read_many_slices. Ensure that obj is a numpy array of hsize_t with
+    either 1 or 2 dimensions, and that it's C-contiguous at least along the
+    innermost dimension.
+    """
+    # np.asarray with unsigned dtype raises if presented with a Python list containing
+    # negative numbers, but can quietly cause an integer underflow if arr is already a
+    # numpy array with signed dtype and negative numbers in it.
+    if isinstance(obj, np.ndarray) and obj.dtype.kind != "u" and (obj < 0).any():
+        raise OverflowError("index out of bounds for uint64")
+    cdef np.ndarray arr = np.asarray(obj, dtype=np_hsize_t)
+
+    if arr.ndim not in (1, 2):
+        raise ValueError("Coordinates arrays must have 1 or 2 dimensions")
+
+    # The array must be contiguous along the columns in order to be passed to
+    # H5Sselect_hyperslab. So a view like a[:2] is OK, but a[::2] must be made
+    # contiguous first. Note that, to save a bit of time, this deep-copy happens before
+    # we broadcast 1D arrays to add rows.
+    if fast and arr.strides[-1] != sizeof(hsize_t):
+        return np.ascontiguousarray(arr)
+    else:
+        return arr
+
+
+@cython.cdivision(True)
+cpdef hsize_t stop2count(hsize_t start, hsize_t stop, hsize_t step) noexcept nogil:
+    """Given a start:stop:step slice or range, return the number of elements yielded.
+
+    This is functionally identical to::
+
+        len(range(start, stop, step))
+
+    Doesn't assume that stop >= start. Assumes that step >= 1.
+    """
+    # Note that hsize_t is unsigned so stop - start could underflow.
+    if stop <= start:
+        return 0
+    return (stop - start - 1) // step + 1
+
+
+cpdef hsize_t count2stop(hsize_t start, hsize_t count, hsize_t step) noexcept nogil:
+    """Inverse of stop2count.
+
+    When count == 0 or when step>1, multiple stops can yield the same count.
+    This function returns the smallest stop >= start.
+    """
+    if count == 0:
+        return start
+    return start + (count - 1) * step + 1
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+@cython.infer_types(True)
+cdef hsize_t[:, :] _clip_count(
+    const hsize_t[:] src_shape,
+    const hsize_t[:] dst_shape,
+    const hsize_t[:, :] src_start,
+    const hsize_t[:, :] dst_start,
+    const hsize_t[:, :] count,
+    const hsize_t[:, :] src_stride,
+    const hsize_t[:, :] dst_stride,
+):
+    """Helper of read_many_slices. Clip count to prevent writing out of bounds.
+    This function also neuters src_start beyond src.shape or dst_start beyond dst.shape.
+    Finally, it also ensures that strides are >= 1.
+
+    TODO refactor as a @cython.ufunc.
+    Cython ufuncs don't support hsize_t (long long) at the time of writing.
+    """
+    nslices, ndim = count.shape[:2]
+    cdef hsize_t[:, :] out = np.empty((nslices, ndim), dtype=np_hsize_t)
+
+    with nogil:
+        for i in range(nslices):
+            for j in range(ndim):
+                if src_stride[i, j] == 0 or dst_stride[i, j] == 0:
+                    raise ValueError("Strides must be strictly greater than zero")
+
+                out[i, j] = min(
+                    count[i, j],
+                    stop2count(src_start[i, j], src_shape[j], src_stride[i, j]),
+                    stop2count(dst_start[i, j], dst_shape[j], dst_stride[i, j]),
+                )
+
+    return out
+
+
+@cython.wraparound(False)
+@cython.boundscheck(False)
+@cython.infer_types(True)
+cdef void _read_many_slices_fast (
+    src: h5py.Dataset,
+    np.ndarray dst,
+    const hsize_t* dst_shape,
+    const hsize_t[:, :] src_start,
+    const hsize_t[:, :] dst_start,
+    const hsize_t[:, :] count,
+    const hsize_t[:, :] src_stride,
+    const hsize_t[:, :] dst_stride,
+):
+    """Implements read_many_slices data transfer when src is a h5py.Dataset with simple
+    extents only (h5py.Dataset._fast_read_ok).
+
+    Performance notes
+    -----------------
+    See docstring of read_many_slices
+    """
+    nslices, ndim = src_start.shape[:2]
+
+    with phil:
+        # h5py internals. See h5py/dataset.py and h5py/_selector.pyx.
+        dset_id: hid_t = src.id.id
+        # must remain in scope for the id to remain valid
+        space = src.id.get_space()
+        file_space_id: hid_t = space.id
+        # must remain in scope for the id to remain valid
+        mem_type = py_create(src.dtype)
+        mem_type_id: hid_t = mem_type.id
+
+        # libhdf5 is not thread safe (read comment about locking in h5py/_objects.pyx),
+        # so we are wrapping everything in a reentrant lock (`with phil`).
+        # We can however release the GIL to allow unrelated code to run in parallel.
+        with nogil:
+            mem_space_id = H5Screate_simple(ndim, dst_shape, NULL)
+            if mem_space_id == H5I_INVALID_HID:
+                raise HDF5Error()
+
+            for i in range(nslices):
+                for j in range(ndim):
+                    if count[i, j] == 0:
+                        break
+                else:
+                    # count > 0 along all axes
+                    err = H5Sselect_hyperslab(
+                        file_space_id,
+                        H5S_SELECT_SET,
+                        &src_start[i, 0],
+                        &src_stride[i, 0],
+                        &count[i, 0],
+                        NULL,
+                    )
+                    if err < 0:
+                        raise HDF5Error()
+
+                    err = H5Sselect_hyperslab(
+                        mem_space_id,
+                        H5S_SELECT_SET,
+                        &dst_start[i, 0],
+                        &dst_stride[i, 0],
+                        &count[i, 0],
+                        NULL,
+                    )
+                    if err < 0:
+                        raise HDF5Error()
+
+                    err = H5Dread(
+                        dset_id,
+                        mem_type_id,
+                        mem_space_id,
+                        file_space_id,
+                        H5P_DEFAULT,
+                        dst.data,
+                    )
+                    if err < 0:
+                        raise HDF5Error()
+
+            err = H5Sclose(mem_space_id)
+            if err < 0:
+                raise HDF5Error()
+
+
+@cython.wraparound(False)
+@cython.boundscheck(False)
+@cython.infer_types(True)
+cdef void _read_many_slices_slow (
+    src: np.ndarray | h5py.Dataset,
+    np.ndarray dst,
+    const hsize_t[:, :] src_start,
+    const hsize_t[:, :] dst_start,
+    const hsize_t[:, :] count,
+    const hsize_t[:, :] src_stride,
+    const hsize_t[:, :] dst_stride,
+):
+    """Implements read_many_slices data transfer when fast transfer cannot be performed.
+
+    This happens when:
+    1. src is a h5py.Dataset but h5py.Dataset._fast_read_ok returns False.
+       This is to avoid replicating the complex machinery found in
+       h5py.Dataset.__getitem__.
+    2. src is a numpy array.
+
+    Performance notes
+    -----------------
+    There has been experimentation to bypass the Python slicing machinery by hacking the
+    numpy C API. While functionally successful, there was no material performance gain.
+
+    An alternative approach would be to manually loop over the strides at least for
+    basic item sizes (1, 2, 4, and 8 bytes). This has not been attempted yet.
+    """
+    nslices, ndim = src_start.shape[:2]
+
+    for i in range(nslices):
+        for j in range(ndim):
+            if count[i, j] == 0:
+                break
+        else:
+            # count > 0 along all axes
+            src_idx = []
+            dst_idx = []
+            for j in range(ndim):
+                src_start_ij = src_start[i, j]
+                dst_start_ij = dst_start[i, j]
+                count_ij = count[i, j]
+                src_stride_ij = src_stride[i, j]
+                dst_stride_ij = dst_stride[i, j]
+
+                src_stop_ij = count2stop(src_start_ij, count_ij, src_stride_ij)
+                dst_stop_ij = count2stop(dst_start_ij, count_ij, dst_stride_ij)
+
+                src_idx.append(slice(src_start_ij, src_stop_ij, src_stride_ij))
+                dst_idx.append(slice(dst_start_ij, dst_stop_ij, dst_stride_ij))
+
+            dst[tuple(dst_idx)] = src[tuple(src_idx)]

--- a/versioned_hdf5/slicetools.pyx
+++ b/versioned_hdf5/slicetools.pyx
@@ -386,9 +386,10 @@ cpdef void read_many_slices(
         return
 
     cdef bint bfast = False
-    if fast is not False and isinstance(src, h5py.Dataset):
-        with phil:
-            bfast = src._fast_read_ok
+    if fast is not False:
+        if isinstance(src, h5py.Dataset):
+            with phil:
+                bfast = src._fast_read_ok
         if fast and not bfast:
             raise ValueError("fast transfer is not possible with this source")
 

--- a/versioned_hdf5/slicetools.pyx
+++ b/versioned_hdf5/slicetools.pyx
@@ -474,6 +474,7 @@ cdef np.ndarray _preproc_many_slices_idx(obj: ArrayLike, hsize_t ndim, bint fast
     # np.asarray with unsigned dtype raises in numpy>=2 if presented with a Python list
     # containing negative numbers, but can quietly cause an integer underflow if arr is
     # already a numpy array with signed dtype and negative numbers in it.
+    # TODO https://github.com/numpy/numpy/issues/25396
     if not NP_GE_200:
         obj = np.asarray(obj)
     if isinstance(obj, np.ndarray) and obj.dtype.kind != "u" and (obj < 0).any():

--- a/versioned_hdf5/tests/test_slicetools.py
+++ b/versioned_hdf5/tests/test_slicetools.py
@@ -1,8 +1,16 @@
+from typing import Any
+
+import hypothesis
 import numpy as np
+import pytest
 from h5py._hl.selections import Selection
+from hypothesis import given
+from hypothesis import strategies as st
 from numpy.testing import assert_equal
 
-from ..slicetools import spaceid_to_slice
+from ..slicetools import count2stop, read_many_slices, spaceid_to_slice, stop2count
+
+max_examples = 10_000
 
 
 def test_spaceid_to_slice(h5file):
@@ -36,3 +44,400 @@ def test_spaceid_to_slice(h5file):
                         print(start, count, stride, block)
                         raise
                     assert_equal(a[s.raw], a[sel], f"{(start, count, stride, block)}")
+
+
+def free_slices_st(size: int) -> Any:
+    """Hypothesis draw of a slice object to slice an array of up to size elements"""
+    start_st = st.integers(0, size)
+    stop_st = st.integers(0, size)
+    # only non-negative steps are allowed
+    step_st = st.integers(1, size)
+    return st.builds(slice, start_st, stop_st, step_st)
+
+
+@given(free_slices_st(5))
+def test_stop2count_count2stop(s):
+    count = stop2count(s.start, s.stop, s.step)
+    assert count == len(range(s.start, s.stop, s.step))
+
+    stop = count2stop(s.start, count, s.step)
+    # When count == 0 or when step>1, multiple stops yield the same count,
+    # so stop won't necessarily be equal to s.stop
+    assert count == len(range(s.start, stop, s.step))
+
+
+@st.composite
+def bound_slices_st(draw, arr_size: int, view_size: int) -> slice:
+    """Hypothesis draw of a slice object to slice an array of <arr_size> points
+    along an axis, returning a view of <view_size> points::
+
+        arr = np.empty(arr_size)
+        idx = bound_slices_st(arr_size, view_size).example()
+        assert arr[idx].size == view_size
+    """
+    start = draw(st.integers(0, arr_size - view_size))
+
+    # Don't want to figure out the exact formula to avoid off-by-one errors.
+    # Just add some margin and then count down.
+    for max_step in range((arr_size - start + 1) // view_size + 1, 0, -1):
+        tmp_stop = count2stop(start, view_size, max_step)
+        if tmp_stop <= arr_size:
+            break
+
+    step = draw(st.integers(1, max_step))
+    stop = count2stop(start, view_size, step)
+    assert len(range(start, min(stop, arr_size), step)) == view_size
+    return slice(start, stop, step)
+
+
+@st.composite
+def matching_slices_st(draw, src_size: int, dst_size: int) -> tuple[slice, slice]:
+    """Hypothesis draw to slice src and dst arrays along the same axis
+    dst[idx_dst] = src[idx_src]
+
+    Returns tuples of idx_src, idx_dst
+    where src[idx_src].size == dst[idx_dst].size
+    """
+    view_size = draw(st.integers(1, min(src_size, dst_size)))
+    slices_st = st.tuples(
+        bound_slices_st(src_size, view_size),
+        bound_slices_st(dst_size, view_size),
+    )
+    return draw(slices_st)
+
+
+@st.composite
+def many_slices_st(
+    draw, max_ndim: int = 4, max_size: int = 20, max_nslices: int = 4
+) -> tuple[
+    # shape of src array
+    tuple[int, ...],
+    # shape of dst array, with same dimensionality as src
+    tuple[int, ...],
+    # list of indices to slice src array with
+    list[tuple[slice, ...]],
+    # matching list of indices to slice dst array with
+    list[tuple[slice, ...]],
+]:
+    src_shape_st = st.lists(st.integers(1, max_size), min_size=1, max_size=max_ndim)
+    src_shape = tuple(draw(src_shape_st))
+    ndim = len(src_shape)
+    dst_shape_st = st.lists(st.integers(1, max_size), min_size=ndim, max_size=ndim)
+    dst_shape = tuple(draw(dst_shape_st))
+
+    nslices = draw(st.integers(1, max_nslices))
+    src_indices = []
+    dst_indices = []
+    for _ in range(nslices):
+        src_idx = []
+        dst_idx = []
+        for src_size, dst_size in zip(src_shape, dst_shape):
+            src_slice, dst_slice = draw(matching_slices_st(src_size, dst_size))
+            src_idx.append(src_slice)
+            dst_idx.append(dst_slice)
+        src_indices.append(tuple(src_idx))
+        dst_indices.append(tuple(dst_idx))
+
+    return src_shape, dst_shape, src_indices, dst_indices
+
+
+@given(args=many_slices_st())
+@hypothesis.settings(
+    max_examples=max_examples,
+    deadline=None,
+    # h5file is not reset between hypothesis examples
+    suppress_health_check=[hypothesis.HealthCheck.function_scoped_fixture],
+)
+def test_read_many_slices(h5file, args):
+    shape_from, shape_to, indices_from, indices_to = args
+
+    src = np.arange(1, np.prod(shape_from) + 1, dtype=np.int32).reshape(shape_from)
+
+    expect = np.zeros(shape_to, dtype=src.dtype)
+    src_start = []
+    dst_start = []
+    count = []
+    src_step = []
+    dst_step = []
+    for idx_from, idx_to in zip(indices_from, indices_to):
+        expect[idx_to] = src[idx_from]
+
+        src_start.append([s.start for s in idx_from])
+        src_step.append([s.step for s in idx_from])
+        dst_start.append([s.start for s in idx_to])
+        dst_step.append([s.step for s in idx_to])
+        count.append([len(range(s.start, s.stop, s.step)) for s in idx_from])
+
+    # Test numpy->numpy
+    dst = np.zeros(shape_to, dtype=src.dtype)
+    read_many_slices(src, dst, src_start, dst_start, count, src_step, dst_step)
+    np.testing.assert_array_equal(dst, expect, strict=True)
+
+    # h5file fixture is not reset between hypothesis examples
+    if "a" in h5file:
+        del h5file["a"]
+    dset = h5file.create_dataset("a", data=src)
+
+    # Test h5py->numpy
+    for kwargs in ({}, {"fast": True}, {"fast": False}):
+        dst = np.zeros(shape_to, dtype=src.dtype)
+        read_many_slices(
+            dset, dst, src_start, dst_start, count, src_step, dst_step, **kwargs
+        )
+        np.testing.assert_array_equal(dst, expect, strict=True)
+
+
+@pytest.mark.parametrize("step", [1, 2, 3, 4, 5, 6])
+@pytest.mark.parametrize("start", [0, 1, 2, 3, 4, 5, 6])
+@pytest.mark.parametrize("use_h5", [True, False])
+def test_read_many_slices_clip_src_count(h5file, use_h5, start, step):
+    """Counts are clipped automatically because either
+    src_start or src_stride are too large.
+    This causes some slices to become size 0 along one dimension.
+    """
+    src = np.arange(1, 21).reshape(5, 4)
+    src_view = src[start::step]
+    expect = np.zeros((8, 4), dtype=src.dtype)
+    expect[: len(src_view)] = src_view
+
+    # Test that completely skipping a slice because its clipped count is zero doesn't
+    # cause the next rows to be skipped
+    expect[7, 3] = src[4, 3]
+
+    if use_h5:
+        src = h5file.create_dataset("a", data=src)
+
+    dst = np.zeros_like(expect)
+    read_many_slices(
+        src,
+        dst,
+        src_start=[(start, 0), (4, 3)],
+        dst_start=[(0, 0), (7, 3)],
+        count=[(999, 999), (999, 999)],
+        src_stride=[(step, 1), (1, 1)],
+    )
+    np.testing.assert_array_equal(dst, expect, strict=True)
+
+
+@pytest.mark.parametrize("step", [1, 2, 3, 4, 5, 6])
+@pytest.mark.parametrize("start", [0, 1, 2, 3, 4, 5, 6])
+@pytest.mark.parametrize("use_h5", [True, False])
+def test_read_many_slices_clip_dst_count(h5file, use_h5, start, step):
+    """Counts are clipped automatically because either
+    dst_start or dst_stride are too large.
+    This causes some slices to become size 0 along one dimension.
+    """
+    src = np.arange(1, 41).reshape(10, 4)
+    expect = np.zeros((5, 4), dtype=src.dtype)
+    dst_view = expect[start::step]
+    expect[start::step] = src[: len(dst_view)]
+
+    # Test that completely skipping a slice because its clipped count is zero doesn't
+    # cause the next slices to be skipped
+    expect[4, 3] = src[7, 3]
+
+    if use_h5:
+        src = h5file.create_dataset("a", data=src)
+
+    dst = np.zeros_like(expect)
+    read_many_slices(
+        src,
+        dst,
+        src_start=[(0, 0), (7, 3)],
+        dst_start=[(start, 0), (4, 3)],
+        count=[(999, 999), (999, 999)],
+        src_stride=None,
+        dst_stride=[(step, 1), (1, 1)],
+    )
+    np.testing.assert_array_equal(dst, expect, strict=True)
+
+
+@pytest.mark.parametrize("all_1d", [True, False])
+@pytest.mark.parametrize("use_h5", [True, False])
+def test_read_many_slices_broadcast_indices(h5file, use_h5, all_1d):
+    """1D indices are automatically broadcast to 2D"""
+    src = np.arange(1, 41).reshape(10, 4)
+    expect = np.zeros((5, 4), dtype=src.dtype)
+    expect[0:3, 2:4] = src[1:4, 1:3]
+    if not all_1d:
+        expect[2:5, 1:3] = src[1:4, 1:3]
+
+    if use_h5:
+        src = h5file.create_dataset("a", data=src)
+
+    dst = np.zeros_like(expect)
+    read_many_slices(
+        src,
+        dst,
+        src_start=(1, 1),
+        dst_start=(0, 2) if all_1d else [(0, 2), (2, 1)],
+        count=(3, 2),
+    )
+    np.testing.assert_array_equal(dst, expect, strict=True)
+
+
+@pytest.mark.parametrize("use_h5", [True, False])
+def test_read_many_slices_no_indices(h5file, use_h5):
+    """Edge case where there are no slices of data to copy"""
+    src = np.arange(1, 41).reshape(10, 4)
+    dst = np.zeros((5, 4), dtype=src.dtype)
+    if use_h5:
+        src = h5file.create_dataset("a", data=src)
+
+    read_many_slices(src, dst, [], [], [])
+    assert (dst == 0).all()
+
+
+@pytest.mark.parametrize("contiguous_cols", [True, False])
+@pytest.mark.parametrize("use_h5", [True, False])
+def test_read_many_slices_noncontiguous_idx(h5file, use_h5, contiguous_cols):
+    """one or more coordinate array is not C-contiguous along the rows or both
+    columns and rows.
+
+    Non-contiguous rows are supported thanks to Cython strided views.
+    Non-contiguous columns are not supported in hdf5 fast mode and are transparently
+    deep-copied before use.
+    """
+    src = np.arange(1, 51).reshape(10, 5)
+
+    src_start = np.array([(0, 1, 2), (9, 9, 9), (2, 3, 4)])
+    if contiguous_cols:
+        src_start = src_start[::2, :2]
+        expect = [[src[0, 1]], [src[2, 3]]]
+    else:
+        src_start = src_start[::2, ::2]
+        expect = [[src[0, 2]], [src[2, 4]]]
+
+    assert not src_start.flags.c_contiguous
+
+    if use_h5:
+        src = h5file.create_dataset("a", data=src)
+
+    dst = np.zeros((2, 1), dtype=src.dtype)
+    read_many_slices(src, dst, src_start, [(0, 0), (1, 0)], (1, 1))
+    np.testing.assert_equal(dst, expect)
+
+
+@pytest.mark.parametrize("use_h5", [True, False])
+def test_read_many_slices_src_size_zero(h5file, use_h5):
+    """src array has size 0"""
+    src = np.empty((3, 0))
+    dst = np.zeros((3, 3), dtype=src.dtype)
+    if use_h5:
+        src = h5file.create_dataset("a", data=src)
+    read_many_slices(src, dst, [(0, 0)], [(0, 0)], [(3, 3)])
+    assert (dst == 0).all()
+
+
+@pytest.mark.parametrize("use_h5", [True, False])
+def test_read_many_slices_dst_size_zero(h5file, use_h5):
+    """dst array has size 0"""
+    src = np.arange(1, 10).reshape(3, 3)
+    dst = np.empty((0, 3), dtype=src.dtype)
+    if use_h5:
+        src = h5file.create_dataset("a", data=src)
+    read_many_slices(src, dst, [(0, 0)], [(0, 0)], [(3, 3)])
+
+
+def test_read_many_slices_noncontiguous_dst(h5file):
+    """dst is a numpy array that's not C-contiguous.
+    It is supported, but only with fast=False.
+    """
+    src = np.arange(1, 17).reshape(4, 4)
+    expect = np.zeros((8, 12), dtype=src.dtype)
+    expect[::2, ::3] = src[()]
+
+    dst = np.zeros_like(expect)
+    read_many_slices(src, dst[::2, ::3], [(0, 0), (2, 0)], [(0, 0), (2, 0)], (2, 4))
+    np.testing.assert_equal(dst, expect)
+
+    src = h5file.create_dataset("a", data=src)
+    dst = np.zeros_like(expect)
+    read_many_slices(
+        src, dst[::2, ::3], [(0, 0), (2, 0)], [(0, 0), (2, 0)], (2, 4), fast=False
+    )
+    np.testing.assert_equal(dst, expect)
+
+    # h5py src only works in slow mode
+    with pytest.raises(NotImplementedError, match="contiguous"):
+        read_many_slices(
+            src, dst[::2, ::3], [(0, 0), (2, 0)], [(0, 0), (2, 0)], (2, 4), fast=True
+        )
+
+    # For the sake of awareness, user must explicitly pass fast=False
+    with pytest.raises(NotImplementedError, match="contiguous"):
+        read_many_slices(src, dst[::2, ::3], [(0, 0), (2, 0)], [(0, 0), (2, 0)], (2, 4))
+
+
+def test_read_many_slices_not_fast_read_ok(h5file):
+    """src is a h5py dataset that doesn't support fast read"""
+    src = np.array(["foo", "bar", "baz"]).astype(object)
+    expect = np.array([b"bar"]).astype(object)
+    src = h5file.create_dataset("a", data=src)
+    assert not src._fast_read_ok
+
+    dst = np.zeros_like(expect)
+    read_many_slices(src, dst, [[1]], [[0]], [[1]])
+    np.testing.assert_array_equal(dst, expect, strict=True)
+
+    dst = np.zeros_like(expect)
+    read_many_slices(src, dst, [[1]], [[0]], [[1]], fast=False)
+    np.testing.assert_array_equal(dst, expect, strict=True)
+
+    with pytest.raises(ValueError, match="fast transfer is not possible"):
+        read_many_slices(src, dst, [[1]], [[0]], [[1]], fast=True)
+
+
+def test_read_many_slices_fail():
+    src = np.arange(1, 5)
+    dst = np.zeros(4, dtype=src.dtype)
+
+    # Negative indices in a list (np.asarray with unsigned dtype fails)
+    with pytest.raises(OverflowError):
+        read_many_slices(src, dst, [[-1]], [[0]], [[1]])
+    # Negative indices in numpy array (needs explicit validation)
+    with pytest.raises(OverflowError):
+        read_many_slices(src, dst, np.array([[-1]]), [[0]], [[1]])
+
+    # Stride 0
+    with pytest.raises(ValueError, match="Strides must be strictly greater than zero"):
+        read_many_slices(src, dst, [[0]], [[0]], [[1]], [[0]], [[1]])
+    with pytest.raises(ValueError, match="Strides must be strictly greater than zero"):
+        read_many_slices(src, dst, [[0]], [[0]], [[1]], [[1]], [[0]])
+
+    # src/dst ndim=0
+    with pytest.raises(ValueError, match="at least one dimension"):
+        read_many_slices(np.array(0), np.array(0), [[]], [[]], [[]])
+
+    # src.ndim != dst.ndim
+    with pytest.raises(ValueError, match="same dtype and dimensionality"):
+        read_many_slices(src.reshape(2, 2), dst, [[0]], [[0]], [[1]])
+
+    # src.dtype != dst.dtype
+    with pytest.raises(ValueError, match="same dtype and dimensionality"):
+        read_many_slices(src.astype(float), dst, [[0]], [[0]], [[1]])
+
+    # Fail to broadcast coordinates
+    with pytest.raises(ValueError, match="cannot be broadcast"):
+        read_many_slices(src, dst, [[0], [1]], [[0], [1], [2]], [[1]])
+
+    # 0-sized coordinates
+    with pytest.raises(ValueError, match="must have 1 or 2 dimensions"):
+        read_many_slices(src, dst, 0, 0, 1)
+
+    # coordinates with 3+ dims
+    with pytest.raises(ValueError, match="must have 1 or 2 dimensions"):
+        read_many_slices(src, dst, np.zeros((1, 1, 1)), [[0]], [[1]])
+
+    # indices.shape[1] != src.ndim
+    with pytest.raises(ValueError, match="as many columns as src.ndim"):
+        read_many_slices(src, dst, [(0, 0)], [(0, 0)], [(1, 1)])
+
+    # force fast transfer on numpy src
+    with pytest.raises(ValueError, match="fast transfer is not possible"):
+        read_many_slices(src, dst, [[0]], [[0]], [[1]], fast=True)
+
+    # dst is not writeable
+    dst.setflags(write=False)
+    with pytest.raises(ValueError, match="writeable"):
+        read_many_slices(src, dst, [[0]], [[0]], [[1]])


### PR DESCRIPTION
This is an alternative to #370 after it's been found out that virtual datasets perform very poorly in libhdf5.

Add a function to quickly read potentially thousands of slices from HDF5 into a numpy array, or between numpy arrays. This new function remains dormant for now and will be used in a later PR by a variant of StagedChangesArray from #370.