### PR TITLE
Handle numpy ints in resize operations

### DIFF
--- a/versioned_hdf5/staged_changes.py
+++ b/versioned_hdf5/staged_changes.py
@@ -1423,7 +1423,9 @@ class ResizePlan(MutatingPlan):
         if old_floor_size == old_size:
             return  # Everything we're doing is adding extra empty chunks
 
-        new_size: int = min(int(new_shape[axis]), old_floor_size + int(chunk_size[axis]))
+        new_size: int = min(
+            int(new_shape[axis]), old_floor_size + int(chunk_size[axis])
+        )
 
         # Two steps:
         # 1. Find edge chunks on base slabs that were partial and became full, or

--- a/versioned_hdf5/staged_changes.py
+++ b/versioned_hdf5/staged_changes.py
@@ -1391,8 +1391,8 @@ class ResizePlan(MutatingPlan):
         Load partial edge chunks into memory to avoid ending up with partially
         overlapping chunks on disk, e.g. [10:19] vs. [10:17].
         """
-        new_size = new_shape[axis]
-        new_floor_size = new_size - new_size % chunk_size[axis]
+        new_size: int = int(new_shape[axis])
+        new_floor_size: int = new_size - new_size % int(chunk_size[axis])
         assert new_floor_size < new_size
 
         self._load_edge_chunks_along_axis(
@@ -1416,14 +1416,14 @@ class ResizePlan(MutatingPlan):
         n_base_slabs: int,
     ):
         """Enlarge along a single axis"""
-        old_size = old_shape[axis]
+        old_size: int = int(old_shape[axis])
 
         # Old size, rounded down to the nearest chunk
-        old_floor_size = old_size - old_size % chunk_size[axis]
+        old_floor_size: int = old_size - old_size % int(chunk_size[axis])
         if old_floor_size == old_size:
             return  # Everything we're doing is adding extra empty chunks
 
-        new_size = min(new_shape[axis], old_floor_size + chunk_size[axis])
+        new_size: int = min(int(new_shape[axis]), old_floor_size + int(chunk_size[axis]))
 
         # Two steps:
         # 1. Find edge chunks on base slabs that were partial and became full, or
@@ -1476,7 +1476,7 @@ class ResizePlan(MutatingPlan):
         self,
         shape: tuple[int, ...],
         chunk_size: tuple[int, ...],
-        axis: int,
+        axis: ssize_t,
         floor_size: int,
         size: int,  # Not necessarily shape[axis]
         n_slabs: int,

--- a/versioned_hdf5/tests/test_api.py
+++ b/versioned_hdf5/tests/test_api.py
@@ -671,7 +671,9 @@ def test_resize_int_types_shrink(tmp_path):
     with h5py.File(tmp_path / "data.h5", "w") as f:
         vfile = VersionedHDF5File(f)
         with vfile.stage_version("r0") as sv:
-            sv.create_dataset("values", data=np.arange(17), maxshape=(None,), chunks=(3,))
+            sv.create_dataset(
+                "values", data=np.arange(17), maxshape=(None,), chunks=(3,)
+            )
     # Test shrinking:
     with h5py.File(tmp_path / "data.h5", "r+") as f:
         vfile = VersionedHDF5File(f)
@@ -680,12 +682,15 @@ def test_resize_int_types_shrink(tmp_path):
             new_size = old_size - 4
             sv["values"].resize((new_size,))
 
+
 def test_resize_int_types_grow(tmp_path):
     # Test that resizing with numpy int types works
     with h5py.File(tmp_path / "data.h5", "w") as f:
         vfile = VersionedHDF5File(f)
         with vfile.stage_version("r0") as sv:
-            sv.create_dataset("values", data=np.arange(17), maxshape=(None,), chunks=(3,))
+            sv.create_dataset(
+                "values", data=np.arange(17), maxshape=(None,), chunks=(3,)
+            )
     # Test growing repeatedly:
     with h5py.File(tmp_path / "data.h5", "r+") as f:
         vfile = VersionedHDF5File(f)
@@ -693,11 +698,12 @@ def test_resize_int_types_grow(tmp_path):
             old_size = sv["values"].size
             new_size = old_size + 7
             sv["values"].resize((new_size,))
-            sv['values'][old_size:new_size] = np.arange(new_size - old_size)
+            sv["values"][old_size:new_size] = np.arange(new_size - old_size)
             old_size = sv["values"].size
             new_size = old_size + 7
             sv["values"].resize((new_size,))
-            sv['values'][old_size:new_size] = np.arange(new_size - old_size)
+            sv["values"][old_size:new_size] = np.arange(new_size - old_size)
+
 
 def test_getitem(vfile):
     data = np.arange(2 * DEFAULT_CHUNK_SIZE)

--- a/versioned_hdf5/tests/test_api.py
+++ b/versioned_hdf5/tests/test_api.py
@@ -666,6 +666,39 @@ def test_resize_multiple_dimensions(tmp_path, h5file):
         assert_equal(version3_2[f"dataset3_{i}"][()], new_data)
 
 
+def test_resize_int_types_shrink(tmp_path):
+    # Test that resizing with numpy int types works
+    with h5py.File(tmp_path / "data.h5", "w") as f:
+        vfile = VersionedHDF5File(f)
+        with vfile.stage_version("r0") as sv:
+            sv.create_dataset("values", data=np.arange(17), maxshape=(None,), chunks=(3,))
+    # Test shrinking:
+    with h5py.File(tmp_path / "data.h5", "r+") as f:
+        vfile = VersionedHDF5File(f)
+        with vfile.stage_version("r1") as sv:
+            old_size = sv["values"].size
+            new_size = old_size - 4
+            sv["values"].resize((new_size,))
+
+def test_resize_int_types_grow(tmp_path):
+    # Test that resizing with numpy int types works
+    with h5py.File(tmp_path / "data.h5", "w") as f:
+        vfile = VersionedHDF5File(f)
+        with vfile.stage_version("r0") as sv:
+            sv.create_dataset("values", data=np.arange(17), maxshape=(None,), chunks=(3,))
+    # Test growing repeatedly:
+    with h5py.File(tmp_path / "data.h5", "r+") as f:
+        vfile = VersionedHDF5File(f)
+        with vfile.stage_version("r1") as sv:
+            old_size = sv["values"].size
+            new_size = old_size + 7
+            sv["values"].resize((new_size,))
+            sv['values'][old_size:new_size] = np.arange(new_size - old_size)
+            old_size = sv["values"].size
+            new_size = old_size + 7
+            sv["values"].resize((new_size,))
+            sv['values'][old_size:new_size] = np.arange(new_size - old_size)
+
 def test_getitem(vfile):
     data = np.arange(2 * DEFAULT_CHUNK_SIZE)
 

--- a/versioned_hdf5/tests/test_staged_changes.py
+++ b/versioned_hdf5/tests/test_staged_changes.py
@@ -768,10 +768,7 @@ def test_numpy_ints_constructors():
 
 def test_numpy_ints_methods():
     """Test when input parameters are numpy.int types instead of plain python ints"""
-    arr = StagedChangesArray.from_array(
-        np.arange(10),
-        (5,),
-    )
+    arr = StagedChangesArray.from_array(np.arange(10), (5,))
     arr[np.int64(7)] = np.int8(42)  # __setitem__
     arr[np.int64(8) : np.int64(9)] = [np.int8(43)]  # __setitem__
     assert arr[np.int64(7)] == 42  # __getitem__


### PR DESCRIPTION
After the changes in 59028f33b3e93d6c69913117e612c2f1a8129735 we no longer handle numpy integer types in `resize`:
```
In [1]: with h5py.File('/tmp/foo.h5', 'w') as f:
   ...:     vf = VersionedHDF5File(f)
   ...:     with vf.stage_version('r0') as sv:
   ...:         sv.create_dataset('values', data=np.arange(123), chunks=(10,))
   ...:
[PYFLYBY] from versioned_hdf5 import VersionedHDF5File
[PYFLYBY] import h5py
[PYFLYBY] import numpy as np

In [2]: with h5py.File('/tmp/foo.h5', 'r+') as f:
   ...:     vf = VersionedHDF5File(f)
   ...:     with vf.stage_version('r1') as sv:
   ...:         old_length = sv['values'].size
   ...:         new_length = old_length - 17
   ...:         sv['values'].resize((new_length,))
   ...:
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[2], line 6
      4 old_length = sv['values'].size
      5 new_length = old_length - 17
----> 6 sv['values'].resize((new_length,))

File /codemill/bessen/infra/versioned_hdf5/venv/lib64/python3.11/site-packages/versioned_hdf5/wrappers.py:747, in InMemoryDataset.resize(self, size, axis)
    744 size = tuple(size)
    745 # === END CODE FROM h5py.Dataset.resize ===
--> 747 self.staged_changes.resize(size)
    748 self.id.shape = size

File staged_changes.pyx:514, in versioned_hdf5.staged_changes.StagedChangesArray.resize()

File staged_changes.pyx:370, in versioned_hdf5.staged_changes.StagedChangesArray._resize_plan()

File staged_changes.pyx:1324, in versioned_hdf5.staged_changes.ResizePlan.__init__()

File staged_changes.pyx:1402, in versioned_hdf5.staged_changes.ResizePlan._shrink_along_axis()

TypeError: Expected int, got numpy.int64
```

This change fixes that regression.