### PR TITLE
Redesign InMemoryDataset data model (libhdf5 direct access)

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -274,6 +274,11 @@ The ndindex library was initially created for versioned-hdf5, in order to make
 index manipulation possible as well as allowing code that passes indices around
 to become much cleaner.
 
+`InMemoryDataset` is implemented as a fairly thin wrapper around
+`StagedChangesArray`, which is abstracted from h5py and holds all the modified
+chunks in memory, presenting them as a numpy-like array, until they are ready to
+be flushed to disk. For details, read [Staging changes in memory](staged_changes).
+
 These wrapper objects all try to emulate the h5py API as closely as possible,
 so that the user can use them just as they would the real h5py objects. Any
 discrepancy between h5py and versioned-hdf5 semantics should be considered a

--- a/versioned_hdf5/tests/test_api.py
+++ b/versioned_hdf5/tests/test_api.py
@@ -2697,67 +2697,6 @@ def test_make_empty_dataset(tmp_path):
         assert_equal(cv["values"][:], np.array([]))
 
 
-@mark.parametrize(
-    ("chunk_size", "iterations"), itertools.product([3, 5, 10], [5, 20, 50, 100])
-)
-def test_resize_performance(tmp_path, chunk_size, iterations):
-    """Test that resizing an InMemoryDataset only calls InMemoryDatasetID.can_read_direct once per iteration.
-
-    InMemoryDatasetID.can_read_direct iterates through every chunk in the InMemoryDataset.data_dict. If this
-    is inadvertently called inside a resize operation, it can lead to quadratic performance. This test checks
-    that `can_read_direct` is only called once per resize operation. See
-    https://github.com/deshaw/versioned-hdf5/issues/325 for more information.
-    """
-    path = tmp_path / "tmp.h5"
-    with h5py.File(path, "w") as f:
-        vf = VersionedHDF5File(f)
-        with vf.stage_version("r0") as sv:
-            sv.create_dataset("values", data=np.array([1, 2, 3]), chunks=(chunk_size,))
-
-        with mock.patch(
-            "versioned_hdf5.wrappers.InMemoryDatasetID.can_read_direct",
-            new_callable=mock.PropertyMock,
-        ) as mock_crd:
-            mock_crd.can_read_direct.return_value = True
-            for i in range(iterations):
-                with vf.stage_version(f"r{i+1}") as sv:
-                    # Grow the dataset
-                    sv["values"].resize((i + 3,))
-
-        assert mock_crd.call_count == iterations
-
-
-@mark.parametrize(
-    ("can_read_direct", "expected_calls"),
-    [
-        [True, 0],
-        [False, 0],
-        [None, 1],
-    ],
-)
-def test_dataset_getitem_can_read_direct(tmp_path, can_read_direct, expected_calls):
-    """Check that InMemoryDataset.get_index only reads directly when expected."""
-    chunk_size = 10
-
-    path = tmp_path / "tmp.h5"
-    with h5py.File(path, "w") as f:
-        vf = VersionedHDF5File(f)
-        with vf.stage_version("r0") as sv:
-            sv.create_dataset("values", data=np.array([1, 2, 3]), chunks=(chunk_size,))
-
-        with mock.patch(
-            "versioned_hdf5.wrappers.InMemoryDatasetID.can_read_direct",
-            new_callable=mock.PropertyMock,
-        ) as mock_crd:
-            mock_crd.can_read_direct.return_value = can_read_direct
-            with vf.stage_version("r1") as sv:
-                sv["values"].get_index(
-                    slice(None, None), can_read_direct=can_read_direct
-                )
-
-        assert mock_crd.call_count == expected_calls
-
-
 def test_insert_in_middle_multi_dim(tmp_path):
     """
     Test we correctly handle inserting into a multi-dimensional Dataset

--- a/versioned_hdf5/versions.py
+++ b/versioned_hdf5/versions.py
@@ -130,7 +130,7 @@ def commit_version(
         shape = None
         if isinstance(data, InMemoryDataset):
             shape = data.shape
-            if data.id._data_dict is None:
+            if not data.staged_changes.has_changes:
                 # The virtual dataset was not changed from the previous
                 # version. Just copy it to the new version directly.
                 assert data.name.startswith(prev_version.name + "/")
@@ -142,7 +142,7 @@ def commit_version(
                 for k, v in data.attrs.items():
                     data_copy.attrs[k] = v
                 continue
-            data = data.id._data_dict
+            data = data.data_dict
         if isinstance(data, dict):
             if chunks[name] is not None:
                 raise NotImplementedError("Specifying chunk size with dict data")

--- a/versioned_hdf5/wrappers.py
+++ b/versioned_hdf5/wrappers.py
@@ -11,7 +11,9 @@ import posixpath
 import textwrap
 import warnings
 from collections import defaultdict
-from typing import Iterable
+from collections.abc import Iterable
+from functools import cached_property
+from typing import Optional, Union
 from weakref import WeakValueDictionary
 
 import numpy as np
@@ -22,20 +24,11 @@ from h5py._hl import filters
 from h5py._hl.base import guess_dtype, phil, with_phil
 from h5py._hl.dataset import _LEGACY_GZIP_COMPRESSION_VALS
 from h5py._hl.selections import guess_shape
-from ndindex import (
-    BooleanArray,
-    ChunkSize,
-    Integer,
-    IntegerArray,
-    Slice,
-    Tuple,
-    ndindex,
-)
+from ndindex import ChunkSize, Slice, Tuple, ndindex
 
 from .backend import DEFAULT_CHUNK_SIZE
-from .slicetools import build_data_dict
+from .slicetools import build_slab_indices_and_offsets
 from .staged_changes import StagedChangesArray
-from .subchunk_map import as_subchunk_map
 
 _groups = WeakValueDictionary({})
 
@@ -606,8 +599,24 @@ class InMemoryDataset(Dataset):
         # gets deleted or closed.
         self.orig_bind = bind
         super().__init__(InMemoryDatasetID(bind.id), **kwargs)
+        self._init_kwargs = kwargs
         self._parent = parent
         self._attrs = dict(super().attrs)
+
+    @cached_property
+    def staged_changes(self) -> StagedChangesArray:
+        dcpl = self.id.get_create_plist()
+        slab_indices, slab_offsets = build_slab_indices_and_offsets(
+            dcpl, self.id.shape, self.id.chunks
+        )
+        return StagedChangesArray(
+            shape=self.id.shape,
+            chunk_size=self.id.chunks,
+            base_slabs=[self.id.raw_data],
+            slab_indices=slab_indices,
+            slab_offsets=slab_offsets,
+            fill_value=self.fillvalue,
+        )
 
     def __repr__(self):
         name = posixpath.basename(posixpath.normpath(self.name))
@@ -620,8 +629,8 @@ class InMemoryDataset(Dataset):
         )
 
     @property
-    def data_dict(self):
-        return self.id.data_dict
+    def data_dict(self) -> dict[Tuple, Slice | np.ndarray]:
+        return _staged_changes_to_data_dict(self.staged_changes)
 
     @property
     def compression(self):
@@ -653,25 +662,19 @@ class InMemoryDataset(Dataset):
         `casting` should be as in the numpy astype() method.
 
         """
