### PR TITLE
Review test matrix; test vs. h5py>=3.8.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,9 +5,24 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
-        h5py-version: ['dev']
-        numpy-version: ['latest', '1.24.4']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        numpy-version: ['latest']
+        ndindex-version: ['latest']
+        h5py-version: ['latest']
+        include:
+        - python-version: '3.9'
+          numpy-version: '1.24.4'
+          ndindex-version: '1.5.1'
+          h5py-version: '3.8.0'
+        - python-version: '3.11'  # numpy 1.24.4 has wheels up to Python 3.11
+          numpy-version: '1.24.4'
+          ndindex-version: 'latest'
+          h5py-version: 'latest'
+        - python-version: '3.13'
+          numpy-version: 'latest'
+          ndindex-version: 'latest'
+          h5py-version: 'dev'
+
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -22,9 +37,23 @@ jobs:
 
       - name: Install target numpy version
         if: matrix.numpy-version != 'latest'
+        run: pip install numpy~=${{ matrix.numpy-version }}
+
+      - name: Install target ndindex version
+        if: matrix.ndindex-version != 'latest'
+        run: pip install ndindex~=${{ matrix.ndindex-version }}
+
+      - name: Install latest h5py version
+        if: matrix.h5py-version == 'latest'
         run: |
-          pip install numpy~=${{ matrix.numpy-version }}
-          pip list
+          # Build against system-wide libhdf5
+          pip install h5py --no-binary :all:
+
+      - name: Install target h5py version
+        if: matrix.h5py-version != 'latest' && matrix.h5py-version != 'dev'
+        run: |
+          # Build against system-wide libhdf5
+          pip install h5py~=${{ matrix.h5py-version }} --no-binary :all:
 
       - name: Install development h5py version
         if: matrix.h5py-version == 'dev'

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -12,7 +12,8 @@ Dependencies
 
 Currently, Versioned HDF5 has the following runtime dependencies:
 
-- ``python>=3.6``
 - ``numpy``
 - ``h5py``
 - ``ndindex``
+
+Refer to ``pyproject.toml`` for minimum supported versions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,15 +15,15 @@ authors = [
 ]
 description = "Versioned HDF5 provides a versioned abstraction on top of h5py"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "numpy",
-    "h5py",
+    "numpy>=1.24.4",
+    "h5py>=3.8.0",
     "ndindex>=1.5.1",
 ]
 urls = { Homepage = "https://github.com/deshaw/versioned-hdf5" }

--- a/versioned_hdf5/tests/test_replay.py
+++ b/versioned_hdf5/tests/test_replay.py
@@ -914,8 +914,6 @@ def test_delete_versions_current_version(vfile):
 
 
 def test_variable_length_strings(vfile):
-    # Warning: this test will segfault with h5py 3.7.0
-    # (https://github.com/h5py/h5py/pull/2111 fixes it)
     with vfile.stage_version("r0") as sv:
         g = sv.create_group("data")
         dt = h5py.string_dtype(encoding="ascii")


### PR DESCRIPTION
- Increase max tested Python version from 3.11 to 3.13
- Test against pinned old versions of all dependencies
- Set the minimum required versions to the minimum tested versions
- Clean up compatibility with obsolete dependencies