### PR TITLE
Accept DTypeLike in `dtype=` parameter in `create_dataset`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,6 @@ show_error_codes = true
 warn_redundant_casts = true
 warn_unused_ignores = true
 warn_unreachable = true
-plugins = "numpy.typing.mypy_plugin"
 
 [[tool.mypy.overrides]]
 module = ["*.tests.*"]

--- a/versioned_hdf5/tests/test_api.py
+++ b/versioned_hdf5/tests/test_api.py
@@ -2889,3 +2889,24 @@ def test_other_compression_validates(tmp_path, library):
         # First four numbers are reserved for blosc compression;
         # others are actual compression options
         assert raw_data._filters["32001"][4:] == (7, 1, 2)
+
+
+@pytest.mark.parametrize("dtype", ["i2", int, float, np.uint8])
+def test_create_dataset_dtype_arg(vfile, dtype):
+    with vfile.stage_version(f"r0") as sv:
+        dset = sv.create_dataset("x", shape=(2,), dtype=dtype)
+        assert isinstance(dset.dtype, np.dtype)
+        assert dset.dtype == np.dtype(dtype)
+
+        dset = sv.create_dataset("y", data=[1, 2], dtype=dtype)
+        assert isinstance(dset.dtype, np.dtype)
+        assert dset.dtype == np.dtype(dtype)
+
+    with vfile.stage_version(f"r1") as sv:
+        dset = sv["x"]
+        assert isinstance(dset.dtype, np.dtype)
+        assert dset.dtype == np.dtype(dtype)
+
+        dset = sv["y"]
+        assert isinstance(dset.dtype, np.dtype)
+        assert dset.dtype == np.dtype(dtype)

--- a/versioned_hdf5/wrappers.py
+++ b/versioned_hdf5/wrappers.py
@@ -202,19 +202,21 @@ class InMemoryGroup(Group):
         self,
         name,
         shape=None,
-        dtype=None,
+        dtype: np.dtype | str | None = None,
         data: np.ndarray | None = None,
         fillvalue=None,
         **kwds,
     ):
         self._check_committed()
-        dirname, data_name = posixpath.split(name)
+        dirname, _ = posixpath.split(name)
         if dirname and dirname not in self:
             self.create_group(dirname)
         if "maxshape" in kwds and any(i != None for i in kwds["maxshape"]):
             warnings.warn(
                 "The maxshape parameter is currently ignored for versioned datasets."
             )
+        if dtype is not None and not isinstance(dtype, np.dtype):
+            dtype = np.dtype(dtype)
         data = _make_new_dset(
             data=data, shape=shape, dtype=dtype, fillvalue=fillvalue, **kwds
         )


### PR DESCRIPTION
Fix crash with a DTypeLike parameter to `create_dataset`, e.g. `dtype="i4"` instead of `dtype=np.int32`.