-        if self.fillvalue is not None:
-            new_fillvalue = self.fillvalue.astype(dtype, casting=casting)
-        else:
-            new_fillvalue = None
-        new_data_dict = {}
-        for c, index in self.data_dict.copy().items():
-            if isinstance(index, Slice):
-                self[c.raw]
-                assert not isinstance(self.data_dict[c], Slice)
-            new_data_dict[c] = self.data_dict[c].astype(dtype, casting=casting)
-        new_dataset = InMemorySparseDataset.from_data_dict(
-            name,
-            new_data_dict,
-            shape=self.shape,
-            dtype=dtype,
+        fillvalue = super().fillvalue
+        init_kwargs = self._init_kwargs.copy()
+        if fillvalue is not None:
+            fillvalue = fillvalue.astype(dtype, casting=casting)
+            init_kwargs.setdefault("fillvalue", fillvalue)
+
+        new_dataset = InMemoryDataset(
+            bind=self.orig_bind,
             parent=parent,
-            chunks=self.chunks,
-            fillvalue=new_fillvalue,
+            **init_kwargs,
         )
+
+        new_dataset.staged_changes = self.staged_changes.astype(dtype, casting=casting)
         parent[name] = new_dataset
         return new_dataset
 
@@ -690,6 +693,14 @@ class InMemoryDataset(Dataset):
             elif "h5py_encoding" in self.dtype.metadata:
                 return self.dtype.type()
         return np.zeros((), dtype=self.dtype)[()]
+
+    @property
+    def shape(self):
+        return self.id.shape
+
+    @property
+    def size(self):
+        return int(np.prod(self.shape))
 
     @property
     def chunks(self):
@@ -733,34 +744,21 @@ class InMemoryDataset(Dataset):
         size = tuple(size)
         # === END CODE FROM h5py.Dataset.resize ===
 
-        old_shape = self.shape
-        data_dict = self.id.data_dict
-        can_read_direct = self.id.can_read_direct
-
-        old_shape_idx = Tuple(*[Slice(0, i) for i in old_shape])
-
-        new_data_dict = {}
-        # Read entire Dataset into in-memory array in one operation.
-        # Usually that's much faster than reading individual chunks.
-        old_data = self.get_index(old_shape_idx.raw, can_read_direct=can_read_direct)
-        # Now read chunks out of the array.
-        for chunk, _, index_raw in as_subchunk_map(old_shape_idx, size, self.chunks):
-            if chunk in data_dict:
-                new_data_dict[chunk] = data_dict[chunk]
-            else:
-                data = np.full(chunk.newshape(size), self.fillvalue, dtype=self.dtype)
-                data[index_raw] = old_data[chunk.raw]
-                new_data_dict[chunk] = data
-
-        self.id.data_dict = new_data_dict
+        self.staged_changes.resize(size)
         self.id.shape = size
 
     @with_phil
-    def get_index(
+    def __getitem__(
         self,
-        args: slice | Slice | Tuple | tuple | h5r.RegionReference,
-        new_dtype: str | None = None,
-        can_read_direct: bool | None = None,
+        args: (
+            str
+            | slice
+            | tuple
+            | list[int]
+            | list[bool]
+            | np.ndarray
+            | h5r.RegionReference
+        ),
     ) -> np.ndarray:
         """Read a slice from the HDF5 dataset given by the index.
 
@@ -770,17 +768,12 @@ class InMemoryDataset(Dataset):
 
         Parameters
         ----------
-        args : slice | Slice | Tuple | tuple | h5r.RegionReference
-            Index to read from the Dataset
-        new_dtype : str | None
-            Dtype of the returned array
-        can_read_direct : bool | None
-            True if we can read directly from the underlying hdf5 Dataset, False otherwise.
-            This should be the value of the InMemoryDatasetID instance's ``can_read_direct``
-            property for this Dataset.
+        args : any numpy one-dimensional or n-dimensional index | h5r.RegionReference
+            Index to read from the Dataset.
 
-            If None, ``self.id.can_read_direct`` is evaluated first to determine if data can
-            be read directly from the underlying dataset.
+            **Note:** more than one list/ndarray index will behave differently as numpy,
+            as it will be interpreted to pick the given indices independently on each
+            axis. Non-flat list/ndarray indices are not supported.
 
         Returns
         -------
@@ -798,15 +791,12 @@ class InMemoryDataset(Dataset):
             if len(names) == 1:
                 names = names[0]  # Read with simpler dtype of this field
             args = tuple(x for x in args if not isinstance(x, str))
-            return self.fields(names, _prior_dtype=new_dtype)[args]
-
-        if new_dtype is None:
-            new_dtype = self.dtype
-        mtype = h5t.py_create(new_dtype)
+            return self.fields(names)[args]
 
         # === Special-case region references ====
 
         if len(args) == 1 and isinstance(args[0], h5r.RegionReference):
+            mtype = h5t.py_create(self.dtype)
             obj = h5r.dereference(args[0], self.id)
             if obj != self.id:
                 raise ValueError("Region reference must point to this dataset")
@@ -815,8 +805,8 @@ class InMemoryDataset(Dataset):
             mshape = guess_shape(sid)
             if mshape is None:
                 # 0D with no data (NULL or deselected SCALAR)
-                return Empty(new_dtype)
-            out = np.empty(mshape, dtype=new_dtype)
+                return Empty(self.dtype)
+            out = np.empty(mshape, self.dtype)
             if out.size == 0:
                 return out
 
@@ -827,42 +817,7 @@ class InMemoryDataset(Dataset):
 
         # === END CODE FROM h5py.Dataset.__getitem__ ===
 
-        idx = ndindex(args).expand(self.shape)
-
-        if can_read_direct is None:
-            can_read_direct = self.id.can_read_direct
-
-        if can_read_direct:
-            return super().__getitem__(idx.raw)
-
-        arr = np.ndarray(idx.newshape(self.shape), new_dtype, order="C")
-
-        for chunk, arr_idx_raw, index_raw in as_subchunk_map(
-            idx, self.shape, self.chunks
-        ):
-            if chunk not in self.id.data_dict:
-                self.id.data_dict[chunk] = np.broadcast_to(
-                    self.fillvalue, chunk.newshape(self.shape)
-                )
-            elif isinstance(self.id.data_dict[chunk], Slice):
-                raw_idx = tuple(
-                    [self.id.data_dict[chunk].raw]
-                    + [slice(0, len(i)) for i in chunk.args[1:]]
-                )
-                self.id.data_dict[chunk] = self.id._read_chunk(raw_idx)
-
-            if self.id.data_dict[chunk].size != 0:
-                arr[arr_idx_raw] = self.id.data_dict[chunk][index_raw]
-
-        # Return arr as a scalar if it is shape () (matching h5py)
-        return arr[()]
-
-    @with_phil
-    def __getitem__(
-        self,
-        args: slice | Slice | Tuple | tuple | h5r.RegionReference,
-    ) -> np.ndarray:
-        return self.get_index(args)
+        return self.staged_changes[args]
 
     @with_phil
     def __setitem__(self, args, val):
@@ -983,27 +938,7 @@ class InMemoryDataset(Dataset):
             mtype = None
 
         # === END CODE FROM h5py.Dataset.__setitem__ ===
-
-        idx = ndindex(args).reduce(self.shape)
-
-        val = np.broadcast_to(val, idx.newshape(self.shape))
-
-        for c, val_idx_raw, index_raw in as_subchunk_map(idx, self.shape, self.chunks):
-            if c not in self.id.data_dict:
-                # Broadcasted arrays do not actually consume memory
-                fill = np.broadcast_to(self.fillvalue, c.newshape(self.shape))
-                self.id.data_dict[c] = fill.astype(self.dtype)
-            elif isinstance(self.id.data_dict[c], Slice):
-                raw_idx = tuple(
-                    [self.id.data_dict[c].raw] + [slice(0, len(i)) for i in c.args[1:]]
-                )
-                self.id.data_dict[c] = self.id._read_chunk(raw_idx)
-
-            if self.id.data_dict[c].size != 0:
-                if not self.id.data_dict[c].flags.writeable:
-                    # self.id.data_dict[c] is a broadcasted array from above
-                    self.id.data_dict[c] = self.id.data_dict[c].copy()
-                self.id.data_dict[c][index_raw] = val[val_idx_raw]
+        self.staged_changes[args] = val
 
 
 class DatasetLike:
@@ -1221,11 +1156,16 @@ class InMemorySparseDataset(DatasetLike):
         self.chunks = ChunkSize(chunks)
         self.parent = parent
 
-        # This works like a mix between InMemoryArrayDataset and
-        # InMemoryDatasetID. Explicit array data is stored in a data_dict like
-        # with InMemoryDatasetID, but unlike it, missing data (which equals
-        # the fill value) is omitted.
-        self.data_dict = {}
+        self.staged_changes = StagedChangesArray.full(
+            shape=shape,
+            chunk_size=tuple(chunks),
+            dtype=dtype,
+            fill_value=self.fillvalue,
+        )
+
+    @property
+    def data_dict(self) -> dict[Tuple, Slice | np.ndarray]:
+        return _staged_changes_to_data_dict(self.staged_changes)
 
     def as_dtype(self, name, dtype, parent, casting="unsafe"):
         """
@@ -1239,39 +1179,18 @@ class InMemorySparseDataset(DatasetLike):
             new_fillvalue = self.fillvalue.astype(dtype, casting=casting)
         else:
             new_fillvalue = None
-        new_data_dict = {}
-        for c, index in self.data_dict.copy().items():
-            new_data_dict[c] = self.data_dict[c].astype(dtype, casting=casting)
 
-        return self.from_data_dict(
-            name,
-            new_data_dict,
+        out = type(self)(
+            name=name,
+            shape=(),
             dtype=dtype,
             parent=parent,
-            fillvalue=new_fillvalue,
             chunks=self.chunks,
-            shape=self.shape,
+            fillvalue=new_fillvalue,
         )
-
-    @classmethod
-    def from_data_dict(
-        cls, name, data_dict, *, shape, dtype, parent, chunks, fillvalue=None
-    ):
-        """
-        Create a InMemorySparseDataset from a data dict.
-
-        This does not do any consistency checks with the metadata provide.
-        """
-        dataset = cls(
-            name,
-            shape=shape,
-            dtype=dtype,
-            parent=parent,
-            chunks=chunks,
-            fillvalue=fillvalue,
-        )
-        dataset.data_dict = data_dict
-        return dataset
+        out.staged_changes = self.staged_changes.astype(dtype, casting=casting)
+        out.shape = self.shape
+        return out
 
     @classmethod
     def from_dataset(cls, dataset, parent=None):
@@ -1297,49 +1216,35 @@ class InMemorySparseDataset(DatasetLike):
             size[axis] = newlen
 
         size = tuple(size)
-        if len(size) > 1:
-            raise NotImplementedError("More than one dimension is not yet supported")
+        self.staged_changes.resize(size)
         self.shape = size
 
     def __getitem__(self, index):
-        idx = ndindex(index).reduce(self.shape)
-
-        newshape = idx.newshape(self.shape)
-        arr = np.full(newshape, self.fillvalue, dtype=self.dtype)
-
-        for c, arr_idx_raw, chunk_idx_raw in as_subchunk_map(
-            idx, self.shape, self.chunks
-        ):
-            if c not in self.data_dict:
-                fill = np.broadcast_to(self.fillvalue, c.newshape(self.shape))
-                self.data_dict[c] = fill
-
-            if self.data_dict[c].size != 0:
-                arr[arr_idx_raw] = self.data_dict[c][chunk_idx_raw]
-
-        # Return arr as a scalar if it is shape () (matching h5py)
-        return arr[()]
+        return self.staged_changes[index]
 
     def __setitem__(self, index, value):
         self.parent._check_committed()
+        self.staged_changes[index] = value
 
-        idx = ndindex(index).reduce(self.shape)
 
-        val = np.broadcast_to(value, idx.newshape(self.shape))
+def _staged_changes_to_data_dict(
+    staged_changes: StagedChangesArray,
+) -> dict[Tuple, Slice | np.ndarray]:
+    """Transitional hack that converts a StagedChangsArray to a legacy data_dict.
 
-        for c, val_idx_raw, chunk_idx_raw in as_subchunk_map(
-            idx, self.shape, self.chunks
-        ):
-            if c not in self.data_dict:
-                # Broadcasted arrays do not actually consume memory
-                fill = np.broadcast_to(self.fillvalue, c.newshape(self.shape))
-                self.data_dict[c] = fill
+    This was introduced when replacing the legacy system, which was wholly designed
+    around the data_dict, with StagedChangesArray and it allowed not to modify from the
+    get go all the code that is triggered upon commit.
 
-            if self.data_dict[c].size != 0:
-                if not self.data_dict[c].flags.writeable:
-                    # self.data_dict[c] is a broadcasted array from above
-                    self.data_dict[c] = self.data_dict[c].copy()
-                self.data_dict[c][chunk_idx_raw] = val[val_idx_raw]
+    We intend to clean this up eventually.
+    """
+    # InMemoryDataset has exactly one raw_data buffer underlying
+    # InMemorySparseDataset has none
+    assert staged_changes.n_base_slabs < 2
+    return {
+        Tuple(*k): Slice(v[0]) if isinstance(v, tuple) else v
+        for k, _, v in staged_changes.changes()
+    }
 
 
 class DatasetWrapper(DatasetLike):
@@ -1372,11 +1277,9 @@ class DatasetWrapper(DatasetLike):
 class InMemoryDatasetID(h5d.DatasetID):
     def __init__(self, _id):
         # super __init__ is handled by DatasetID.__cinit__ automatically
-        self._data_dict = None
         with phil:
             sid = self.get_space()
             self._shape = sid.get_simple_extent_dims()
-        self._reshaped = False
 
         attr = h5a.open(self, b"raw_data")
         htype = h5t.py_create(attr.dtype)
@@ -1396,51 +1299,6 @@ class InMemoryDatasetID(h5d.DatasetID):
         dcpl.get_fill_value(fillvalue_a)
         self.fillvalue = fillvalue_a[0]
 
-    @property
-    def data_dict(self):
-        if self._data_dict is None:
-            dcpl = self.get_create_plist()
-
-            is_virtual: bool = dcpl.get_layout() == h5d.VIRTUAL
-
-            if not is_virtual:
-                # A dataset created with only a fillvalue will be nonvirtual,
-                # since create_virtual_dataset makes a nonvirtual dataset when
-                # there are no virtual sources.
-                self._data_dict = {}
-            # Same as dataset.get_virtual_sources
-            elif 0 in self.shape:
-                # Work around https://github.com/h5py/h5py/issues/1660
-                empty_idx = Tuple().expand(self.shape)
-                self._data_dict = {empty_idx: Slice()}
-            else:
-                self._data_dict = build_data_dict(dcpl, self.raw_data.name)
-
-        return self._data_dict
-
-    @data_dict.setter
-    def data_dict(self, value):
-        self._data_dict = value
-
-    @property
-    def can_read_direct(self) -> bool:
-        """Check whether reading directly from the underlying dataset is okay.
-
-        Returns
-        -------
-        bool
-            If this is True, then h5py.Dataset.__getitem__ can be used, which may
-            be faster than InMemoryDataset.__getitem__. This will happen in
-            particular when reading a read-only dataset.
-        """
-        if self._data_dict is not None and any(
-            isinstance(i, np.ndarray) for i in self._data_dict.values()
-        ):
-            return False
-        if self._reshaped:
-            return False
-        return True
-
     def set_extent(self, shape):
         raise NotImplementedError("Resizing an InMemoryDataset other than via resize()")
 
@@ -1451,10 +1309,6 @@ class InMemoryDatasetID(h5d.DatasetID):
     @shape.setter
     def shape(self, size):
         self._shape = size
-        self._reshaped = True
-
-    def _read_chunk(self, chunk_idx):
-        return self.raw_data[chunk_idx]
 
     def write(self, mspace, fspace, arr_obj, mtype=None, dxpl=None):
         raise NotImplementedError(


### PR DESCRIPTION
This PR has been broken down into several stages - read below.

`versioned_hdf5.wrappers.InMemoryDataset` is plagued by slowness caused by the control code, both because the control code itself is very slow and because it calls `h5py.Dataset.__getitem__` on the raw_data independently for every single chunk.

This PR completely replaces the internal implementation of InMemoryDataset by instead performing a fast inner loop of calls to H5DRead, directly to the libhdf5 C library. The control logic - the generation of the index information needed to perform the transfers, which was previously performed by `build_data_dict` and `as_subchunk_map` - has also been completely rewritten and is now much more aggressively cythonized.

This new design introduces a helper class, `StagedChangesArray`, to which `InMemoryDataset` is now a fairly thin wrapper, and which holds the modified chunks. This class has minimal external API and is completely abstracted from h5py. Internally, all the control logic is encapsulated by a series of `*Plan` classes (`GetItemPlan`, `SetItemPlan`, etc.), each formulating what actions need to be performed in order to evade a user request (`__getitem__`, `__setitem__`, etc.). On each user request,
1. `StagedChangesArray` formulates a plan;
2. executes it, possibly mutating its internal state;
3. discards the plan.

## Other major design changes
In master `__setitem__` first loads all impacted chunks into memory, in the off chance that they are not wholly covered by the parameter index, and then updates them. In this PR, this happens exclusively for the chunks that are not wholly covered by the index of `__setitem__`.
In other words, `a[:] = 1` in master loads the whole dataset into memory if it's not in memory already, whereas in this PR it never touches the disk.

Analogously, in master `resize()` reads the whole dataset from disk. This no longer happens in this PR, which only loads the edge chunks if the shape is not exactly divisible by chunk_size.

There is no longer any direct `__getitem__` call to the virtual dataset. It was found to be exceptionally slow, due to deficiencies in the algorithm in libhdf5 C itself, and has been ditched.
A previous redesign, #370, had to be scrapped due to this limitation.
It remains possible to obtain a plain-h5py virtual dataset by accessing the address
 `_version_data/versions/<version name>/<dataset name>`. Notably, this can be performed in any language that offers libhdf5 bindings, not just python.

There is no longer cache-on-read: any an all caching is performed by libhdf5; the only data in memory within the StagedChangesArray are the chunks that the user intentfully modified.

## Status
- [x] implementation
- [x] all pre-existing unit tests pass
- [x] additional unit tests for the various subsystems (slicetools.pyx, subchunk_map.py)
- [x] additional unit tests for staged_changes.py
- [x] high level documentation
- [x] break PR up into stages to simplify code review
- [x] clean up legacy code
- [x] ad-hoc performance benchmarks
- [ ] review published benchmarks
- [x] demo notebooks

## Demo and benchmakrs
See jupyter notebooks (not to be merged into master) at https://github.com/crusaderky/versioned-hdf5/tree/staged_changes_extras

## PRs chain
This change is in excess of 6000 lines.
For the sake of sanity, it has been broken down into multiple PRs:

- #374
- #378
- #382 
- #385 
- #384 
- #387
- #372
- #391 
- #392 
- #388
- #373
- #390
- #393 
- #394
- #386 (this PR): Integration: hot-swap the implementation of InMemoryDataset. Until this PR, all of the above work lies dormant.
- (blocked by this PR) #395

## Known issues
Slices with step>1, as well as fancy indices which can be locally represented as such, can be slower than in master. The reason is that they're very slow in libhdf5, whereas master was (unconsciously?) side-stepping the issue by loading up whole chunks and then applying the strided slice to the numpy chunks in memory.

This is, technically, a regression only when calling `__getitem__` after `__setitem__`. In master, if you call `__getitem__` on an unmodified dataset, you access the virtual dataset, which is even slower as the issue with step>1 interplays with libhdf5 cache size, and the whole virtual dataset is always larger than the hdf5 cache.

This issue is mitigated, but not solved, by making sure that the [chunk cache](https://docs.h5py.org/en/stable/high/file.html#chunk-cache) is larger than a single chunk. 

Compared to a single contiguous read (potentially followed by strided copy in pure numpy), the performance of reading with step>1 directly from hdf5 is:

- up to 12x slower, if a chunk fits in the cache (1MB by default)
- up to 150x slower, for larger chunks

Master shows a 120x slowdown, regardless of chunk size, but only when reading from the virtual dataset (no changes).

Implementing cache-on-read would effectively work around this issue, but it's not trivial given the current design (the easiest way to do it is to first move hashing into the StagedChangesArray, which makes a lot of sense in its own right anyway).
