### PR TITLE
[InMemoryDataset redesign] read_many_slices_param

### DIFF
--- a/versioned_hdf5/subchunk_map.pxd
+++ b/versioned_hdf5/subchunk_map.pxd
@@ -11,6 +11,7 @@ cdef class IndexChunkMapper:
     cdef readonly hsize_t last_chunk_size
 
     cpdef tuple[object, object, object] chunk_submap(self, hsize_t chunk_idx)
+    cpdef tuple[object, object | None] read_many_slices_params(self)
 
     cpdef object chunks_indexer(self)
     cpdef object whole_chunks_idxidx(self)
@@ -19,3 +20,34 @@ cdef class IndexChunkMapper:
     cdef tuple[hsize_t, hsize_t] _chunk_start_stop(
         self, hsize_t chunk_idx
     ) noexcept nogil
+
+
+cpdef hsize_t[:, :, :] read_many_slices_params_nd(
+    transfer_type,  # TransferType Python enum
+    list[IndexChunkMapper] mappers,
+    hsize_t[:, :] chunk_idxidx,
+    hsize_t[:] src_slab_offsets,
+    hsize_t[:] dst_slab_offsets,
+)
+
+
+# At the moment of writing, Cython enums are unusable in pure python mode:
+# https://github.com/cython/cython/issues/4252
+# The below is for user reference only and not actually used in the code.
+
+cdef enum ReadManySlicesColumn:
+    """Axis 1 of the return value of IndexChunkMapper.read_many_slices_params"""
+    chunk_sub_start = 0
+    value_sub_start = 1
+    count = 2
+    chunk_sub_stride = 3
+    value_sub_stride = 4
+
+
+cdef enum ReadManySlicesNDColumn:
+    """Axis 1 of the return value of read_many_slices_params_nd"""
+    src_start = 0
+    dst_start = 1
+    count_ = 2  # Two enums can't define the same label
+    src_stride = 3
+    dst_stride = 4

--- a/versioned_hdf5/subchunk_map.py
+++ b/versioned_hdf5/subchunk_map.py
@@ -142,7 +142,7 @@ class IndexChunkMapper:
 
         **Basic indexing**
 
-        For basic indexing and in simple secial cases of fancy indexes, there is a
+        For basic indexing and in simple special cases of fancy indexes, there is a
         1:1 correlation between selected chunks and slices to tranfer. In this
 
         len(slices) == len(self.chunk_indices).
@@ -576,17 +576,19 @@ class IntegerArrayMapper(IndexChunkMapper):
         slices = np.empty((max_rows, 5), dtype=np_hsize_t)
         slices_v: hsize_t[:, :] = slices
 
-        assert max_rows >= n_sel_chunks
-        if max_rows > n_sel_chunks:
-            chunks_to_slices = np.empty(n_sel_chunks + 1, dtype=np_hsize_t)
-            chunk_to_slices_v: hsize_t[:] = chunks_to_slices
-        else:
+        # Each selected chunk containst at least one point by construction
+        assert n_sel_chunks <= max_rows
+        if n_sel_chunks == max_rows:
             # Because we know we are selecting at least one point per chunk of
             # chunk_indices, then if there are exactly as many chunks as there are
             # points we know that each point falls in a separate chunk and there will be
             # exactly one slice(idx[i], idx[i] + 1, 1) per chunk, so there is no need
             # for the 1:N mapping table chunk_to_slices.
             chunks_to_slices = None
+        else:
+            # At least one chunk contains more than one point
+            chunks_to_slices = np.empty(n_sel_chunks + 1, dtype=np_hsize_t)
+            chunk_to_slices_v: hsize_t[:] = chunks_to_slices
 
         if self.is_ascending:
             starts_stops = np.empty((n_sel_chunks, 2), dtype=np_hsize_t)

--- a/versioned_hdf5/tests/test_subchunk_map.py
+++ b/versioned_hdf5/tests/test_subchunk_map.py
@@ -260,10 +260,6 @@ def test_read_many_slices_param(args):
 
     actual_view = actual[None] if actual.shape == () else actual
 
