### PR TITLE
[InMemoryDataset redesign] New function asarray()

### DIFF
--- a/versioned_hdf5/meson.build
+++ b/versioned_hdf5/meson.build
@@ -5,6 +5,7 @@ py.install_sources(
         'backend.py',
         'hashtable.py',
         'replay.py',
+        'tools.py',
         'versions.py',
         'wrappers.py',
     ],

--- a/versioned_hdf5/tests/test_tools.py
+++ b/versioned_hdf5/tests/test_tools.py
@@ -1,0 +1,55 @@
+import numpy as np
+import numpy.ma as ma
+from numpy.testing import assert_array_equal
+
+from ..tools import asarray
+
+
+def test_asarray():
+    a = np.array([1, -1], dtype="i2")
+    b = asarray(a)
+    assert b is a
+    b = asarray(a, "i2")
+    assert b is a
+    b = asarray(a, "u2")
+    assert_array_equal(b, a.astype("u2"), strict=True)
+    assert b.base is a
+    b = asarray(a, "i4")
+    assert_array_equal(b, a.astype("i4"), strict=True)
+    assert b.base is None
+
+    # Don't just test itemsize
+    a = np.array([1, -1], dtype="i4")
+    b = asarray(a, "f4")
+    assert_array_equal(b, a.astype("f4"), strict=True)
+    assert b.base is None
+
+    # non-arrays are coerced to np.ndarray
+    a = [1, -1]
+    b = asarray(a)
+    assert_array_equal(b, np.asarray(a), strict=True)
+    b = asarray(a, dtype=np.float32)
+    assert_array_equal(b, np.asarray(a, dtype=np.float32), strict=True)
+
+    a = 1
+    b = asarray(a)
+    assert isinstance(b, np.ndarray)
+    assert_array_equal(b, np.asarray(a), strict=True)
+
+    a = np.int16(1)
+    b = asarray(a)
+    assert isinstance(b, np.ndarray)
+    assert_array_equal(b, np.asarray(a), strict=True)
+
+    # array-likes aren't coerced to np.ndarray
+    a = ma.masked_array([1, -1], mask=[0, 1], dtype="i2")
+    b = asarray(a)
+    assert b is a
+    b = asarray(a, dtype="u2")
+    assert type(b) is type(a)
+    assert b.base is a
+    assert_array_equal(b, a.astype("u2"), strict=True)
+    b = asarray(a, dtype="i4")
+    assert type(b) is type(a)
+    assert b.base is None
+    assert_array_equal(b, a.astype("i4"), strict=True)

--- a/versioned_hdf5/tools.py
+++ b/versioned_hdf5/tools.py
@@ -1,0 +1,31 @@
+import numpy as np
+
+
+def asarray(a, dtype=None):
+    """Variant of np.asarray(a, dtype=dtype), with two differences:
+
+    1. If a is a numpy-like array, don't coerce it to a numpy.ndarray
+    2. If a has a ABI-compatible dtype, return a view instead of a copy
+       (works around https://github.com/numpy/numpy/issues/27509)
+    """
+    if not hasattr(a, "__array__") or np.isscalar(a):
+        return np.asarray(a, dtype=dtype)
+
+    if dtype is None:
+        return a
+
+    dtype = np.dtype(dtype)
+    if a.dtype == dtype:
+        return a
+
+    if (
+        dtype.itemsize == a.itemsize
+        and dtype.kind in ("i", "u")
+        and a.dtype.kind in ("i", "u")
+        and hasattr(a, "view")
+    ):
+        # Note that this does not reduce the amount of safety checks:
+        # np.array(-1).astype("u1") doesn't raise and returns 255!
+        return a.view(dtype)
+
+    return a.astype(dtype)


### PR DESCRIPTION
Part of #386 

Variant of np.asarray(a, dtype=dtype), with two differences:
1. If a is a numpy-like array, don't coerce it to a numpy.ndarray
2. If a has a ABI-compatible dtype, return a view instead of a copy

Works around https://github.com/numpy/numpy/issues/27509