### PR TITLE
[BUG] Change empty dataset detection to work with h5py dev version

### DIFF
--- a/versioned_hdf5/replay.py
+++ b/versioned_hdf5/replay.py
@@ -425,7 +425,7 @@ def _is_empty(f: VersionedHDF5File, name: str, version: str) -> bool:
     bool
         True if the dataset is empty, False otherwise
     """
-    return not f["_version_data/versions"][version][name].is_virtual
+    return f["_version_data/versions"][version][name].len() == 0
 
 
 def _exists_in_version(f: VersionedHDF5File, name: str, version: str) -> bool:


### PR DESCRIPTION
Fixes #419.

This PR fixes an issue where empty datasets were not being detected correctly, which manifested as a bug when deleting empty datasets. Usually if the user deletes a version of empty dataset, the raw data is not modified because empty datasets don't point to any raw data. If the dataset to be deleted was not empty, this triggers a recreation of the hash table, raw data, and virtual datasets; if the dataset to be deleted was not virtual, we'd skip all of that.

To determine whether a dataset was empty, previously we were checking whether the dataset was virtual, because with previous versions of h5py empty datasets were never allowed to be virtual. With the latest version of h5py empty datasets can now be virtual, meaning our detection logic fails. As a result the raw data, hash table, and other virtual datasets were being modified inadvertently - this caused the test failure.

With this change, we now just look at the length of the dataset to know whether it's empty or not. This _should_ be backwards compatible with existing data, so no migration should be necessary.