-    # print("=" * 80)
-    # print(f"{idx=} {chunks=} {shape=} {slab_offsets=}")
-    # print(slices)
-
     read_many_slices(
         src=slab,
         dst=actual_view,
@@ -338,13 +334,6 @@ def test_read_many_slices_param_nd(args):
         src_stride=getitem_slices_nd[:, 3, :],
         dst_stride=getitem_slices_nd[:, 4, :],
     )
-
-    # print("=" * 80)
-    # print(f"{idx=} {chunks=} {shape=} {slab_offsets=}")
-    # print("slab=\n", slab)
-    # print(f"slices_nd=\n{np.asarray(getitem_slices_nd)}")
-    # print("expect=\n", expect)
-    # print("dst=\n", getitem_dst)
 
     assert_array_equal(getitem_dst, expect)
 

--- a/versioned_hdf5/tests/test_subchunk_map.py
+++ b/versioned_hdf5/tests/test_subchunk_map.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import itertools
 from typing import Any
 
 import hypothesis
@@ -9,7 +10,16 @@ from hypothesis import given
 from hypothesis import strategies as st
 from numpy.testing import assert_array_equal
 
-from ..subchunk_map import DROP_AXIS, SliceMapper, as_subchunk_map, index_chunk_mappers
+from ..cytools import np_hsize_t
+from ..slicetools import read_many_slices
+from ..subchunk_map import (
+    DROP_AXIS,
+    SliceMapper,
+    TransferType,
+    as_subchunk_map,
+    index_chunk_mappers,
+    read_many_slices_params_nd,
+)
 
 max_examples = 10_000
 
@@ -185,6 +195,229 @@ def test_chunks_indexer(args):
             assert not coverage.all(), "partial chunk is wholly covered"
 
     assert_array_equal(actual, expect)
