### PR TITLE
[InMemoryDataset redesign] Harden validation in subchunk_map

### DIFF
--- a/versioned_hdf5/subchunk_map.py
+++ b/versioned_hdf5/subchunk_map.py
@@ -17,6 +17,7 @@ import numpy as np
 # indexing hdf5 datasets on disk wider than 2**31
 from cython import bint
 from ndindex import ChunkSize, Slice, Tuple, ndindex
+from ndindex.ellipsis import ellipsis
 from numpy.typing import NDArray
 
 from .cytools import ceil_a_over_b, count2stop, np_hsize_t, smallest_step_after
@@ -135,12 +136,12 @@ class SliceMapper(IndexChunkMapper):
         dset_size: hsize_t,
         chunk_size: hsize_t,
     ):
+        if idx.step <= 0:
+            raise NotImplementedError("Slice step must be positive")
+
         self.start = idx.start
         self.stop = idx.stop
         self.step = idx.step
-
-        if self.step <= 0:
-            raise NotImplementedError(f"Slice step must be positive not {self.step}")
 
         if self.step > chunk_size:
             n = (self.stop - self.start + self.step - 1) // self.step
@@ -270,12 +271,25 @@ def index_chunk_mappers(
 
     d: hsize_t
     n: hsize_t
+    fancy_count = 0
     mappers = []
 
     # Process the prefix of the axes which idx selects on
     for i, d, n in zip(idx.args, shape[:idx_len], chunk_size[:idx_len]):
-        i = i.reduce((d,))
-        mappers.append(_index_to_mapper(i.raw, d, n))
+        if isinstance(i, ellipsis):  # ndindex wrapper for Ellipsis; reduces erratically
+            raise NotImplementedError("Ellipsis not supported")
+
+        i = i.reduce((d,)).raw
+
+        # _index_to_mapper tentatively simplifies fancy indices to slices.
+        # However, it would be a mistake to simplify [[0, 1], [0, 1]] to [:2, :2]!
+        if isinstance(i, np.ndarray):
+            fancy_count += 1
+            if fancy_count > 1:
+                raise NotImplementedError("Multiple fancy indices")
+
+        mapper = _index_to_mapper(i, d, n)
+        mappers.append(mapper)
 
     # Handle the remaining suffix axes on which we did not select, we still need to
     # break them up into chunks.
@@ -302,7 +316,11 @@ def _index_to_mapper(idx, dset_size: hsize_t, chunk_size: hsize_t) -> IndexChunk
     if isinstance(idx, slice):
         return SliceMapper(idx, dset_size, chunk_size)
 
-    raise NotImplementedError(f"index type {type(idx)} not supported")
+    if idx is None:
+        raise NotImplementedError(f"None/np.newaxis not supported")
+
+    # Unreachable: ndindex preprocessing should have caught this
+    raise TypeError(f"Bad index {idx} of type {type(idx)}")  # pragma: nocover
 
 
 def as_subchunk_map(

--- a/versioned_hdf5/tests/test_subchunk_map.py
+++ b/versioned_hdf5/tests/test_subchunk_map.py
@@ -10,7 +10,7 @@ from hypothesis import strategies as st
 from hypothesis.extra import numpy as stnp
 from numpy.testing import assert_array_equal
 
-from ..subchunk_map import as_subchunk_map
+from ..subchunk_map import as_subchunk_map, index_chunk_mappers
 
 max_examples = 10_000
 
@@ -133,3 +133,52 @@ def test_as_subchunk_map(args):
         actual[value_sub_idx] = source[chunk_idx][chunk_sub_idx]
 
     assert_array_equal(actual, expect)
+
+
+def test_invalid_indices():
+    with pytest.raises(IndexError, match="too many indices"):
+        index_chunk_mappers((0, 0), (4,), (2,))
+    with pytest.raises(IndexError, match="out of bounds"):
+        index_chunk_mappers((4,), (4,), (2,))
+    with pytest.raises(IndexError, match="out of bounds"):
+        index_chunk_mappers((-5,), (4,), (2,))
+    with pytest.raises(IndexError, match="out of bounds"):
+        index_chunk_mappers(([4],), (4,), (2,))
+    with pytest.raises(IndexError, match="out of bounds"):
+        index_chunk_mappers(([-5],), (4,), (2,))
+    with pytest.raises(IndexError, match="boolean index did not match indexed array"):
+        index_chunk_mappers(([True] * 3,), (4,), (2,))
+    with pytest.raises(IndexError, match="boolean index did not match indexed array"):
+        index_chunk_mappers(([True] * 5,), (4,), (2,))
+
+    with pytest.raises(IndexError, match="valid indices"):
+        index_chunk_mappers("foo", (4,), (2,))
+    with pytest.raises(ValueError, match="step"):
+        index_chunk_mappers(slice(None, None, 0), (4,), (2,))
+
+    with pytest.raises(NotImplementedError, match="step"):
+        index_chunk_mappers(slice(None, None, -1), (4,), (2,))
+    with pytest.raises(NotImplementedError, match="None"):
+        index_chunk_mappers(None, (4,), (2,))
+    with pytest.raises(NotImplementedError, match="newaxis"):
+        index_chunk_mappers(np.newaxis, (4,), (2,))
+    with pytest.raises(NotImplementedError, match="Ellipsis"):
+        index_chunk_mappers((..., 0), (4, 4), (2, 2))
+
+    # Fancy indices are tentatively simplified to slices. However, it would be a
+    # mistake to simplify [[0, 1], [0, 1]] to [:2, :2]!
+    with pytest.raises(NotImplementedError, match="Multiple fancy indices"):
+        index_chunk_mappers(([0, 1], [0, 1]), (4, 4), (2, 2))
+    with pytest.raises(NotImplementedError, match="Multiple fancy indices"):
+        index_chunk_mappers(([True, True], [True, True]), (2, 2), (2, 2))
+    with pytest.raises(NotImplementedError, match="Multiple fancy indices"):
+        index_chunk_mappers(([True, True], [0, 1]), (2, 2), (2, 2))
+    with pytest.raises(NotImplementedError, match="1-dimensional"):
+        index_chunk_mappers([[0, 1], [1, 0]], (4,), (2,))
+
+    with pytest.raises(ValueError, match="chunk sizes"):
+        index_chunk_mappers((), (4,), (0,))
+    with pytest.raises(ValueError, match="shape"):
+        index_chunk_mappers((), (-1,), (2,))
+    with pytest.raises(ValueError, match="chunks"):
+        index_chunk_mappers((), (4,), (2, 2))


### PR DESCRIPTION
Part of #386

Harden error control in user input validation in versioned_hdf5 indices. Improve error messages.
