### PR TITLE
Fix InMemoryArrayDataset dtype

### DIFF
--- a/versioned_hdf5/backend.py
+++ b/versioned_hdf5/backend.py
@@ -23,10 +23,6 @@ DATA_VERSION = 4
 CORRUPT_DATA_VERSIONS = frozenset([2, 3])
 
 
-def normalize_dtype(dtype):
-    return np.array([], dtype=dtype).dtype
-
-
 def get_chunks(shape, dtype, chunk_size):
     # TODO: Implement this
     if len(shape) > 1:
@@ -92,7 +88,7 @@ def create_base_dataset(
     if dtype is None:
         # https://github.com/h5py/h5py/issues/1474
         dtype = data.dtype
-    dtype = normalize_dtype(dtype)
+    dtype = np.dtype(dtype)
     if dtype.metadata and (
         "vlen" in dtype.metadata or "h5py_encoding" in dtype.metadata
     ):

--- a/versioned_hdf5/tests/test_wrappers.py
+++ b/versioned_hdf5/tests/test_wrappers.py
@@ -76,6 +76,7 @@ def test_InMemoryArrayDataset_resize(h5file):
 @pytest.mark.parametrize(
     "kwargs",
     [
+        dict(data=[0], dtype="i2"),
         dict(data=[0], dtype=np.int16),
         dict(data=np.asarray([0], dtype=np.int16)),
         dict(data=np.asarray([0], dtype=np.int32), dtype=np.int16),
@@ -86,6 +87,7 @@ def test_InMemoryArrayDataset_dtype(h5file, kwargs):
     vfile = VersionedHDF5File(h5file)
     with vfile.stage_version("r0") as group:
         ds = group.create_dataset("x", **kwargs)
+        assert isinstance(ds.dtype, np.dtype)
         assert ds.dtype == np.int16
         assert ds[:].dtype == np.int16
         assert np.asarray(ds).dtype == np.int16

--- a/versioned_hdf5/tests/test_wrappers.py
+++ b/versioned_hdf5/tests/test_wrappers.py
@@ -70,6 +70,24 @@ def test_InMemoryArrayDataset_resize(h5file):
     assert dataset.shape == dataset.array.shape == (90,)
 
 
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        dict(data=[0], dtype=np.int16),
+        dict(data=np.asarray([0], dtype=np.int16)),
+        dict(data=np.asarray([0], dtype=np.int32), dtype=np.int16),
+        dict(shape=(1,), dtype=np.int16),
+    ],
+)
+def test_InMemoryArrayDataset_dtype(h5file, kwargs):
+    vfile = VersionedHDF5File(h5file)
+    with vfile.stage_version("r0") as group:
+        ds = group.create_dataset("x", **kwargs)
+        assert ds.dtype == np.int16
+        assert ds[:].dtype == np.int16
+        assert np.asarray(ds).dtype == np.int16
+
+
 def test_InMemorySparseDataset(h5file):
     group = h5file.create_group("group")
     parent = InMemoryGroup(group.id)

--- a/versioned_hdf5/tests/test_wrappers.py
+++ b/versioned_hdf5/tests/test_wrappers.py
@@ -23,7 +23,7 @@ def test_InMemoryArrayDataset(h5file):
     ).reshape((50, 2))
     dataset = InMemoryArrayDataset("data", a, parent=parent)
     assert dataset.name == "data"
-    assert_equal(dataset.array, a)
+    assert_equal(dataset._array, a)
     assert dataset.attrs == {}
     assert dataset.shape == a.shape
     assert dataset.dtype == a.dtype
@@ -39,9 +39,12 @@ def test_InMemoryArrayDataset(h5file):
     assert_equal(list(dataset), list(a))
 
     assert dataset[30, 0] == a[30, 0] == 60
+    assert isinstance(dataset[30, 0], np.generic)
     dataset[30, 0] = 1000
     assert dataset[30, 0] == 1000
-    assert dataset.array[30, 0] == 1000
+    assert dataset._array[30, 0] == 1000
+    assert (dataset[30, :] == a[30, :]).all()
+    assert isinstance(dataset[30, :], np.ndarray)
 
     assert dataset.size == 100
 
@@ -54,20 +57,20 @@ def test_InMemoryArrayDataset_resize(h5file):
     dataset.resize((110,))
 
     assert len(dataset) == 110
-    assert_equal(dataset[:100], dataset.array[:100])
+    assert_equal(dataset[:100], dataset._array[:100])
     assert_equal(dataset[:100], a)
-    assert_equal(dataset[100:], dataset.array[100:])
+    assert_equal(dataset[100:], dataset._array[100:])
     assert_equal(dataset[100:], 0)
-    assert dataset.shape == dataset.array.shape == (110,)
+    assert dataset.shape == dataset._array.shape == (110,)
 
     a = np.arange(100)
     dataset = InMemoryArrayDataset("data", a, parent=parent)
     dataset.resize((90,))
 
     assert len(dataset) == 90
-    assert_equal(dataset, dataset.array)
+    assert_equal(dataset, dataset._array)
     assert_equal(dataset, np.arange(90))
