### PR TITLE
Remove legacy hacks in ASV benchmarks

### DIFF
--- a/benchmarks/delete_versions.py
+++ b/benchmarks/delete_versions.py
@@ -5,39 +5,9 @@ import tempfile
 import h5py
 import numpy
 
-from versioned_hdf5 import VersionedHDF5File
+from versioned_hdf5 import VersionedHDF5File, delete_versions
 
 filename = "delete_versions_bench.h5"
-
-
-try:
-    from versioned_hdf5 import delete_versions
-except ImportError:
-    from versioned_hdf5.replay import recreate_dataset, swap, tmp_group
-
-    def delete_versions(f, versions_to_delete, names=("values",)):
-        """
-        Modified replay.delete_version to delete multiple versions.
-        """
-        if isinstance(f, VersionedHDF5File):
-            f = f.f
-
-        def callback(dataset, version_name):
-            if version_name in versions_to_delete:
-                return
-            return dataset
-
-        newf = tmp_group(f)
-
-        for name in names:
-            recreate_dataset(f, name, newf, callback=callback)
-
-        swap(f, newf)
-
-        for version in versions_to_delete:
-            del f["_version_data/versions"][version]
-
-        del newf[newf.name]
 
 
 class TimeDeleting:

--- a/benchmarks/inmemoryarraydataset.py
+++ b/benchmarks/inmemoryarraydataset.py
@@ -1,19 +1,10 @@
 import os
 
 import h5py
+import numpy as np
 
 from versioned_hdf5 import VersionedHDF5File
 from versioned_hdf5.wrappers import InMemoryArrayDataset
-
-try:
-    from versioned_hdf5.wrappers import DatasetWrapper
-except ImportError:
-
-    class DatasetWrapper:
-        pass
-
-
-import numpy as np
 
 
 class TimeInMemoryArrayDataset:
@@ -31,11 +22,7 @@ class TimeInMemoryArrayDataset:
                     data=np.arange(10000).reshape((100, 10, 10)),
                     chunks=(3, 3, 3),
                 )
-                assert (
-                    isinstance(dataset, InMemoryArrayDataset)
-                    or isinstance(dataset, DatasetWrapper)
-                    and isinstance(dataset.dataset, InMemoryArrayDataset)
-                )
+                assert isinstance(dataset.dataset, InMemoryArrayDataset)
                 dataset[:, 0, 0:6]
 
     def time_setattr(self):
@@ -47,11 +34,7 @@ class TimeInMemoryArrayDataset:
                     data=np.arange(10000).reshape((100, 10, 10)),
                     chunks=(3, 3, 3),
                 )
-                assert (
-                    isinstance(dataset, InMemoryArrayDataset)
-                    or isinstance(dataset, DatasetWrapper)
-                    and isinstance(dataset.dataset, InMemoryArrayDataset)
-                )
+                assert isinstance(dataset.dataset, InMemoryArrayDataset)
                 dataset[:, 0, 0:6] = -1
 
     def time_resize_bigger(self):
@@ -63,11 +46,7 @@ class TimeInMemoryArrayDataset:
                     data=np.arange(10000).reshape((100, 10, 10)),
                     chunks=(3, 3, 3),
                 )
-                assert (
-                    isinstance(dataset, InMemoryArrayDataset)
-                    or isinstance(dataset, DatasetWrapper)
-                    and isinstance(dataset.dataset, InMemoryArrayDataset)
-                )
+                assert isinstance(dataset.dataset, InMemoryArrayDataset)
                 dataset.resize((100, 100, 100))
 
     def time_resize_smaller(self):
@@ -79,9 +58,5 @@ class TimeInMemoryArrayDataset:
                     data=np.arange(10000).reshape((100, 10, 10)),
                     chunks=(3, 3, 3),
                 )
-                assert (
-                    isinstance(dataset, InMemoryArrayDataset)
-                    or isinstance(dataset, DatasetWrapper)
-                    and isinstance(dataset.dataset, InMemoryArrayDataset)
-                )
+                assert isinstance(dataset.dataset, InMemoryArrayDataset)
                 dataset.resize((10, 10, 10))

--- a/benchmarks/inmemorydataset.py
+++ b/benchmarks/inmemorydataset.py
@@ -1,19 +1,10 @@
 import os
 
 import h5py
+import numpy as np
 
 from versioned_hdf5 import VersionedHDF5File
 from versioned_hdf5.wrappers import InMemoryDataset
-
-try:
-    from versioned_hdf5.wrappers import DatasetWrapper
-except ImportError:
-
-    class DatasetWrapper:
-        pass
-
-
-import numpy as np
 
 
 class TimeInMemoryDataset:
@@ -44,11 +35,7 @@ class TimeInMemoryDataset:
 
     def time_getitem(self):
         dataset = self.versioned_file["version1"]["data"]
-        assert (
-            isinstance(dataset, InMemoryDataset)
-            or isinstance(dataset, DatasetWrapper)
-            and isinstance(dataset.dataset, InMemoryDataset)
-        )
+        assert isinstance(dataset.dataset, InMemoryDataset)
         dataset[:, 0, 0:6]
 
     def time_setitem(self):
@@ -56,11 +43,7 @@ class TimeInMemoryDataset:
         self.setup()
         with self.versioned_file.stage_version("version2") as g:
             dataset = g["data"]
-            assert (
-                isinstance(dataset, InMemoryDataset)
-                or isinstance(dataset, DatasetWrapper)
-                and isinstance(dataset.dataset, InMemoryDataset)
-            )
+            assert isinstance(dataset.dataset, InMemoryDataset)
             dataset[:, 0, 0:6] = -1
 
     def time_resize_bigger(self):
@@ -68,11 +51,7 @@ class TimeInMemoryDataset:
         self.setup()
         with self.versioned_file.stage_version("version2") as g:
             dataset = g["data"]
-            assert (
-                isinstance(dataset, InMemoryDataset)
-                or isinstance(dataset, DatasetWrapper)
-                and isinstance(dataset.dataset, InMemoryDataset)
-            )
+            assert isinstance(dataset.dataset, InMemoryDataset)
             dataset.resize((100, 100, 100))
 
     def time_resize_smaller(self):
@@ -80,9 +59,5 @@ class TimeInMemoryDataset:
         self.setup()
         with self.versioned_file.stage_version("version2") as g:
             dataset = g["data"]
-            assert (
-                isinstance(dataset, InMemoryDataset)
-                or isinstance(dataset, DatasetWrapper)
-                and isinstance(dataset.dataset, InMemoryDataset)
-            )
+            assert isinstance(dataset.dataset, InMemoryDataset)
             dataset.resize((10, 10, 10))


### PR DESCRIPTION
These backwards compatibility hacks are for extremely old versions of versioned_hdf5 which should no longer interest anybody.
The current benchmark suite is being run in CI on >=1.7.0.