### PR TITLE
[InMemoryDataset redesign] build_indices_and_offsets

### DIFF
--- a/versioned_hdf5/tests/test_slicetools.py
+++ b/versioned_hdf5/tests/test_slicetools.py
@@ -129,7 +129,9 @@ def test_build_slab_indices_and_offsets_sparse(h5file):
             [456, 123, 123],
             [789, 123, 123],
             [123, 123, 123],
-            [123, 123, 123],  # FIXME Spurious extra chunk
+            # FIXME Spurious extra chunk. Discussion:
+            # https://github.com/deshaw/versioned-hdf5/pull/385#discussion_r1817313138
+            [123, 123, 123],
             [123, 123, 123],
         ],
         dtype=np.int64,

--- a/versioned_hdf5/wrappers.py
+++ b/versioned_hdf5/wrappers.py
@@ -33,7 +33,7 @@ from ndindex import (
 )
 
 from .backend import DEFAULT_CHUNK_SIZE
-from .slicetools import build_data_dict, build_slab_indices_and_offsets
+from .slicetools import build_data_dict
 from .subchunk_map import as_subchunk_map
 
 _groups = WeakValueDictionary({})
@@ -1399,8 +1399,6 @@ class InMemoryDatasetID(h5d.DatasetID):
     def data_dict(self):
         if self._data_dict is None:
             dcpl = self.get_create_plist()
-
-            build_slab_indices_and_offsets(dcpl, self.shape, self.chunks)
 
             is_virtual: bool = dcpl.get_layout() == h5d.VIRTUAL
 

--- a/versioned_hdf5/wrappers.py
+++ b/versioned_hdf5/wrappers.py
@@ -33,7 +33,7 @@ from ndindex import (
 )
 
 from .backend import DEFAULT_CHUNK_SIZE
-from .slicetools import build_data_dict
+from .slicetools import build_data_dict, build_slab_indices_and_offsets
 from .subchunk_map import as_subchunk_map
 
 _groups = WeakValueDictionary({})
@@ -1399,6 +1399,8 @@ class InMemoryDatasetID(h5d.DatasetID):
     def data_dict(self):
         if self._data_dict is None:
             dcpl = self.get_create_plist()
+
+            build_slab_indices_and_offsets(dcpl, self.shape, self.chunks)
 
             is_virtual: bool = dcpl.get_layout() == h5d.VIRTUAL
 


### PR DESCRIPTION
Part of #386 

Rewrite `build_data_dict` to serve the new StagedChangesArray introduced by #386.
This PR adds a new function, which remains dormant side-by-side to `build_data_dict`, and will eventually replace it.

## Testing
Besides unit tests, I've temporarily rigged running this function every time `build_data_dict` runs (see reverted commit) and never crashed. Definitive proof that this function returns correct results throughout the whole test suite is that #386, which uses it, is green.

## Edge cases
`build_data_dict` implements logic for a wealth of weird edge cases, which never come up in any unit tests and made no sense to me since, as far as I understand, they could only possibly be generated if someone manually crafted a virtual dataset and then expected versioned_hdf5 to read it. Detailed discussion below.
