### PR TITLE
[BUG] Fix sphinx config that prevents certain tags from being built

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,7 +41,7 @@ extensions = [
 ]
 
 # sphinx-multiversion configuration
-smv_tag_whitelist = r"^[0-9].[0-9].*$"
+smv_tag_whitelist = r"^v?[0-9].[0-9].*$"
 smv_branch_whitelist = "master"
 smv_remote_whitelist = None
 smv_released_pattern = r"^tags/.*$"


### PR DESCRIPTION
This PR fixes an issue where more recent versions of the documentation were not being built by `sphinx-multiversion`. This is because only tags of the form `1.7.0` were allowed, while `v1.8.0` was not. This restriction has been removed.