-    assert dataset.shape == dataset.array.shape == (90,)
+    assert dataset.shape == dataset._array.shape == (90,)
 
 
 @pytest.mark.parametrize(

--- a/versioned_hdf5/wrappers.py
+++ b/versioned_hdf5/wrappers.py
@@ -958,6 +958,7 @@ class DatasetLike:
     _fillvalue
     parent (the parent group)
     """
+
     name: str
     shape: tuple[int, ...]
     dtype: np.dtype

--- a/versioned_hdf5/wrappers.py
+++ b/versioned_hdf5/wrappers.py
@@ -13,7 +13,7 @@ import warnings
 from collections import defaultdict
 from collections.abc import Iterable
 from functools import cached_property
-from typing import Optional, Union
+from typing import Any
 from weakref import WeakValueDictionary
 
 import numpy as np
@@ -622,7 +622,7 @@ class InMemoryDataset(Dataset):
             fill_value=self.fillvalue,
         )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         name = posixpath.basename(posixpath.normpath(self.name))
         namestr = '"%s"' % (name if name != "" else "/")
         return '<%s %s: shape %s, type "%s">' % (
@@ -683,7 +683,7 @@ class InMemoryDataset(Dataset):
         return new_dataset
 
     @property
-    def fillvalue(self):
+    def fillvalue(self) -> Any:
         if super().fillvalue is not None:
             return super().fillvalue
         if self.dtype.metadata:
@@ -699,11 +699,11 @@ class InMemoryDataset(Dataset):
         return np.zeros((), dtype=self.dtype)[()]
 
     @property
-    def shape(self):
+    def shape(self) -> tuple[int, ...]:
         return self.id.shape
 
     @property
-    def size(self):
+    def size(self) -> int:
         return int(np.prod(self.shape))
 
     @property
@@ -715,7 +715,7 @@ class InMemoryDataset(Dataset):
         return self._attrs
 
     @property
-    def parent(self):
+    def parent(self) -> InMemoryGroup:
         return self._parent
 
     def __array__(self, dtype=None):
@@ -958,13 +958,18 @@ class DatasetLike:
     _fillvalue
     parent (the parent group)
     """
+    name: str
+    shape: tuple[int, ...]
+    dtype: np.dtype
+    _fillvalue: object | None
+    parent: InMemoryGroup
 
     @property
-    def size(self):
-        return np.prod(self.shape)
+    def size(self) -> int:
+        return int(np.prod(self.shape))
 
     @property
-    def fillvalue(self):
+    def fillvalue(self) -> Any:
         if self._fillvalue is not None:
             return np.array([self._fillvalue], dtype=self.dtype)[0]
         if self.dtype.metadata:
@@ -980,25 +985,22 @@ class DatasetLike:
         return np.zeros((), dtype=self.dtype)[()]
 
     @property
-    def ndim(self):
+    def ndim(self) -> int:
         return len(self.shape)
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         return bool(self.size)
 
-    def __len__(self):
+    def __len__(self) -> int:
         return self.len()
 
-    def len(self):
-        """
-        Length of the first axis
-        """
-        shape = self.shape
-        if len(shape) == 0:
+    def len(self) -> int:
+        """Length of the first axis."""
+        if len(self.shape) == 0:
             raise TypeError("Attempt to take len() of scalar dataset")
-        return shape[0]
+        return self.shape[0]
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         name = posixpath.basename(posixpath.normpath(self.name))
         namestr = '"%s"' % (name if name != "" else "/")
         return '<%s %s: shape %s, type "%s">' % (
@@ -1008,7 +1010,7 @@ class DatasetLike:
             self.dtype.str,
         )
 
-    def __iter__(self):
+    def __iter__(self) -> Iterable[np.ndarray | np.generic]:
         """Iterate over the first axis. TypeError if scalar.
 
         BEWARE: Modifications to the yielded data are *NOT* written to file.
@@ -1077,11 +1079,11 @@ class InMemoryArrayDataset(DatasetLike):
         )
 
     @property
-    def shape(self):
+    def shape(self) -> tuple[int, ...]:
         return self._array.shape
 
     @property
-    def dtype(self):
+    def dtype(self) -> np.dtype:
         return self._dtype or self._array.dtype
 
     def __getitem__(self, item):

--- a/versioned_hdf5/wrappers.py
+++ b/versioned_hdf5/wrappers.py
@@ -967,7 +967,7 @@ class DatasetLike:
     def fillvalue(self):
         if self._fillvalue is not None:
             return np.array([self._fillvalue], dtype=self.dtype)[0]
-        if getattr(self.dtype, "metadata", None):
+        if self.dtype.metadata:
             # Custom h5py string dtype. Make sure to use a fillvalue of ''
             if "vlen" in self.dtype.metadata:
                 # h5py 3 reads str variable length datasets as bytes. See
@@ -1085,7 +1085,7 @@ class InMemoryArrayDataset(DatasetLike):
         return self._dtype or self._array.dtype
 
     def __getitem__(self, item):
-        return np.asarray(self._array[item], dtype=self._dtype)
+        return np.asarray(self._array[item], dtype=self._dtype)[()]
 
     def __setitem__(self, item, value):
         self.parent._check_committed()


### PR DESCRIPTION
Fix bugs where `InMemoryArrayDataset.__getitem__` and `__array__` would return the wrong dtype.
Speed up `create_dataset` with list data and explicit dtype, by avoiding a double conversion e.g. list -> np.int64 -> np.int16 (or whatever is the desired dtype).