+
+
+@pytest.mark.slow
+@given(idx_shape_chunks_st(max_ndim=1))
+@hypothesis.settings(max_examples=max_examples, deadline=None)
+def test_read_many_slices_param(args):
+    idx, shape, chunks = args
+    _, mappers = index_chunk_mappers(idx, shape, chunks)
+    if not mappers:
+        return  # Early exit for empty index
+    assert len(shape) == len(chunks) == len(mappers) == 1
+    dset_size = shape[0]
+    chunk_size = chunks[0]
+    mapper = mappers[0]
+    assert mapper.dset_size == shape[0]
+    assert mapper.chunk_size == chunks[0]
+
+    source = np.arange(1, dset_size + 1, dtype=np.int32)
+    expect = source[idx]
+    actual = np.zeros_like(expect)
+
+    slab_offsets = np.arange(0, dset_size, chunk_size, dtype=np_hsize_t)
+    assert len(slab_offsets) == mapper.n_chunks
+
+    # Randomize the order of the chunks on the slab.
+    # Note that the last chunk may be smaller than chunk_size,
+    # so we may end up with an area of the slab full off zeros.
+    slab_offsets = np.random.permutation(slab_offsets)
+    slab = np.zeros(mapper.n_chunks * chunk_size, dtype=source.dtype)
+    for i, offset in enumerate(slab_offsets.tolist()):
+        chunk = source[i * chunk_size : (i + 1) * chunk_size]
+        slab[offset : offset + len(chunk)] = chunk
+
+    n_sel_chunks = len(mapper.chunk_indices)
+    slab_offsets = slab_offsets[mapper.chunks_indexer()]
+    assert len(slab_offsets) == n_sel_chunks
+
+    slices, chunks_to_slices = mapper.read_many_slices_params()
+    if chunks_to_slices is None:
+        assert slices.shape == (n_sel_chunks, 5)
+    else:
+        # Test that we are not generating a 1:N mapping in the special case of a fancy
+        # index that contains exactly one point per chunk, and therefore
+        # read_many_slices() needs to transfer exactly one slice per chunk;
+        # e.g. chunk_size=10, idx=[3, 15, 21].
+        assert slices.shape[0] > n_sel_chunks
+        assert slices.shape[1] == 5
+
+        assert chunks_to_slices.shape == (n_sel_chunks + 1,)
+        assert chunks_to_slices[0] == 0
+        assert chunks_to_slices[-1] == len(slices)
+
+        # Replicate slab_offsets for each slice of each chunk
+        slab_offsets_idx = []
+        for i in range(n_sel_chunks):
+            start = chunks_to_slices[i]
+            stop = chunks_to_slices[i + 1]
+            assert 0 <= start < stop <= len(slices)
+            count = stop - start
+            slab_offsets_idx += [i] * count
+        slab_offsets = slab_offsets[slab_offsets_idx]
+    assert len(slab_offsets) == len(slices)
+
+    actual_view = actual[None] if actual.shape == () else actual
+
+    # print("=" * 80)
+    # print(f"{idx=} {chunks=} {shape=} {slab_offsets=}")
+    # print(slices)
+
+    read_many_slices(
+        src=slab,
+        dst=actual_view,
+        src_start=slices[:, 0:1] + slab_offsets[:, None],
+        dst_start=slices[:, 1:2],
+        count=slices[:, 2:3],
+        src_stride=slices[:, 3:4],
+        dst_stride=slices[:, 4:5],
+    )
+
+    assert_array_equal(actual, expect)
+
+
+@pytest.mark.slow
+@given(idx_shape_chunks_st())
+@hypothesis.settings(max_examples=max_examples, deadline=None)
+def test_read_many_slices_param_nd(args):
+    idx, shape, chunks = args
+    _, mappers = index_chunk_mappers(idx, shape, chunks)
+    if not mappers:
+        return  # Early exit for empty index
+
+    source = np.arange(1, np.prod(shape) + 1, dtype=np.int32).reshape(shape)
+    expect = source[idx]
+
+    chunk_idxidx = np.array(
+        list(itertools.product(*[list(range(len(m.chunk_indices))) for m in mappers])),
+        dtype=np_hsize_t,
+    )
+
+    # Generate the slab and the slab_offsets.
+    # We don't care to populate the slab with the full contents of the source dataset,
+    # we just need the chunks impacted by the index.
+    n_chunks = np.prod([m.n_chunks for m in mappers])
+    slab = np.zeros((n_chunks * chunks[0], *chunks[1:]), dtype=source.dtype)
+    slab_offsets = np.random.choice(  # randomize slab order
+        np.arange(0, n_chunks * chunks[0], chunks[0], dtype=np_hsize_t),
+        size=len(chunk_idxidx),
+        replace=False,
+    )
+    for chunk_idxidx_i, slab_offset_i in zip(chunk_idxidx, slab_offsets.tolist()):
+        source_idx = []
+        for j, chunk_idxidx_ij in enumerate(chunk_idxidx_i):
+            chunk_idx_ij = int(mappers[j].chunk_indices[chunk_idxidx_ij])
+            source_idx.append(
+                slice(start := chunk_idx_ij * chunks[j], start + chunks[j])
+            )
+        chunk = source[tuple(source_idx)]
+        # chunk may be smaller than the chunk size along the edges
+        slab[slab_offset_i:][tuple(slice(c) for c in chunk.shape)] = chunk
+
+    # Can't pass "hsize_t[:] | None" to cythonized functions
+    DUMMY_SLAB_OFFSETS = np.empty(0, dtype=np_hsize_t)
+
+    getitem_dst = np.zeros_like(expect)
+    getitem_dst_view = getitem_dst[tuple(m.value_view_idx for m in mappers)]
+
+    # __getitem__
+    getitem_slices_nd = read_many_slices_params_nd(
+        TransferType.getitem,
+        mappers,
+        chunk_idxidx,
+        src_slab_offsets=slab_offsets,
+        dst_slab_offsets=DUMMY_SLAB_OFFSETS,
+    )
+    read_many_slices(
+        src=slab,
+        dst=getitem_dst_view,
+        src_start=getitem_slices_nd[:, 0, :],
+        dst_start=getitem_slices_nd[:, 1, :],
+        count=getitem_slices_nd[:, 2, :],
+        src_stride=getitem_slices_nd[:, 3, :],
+        dst_stride=getitem_slices_nd[:, 4, :],
+    )
+
+    # print("=" * 80)
+    # print(f"{idx=} {chunks=} {shape=} {slab_offsets=}")
+    # print("slab=\n", slab)
+    # print(f"slices_nd=\n{np.asarray(getitem_slices_nd)}")
+    # print("expect=\n", expect)
+    # print("dst=\n", getitem_dst)
+
+    assert_array_equal(getitem_dst, expect)
+
+    # Now do it again in the other way for __setitem__
+    setitem_dst_slab = np.zeros_like(slab)
+    setitem_slices_nd = read_many_slices_params_nd(
+        TransferType.setitem,
+        mappers,
+        chunk_idxidx,
+        src_slab_offsets=DUMMY_SLAB_OFFSETS,
+        dst_slab_offsets=slab_offsets,
+    )
+    read_many_slices(
+        src=getitem_dst_view,
+        dst=setitem_dst_slab,
+        src_start=setitem_slices_nd[:, 0, :],
+        dst_start=setitem_slices_nd[:, 1, :],
+        count=setitem_slices_nd[:, 2, :],
+        src_stride=setitem_slices_nd[:, 3, :],
+        dst_stride=setitem_slices_nd[:, 4, :],
+    )
+    getitem_dst2 = np.zeros_like(getitem_dst)
+    getitem_dst_view2 = getitem_dst2[tuple(m.value_view_idx for m in mappers)]
+    read_many_slices(
+        src=setitem_dst_slab,
+        dst=getitem_dst_view2,
+        src_start=getitem_slices_nd[:, 0, :],
+        dst_start=getitem_slices_nd[:, 1, :],
+        count=getitem_slices_nd[:, 2, :],
+        src_stride=getitem_slices_nd[:, 3, :],
+        dst_stride=getitem_slices_nd[:, 4, :],
+    )
+    assert_array_equal(getitem_dst2, expect)
+
+    # And finally slab-to-slab
+    slab2slab_dst = np.zeros_like(slab)
+    dst_slab_offsets = np.random.permutation(slab_offsets)
+    slab2slab_slices_nd = read_many_slices_params_nd(
+        TransferType.slab_to_slab,
+        mappers,
+        chunk_idxidx,
+        src_slab_offsets=slab_offsets,
+        dst_slab_offsets=dst_slab_offsets,
+    )
+    read_many_slices(
+        src=slab,
+        dst=slab2slab_dst,
+        src_start=slab2slab_slices_nd[:, 0, :],
+        dst_start=slab2slab_slices_nd[:, 1, :],
+        count=slab2slab_slices_nd[:, 2, :],
+        src_stride=slab2slab_slices_nd[:, 3, :],
+        dst_stride=slab2slab_slices_nd[:, 4, :],
+    )
+    # In order to test the new slab, read from it with __getitem__
+    getitem_slices_nd3 = read_many_slices_params_nd(
+        TransferType.getitem,
+        mappers,
+        chunk_idxidx,
+        src_slab_offsets=dst_slab_offsets,
+        dst_slab_offsets=DUMMY_SLAB_OFFSETS,
+    )
+    getitem_dst3 = np.zeros_like(getitem_dst)
+    getitem_dst_view3 = getitem_dst3[tuple(m.value_view_idx for m in mappers)]
+    read_many_slices(
+        src=slab2slab_dst,
+        dst=getitem_dst_view3,
+        src_start=getitem_slices_nd3[:, 0, :],
+        dst_start=getitem_slices_nd3[:, 1, :],
+        count=getitem_slices_nd3[:, 2, :],
+        src_stride=getitem_slices_nd3[:, 3, :],
+        dst_stride=getitem_slices_nd3[:, 4, :],
+    )
+    assert_array_equal(getitem_dst3, expect)
 
 
 def test_simplify_indices():


### PR DESCRIPTION
- Part of #386 
- Blocked by and incorporates #388 
- Blocked by and incorporates #373

Add new function `read_many_slices_params_nd()`.

This internally uses a helper function `IndexChunkMapper.read_many_slices_param()`, which duplicates functionality from `IndexChunkMapper.chunk_submap()`and will eventually replace it once `as_subchunk_map()` is no longer used.

