### PR TITLE
wrappers spring cleaning

### DIFF
--- a/versioned_hdf5/staged_changes.py
+++ b/versioned_hdf5/staged_changes.py
@@ -40,6 +40,7 @@ if cython.compiled:  # pragma: nocover
 
 
 T = TypeVar("T", bound=np.generic)
+Casting = Literal["no", "equiv", "safe", "same_kind", "unsafe"]
 
 
 class StagedChangesArray(MutableMapping[Any, T]):
@@ -555,7 +556,11 @@ class StagedChangesArray(MutableMapping[Any, T]):
             out.slabs.append(slab)
         return out
 
-    def astype(self, dtype: DTypeLike, casting: Any = "unsafe") -> StagedChangesArray:
+    def astype(
+        self,
+        dtype: DTypeLike,
+        casting: Casting = "unsafe",
+    ) -> StagedChangesArray:
         """Return a new StagedChangesArray with a different dtype.
 
         Chunks that are not yet staged are loaded from the base slabs.

--- a/versioned_hdf5/tests/test_api.py
+++ b/versioned_hdf5/tests/test_api.py
@@ -12,7 +12,7 @@ import pytest
 from h5py._hl.filters import guess_chunk
 from numpy.testing import assert_equal
 from packaging.version import Version
-from pytest import mark, raises
+from pytest import raises
 
 from ..api import VersionedHDF5File
 from ..backend import DATA_VERSION, DEFAULT_CHUNK_SIZE
@@ -315,6 +315,26 @@ def test_create_dataset(vfile):
     )
 
 
+def test_create_dataset_warns_for_ignored_kwargs(vfile):
+    """create_dataset() in versioned_hdf5 has a lot less kwargs
+    than the same function in h5py. Test that the extra args are
+    accepted, but ignored with a warning.
+    """
+    match = "parameter is currently ignored for versioned datasets"
+    with vfile.stage_version("v1", "") as group:
+        with pytest.warns(UserWarning, match=match):
+            group.create_dataset("a", data=[1, 2], track_order=True)
+        with pytest.warns(UserWarning, match=match):
+            group.create_dataset("b", data=[1, 2], track_order=False)
+        # None is quietly ignored
+        group.create_dataset("c", data=[1, 2], track_order=None)
+
+        # Quietly ignore maxshape if it's a tuple of Nones
+        with pytest.warns(UserWarning, match=match):
+            group.create_dataset("d", data=[1, 2], maxshape=(3,))
+        group.create_dataset("e", data=[1, 2], maxshape=(None,))
+
+
 def test_changes_dataset(vfile):
     # Testcase similar to those on generate_data.py
     test_data = np.ones((2 * DEFAULT_CHUNK_SIZE,))
@@ -597,7 +617,7 @@ def test_resize_unaligned(vfile):
             assert_equal(group[ds_name][:], np.arange((i + 1) * 1000))
 
 
-@mark.slow
+@pytest.mark.slow
 def test_resize_multiple_dimensions(tmp_path, h5file):
     # Test semantics against raw HDF5
 

--- a/versioned_hdf5/tests/test_api.py
+++ b/versioned_hdf5/tests/test_api.py
@@ -2865,7 +2865,7 @@ def test_other_compression_bad_value(tmp_path, library):
     path = tmp_path / "tmp.h5"
     with h5py.File(path, "w") as f:
         vf = VersionedHDF5File(f)
-        with vf.stage_version("r0") as sv, pytest.raises(ValueError, match="invalid"):
+        with pytest.raises(ValueError, match="invalid"), vf.stage_version("r0") as sv:
             sv.create_dataset(
                 "values",
                 data=np.arange(10),

--- a/versioned_hdf5/tests/test_replay.py
+++ b/versioned_hdf5/tests/test_replay.py
@@ -639,8 +639,8 @@ def test_modify_metadata_dtype_fillvalue(vfile):
 
     assert vfile["version1"]["test_data2"].dtype == np.float32
     assert vfile["version2"]["test_data2"].dtype == np.float32
-    assert vfile["version1"]["test_data2"].fillvalue == 3.14
-    assert vfile["version2"]["test_data2"].fillvalue == 3.14
+    np.testing.assert_allclose(vfile["version1"]["test_data2"].fillvalue, 3.14)
+    np.testing.assert_allclose(vfile["version2"]["test_data2"].fillvalue, 3.14)
 
 
 def test_delete_version(vfile):

--- a/versioned_hdf5/tests/test_slicetools.py
+++ b/versioned_hdf5/tests/test_slicetools.py
@@ -219,6 +219,7 @@ def many_slices_st(
     return src_shape, dst_shape, src_indices, dst_indices
 
 
+@pytest.mark.slow
 @given(args=many_slices_st())
 @hypothesis.settings(
     max_examples=max_examples,

--- a/versioned_hdf5/tests/test_wrappers.py
+++ b/versioned_hdf5/tests/test_wrappers.py
@@ -83,8 +83,7 @@ def test_InMemoryArrayDataset_resize(h5file):
         dict(shape=(1,), dtype=np.int16),
     ],
 )
-def test_InMemoryArrayDataset_dtype(h5file, kwargs):
-    vfile = VersionedHDF5File(h5file)
+def test_InMemoryArrayDataset_dtype(vfile, kwargs):
     with vfile.stage_version("r0") as group:
         ds = group.create_dataset("x", **kwargs)
         assert isinstance(ds.dtype, np.dtype)

--- a/versioned_hdf5/wrappers.py
+++ b/versioned_hdf5/wrappers.py
@@ -7,28 +7,32 @@ h5py license.
 
 from __future__ import annotations
 
+import math
 import posixpath
 import textwrap
 import warnings
 from collections import defaultdict
 from collections.abc import Iterable
 from functools import cached_property
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from weakref import WeakValueDictionary
 
 import numpy as np
-from h5py import Dataset, Datatype, Empty, Group
-from h5py import __version__ as h5py_version
-from h5py import h5a, h5d, h5g, h5i, h5p, h5r, h5s, h5t
+from h5py import Dataset, Empty, Group, h5a, h5d, h5g, h5i, h5p, h5r, h5s, h5t
 from h5py._hl import filters
 from h5py._hl.base import guess_dtype, phil, with_phil
 from h5py._hl.dataset import _LEGACY_GZIP_COMPRESSION_VALS
 from h5py._hl.selections import guess_shape
-from ndindex import ChunkSize, Slice, Tuple, ndindex
+from ndindex import Slice, Tuple, ndindex
+from numpy.typing import ArrayLike, DTypeLike
 
 from .backend import DEFAULT_CHUNK_SIZE
 from .slicetools import build_slab_indices_and_offsets
-from .staged_changes import StagedChangesArray
+from .staged_changes import Casting, StagedChangesArray
+
+if TYPE_CHECKING:
+    # TODO import from typing (requires Python >=3.11)
+    from typing_extensions import Self
 
 _groups = WeakValueDictionary({})
 
@@ -200,33 +204,79 @@ class InMemoryGroup(Group):
 
     def create_dataset(
         self,
-        name,
-        shape=None,
-        dtype: np.dtype | str | None = None,
-        data: np.ndarray | None = None,
-        fillvalue=None,
-        **kwds,
+        name: str,
+        shape: tuple[int, ...] | None = None,
+        dtype: DTypeLike | None = None,
+        data: ArrayLike | None = None,
+        fillvalue: Any | None = None,
+        chunks: tuple[int, ...] | int | bool | None = None,
+        compression=None,
+        compression_opts=None,
+        **kwds: Any,
     ):
         self._check_committed()
         dirname, _ = posixpath.split(name)
         if dirname and dirname not in self:
             self.create_group(dirname)
-        if "maxshape" in kwds and any(i != None for i in kwds["maxshape"]):
-            warnings.warn(
-                "The maxshape parameter is currently ignored for versioned datasets."
-            )
+
+        for k, v in kwds.items():
+            if v is not None and not (k == "maxshape" and all(i == None for i in v)):
+                warnings.warn(
+                    f"The {k} parameter is currently ignored for versioned datasets."
+                )
+
         if dtype is not None and not isinstance(dtype, np.dtype):
             dtype = np.dtype(dtype)
-        data = _make_new_dset(
-            data=data, shape=shape, dtype=dtype, fillvalue=fillvalue, **kwds
-        )
+
+        if isinstance(data, Empty):
+            raise NotImplementedError("Empty datasets are not supported.")
+
+        if data is not None:
+            if not isinstance(data, np.ndarray) or data.dtype.kind == "O":
+                dtype = dtype or guess_dtype(data)
+            data = np.asarray(data, order="C", dtype=dtype)
+
         if shape is None:
+            if data is None:
+                raise TypeError("Either shape or data must be specified")
             shape = data.shape
-        if fillvalue is not None and isinstance(data, np.ndarray):
-            data = InMemoryArrayDataset(name, data, parent=self, fillvalue=fillvalue)
-        chunks = kwds.get("chunks")
-        if data is None:
-            data = InMemorySparseDataset(
+        elif data is not None and data.shape != shape:
+            raise ValueError(
+                f"data.shape {data.shape} does not match specified shape {shape}"
+            )
+
+        if chunks in (True, None):
+            if len(shape) == 1:
+                chunks = (DEFAULT_CHUNK_SIZE,)
+            else:
+                raise NotImplementedError(
+                    "chunks must be specified for multi-dimensional datasets"
+                )
+        elif chunks is False:
+            raise ValueError("chunks=False is not supported for versioned datasets")
+        elif isinstance(chunks, int) and not isinstance(chunks, bool):
+            chunks = (chunks,)
+        assert isinstance(chunks, tuple)
+
+        if len(shape) != len(chunks):
+            raise ValueError(
+                f"Dimensions of chunks ({chunks}) must equal the dimensions of the "
+                f"shape ({shape})"
+            )
+        if len(shape) == 0:
+            raise NotImplementedError("Scalar datasets are not implemented.")
+
+        ds: DatasetLike
+        if data is not None:
+            ds = InMemoryArrayDataset(
+                name,
+                data,
+                parent=self,
+                fillvalue=fillvalue,
+                chunks=chunks,
+            )
+        else:
+            ds = InMemorySparseDataset(
                 name,
                 shape=shape,
                 dtype=dtype,
@@ -234,29 +284,12 @@ class InMemoryGroup(Group):
                 fillvalue=fillvalue,
                 chunks=chunks,
             )
-        if chunks in [True, None]:
-            if len(shape) == 1:
-                chunks = (DEFAULT_CHUNK_SIZE,)
-            else:
-                raise NotImplementedError(
-                    "chunks must be specified for multi-dimensional datasets"
-                )
-        if isinstance(chunks, int) and not isinstance(chunks, bool):
-            chunks = (chunks,)
-        if len(shape) != len(chunks):
-            raise ValueError(
-                f"Dimensions of chunks ({chunks}) must equal the dimensions of the shape ({shape})"
-            )
-        if len(shape) == 0:
-            raise NotImplementedError("Scalar datasets are not implemented.")
 
         self.set_chunks(name, chunks)
-        self.set_compression(name, kwds.get("compression"))
-        self.set_compression_opts(name, kwds.get("compression_opts"))
-        self[name] = data
-        if dtype is not None:
-            self[name]._dtype = dtype
-        return self[name]
+        self.set_compression(name, compression)
+        self.set_compression_opts(name, compression_opts)
+        self[name] = ds
+        return ds
 
     def __iter__(self):
         names = list(self._data) + list(self._subgroups)
@@ -377,220 +410,6 @@ class InMemoryGroup(Group):
     # TODO: override other relevant methods here
 
 
-def _make_new_dset(
-    shape: int | tuple[int, ...] | None = None,
-    dtype: np.dtype | None = None,
-    data: np.ndarray | None = None,
-    chunks: tuple[int, ...] | None = None,
-    compression: int | str | bool | None = None,
-    shuffle: bool | None = None,
-    fletcher32: bool | None = None,
-    maxshape: tuple[int, ...] | None = None,
-    compression_opts: int | tuple[int, ...] | None = None,
-    fillvalue: int | str | float | None = None,
-    scaleoffset: bool | int | None = None,
-    track_times: bool | None = None,
-    external: Iterable[tuple[str, int, int]] | None = None,
-    track_order: bool | None = None,
-    dcpl: h5p.PropDCID | None = None,
-) -> np.ndarray:
-    """Create a new low-level dataset identifier.
-
-    Based on h5py._hl.dataset.make_new_dset(), except it doesn't actually create
-    the dataset, it just canonicalizes the arguments. Additionally, this function
-    allows datasets which are smaller than the data in any dimension to be
-    instantiated, whereas the upstream h5py version does not.
-
-    See the LICENSE file for the h5py license.
-
-    Parameters
-    ----------
-    shuffle : bool | None
-        Whether to call dcpl.set_shuffle() on the underlying PropDCID
-    fletcher32 : bool | None
-        Whether to call dcpl.set_fletcher32(). Note that scale/offset following
-        fletcher32 in the filter chain will (almost?) always triggers a read
-        error, as most scale/offset settings are lossy. Since fletcher32 must
-        come first (see comment in h5py._hl.filters.fill_dcpl) combination of
-        fletcher32 and scale/offset is prohibited.
-    maxshape : tuple[int, ...] | None
-        Max shape of the dataste
-    compression_opts : int | tuple[int, ...] | None
-        Compression options passed to h5py._hl.filters.fill_dcpl
-    fillvalue : int | str | float | None
-        Value used to fill the parts of chunks that extend beyond the dataset
-    scaleoffset : bool | int | None
-        This must be an integer when it is not None or False, except for integral
-        data, for which scaleoffset == True is permissible (will use
-        SO_INT_MINBITS_DEFAULT)
-    track_times : bool |  None
-        Argument to pass to dcpl.set_obj_track_times(track_times)
-    shape : int | tuple[int, ...] | None
-        Shape of the dataset to create
-    dtype : np.dtype | None
-        Dtype of the dataset to create
-    data : np.ndarray | None
-        Dataset to store
-    chunks : tuple[int, ...] | None
-        Chunk size in each dimension
-    compression : int | str | bool | None
-        Compression to use for the dataset
-    external : Iterable[tuple[str, int, int]] | None
-        List of tuples to be passed to h5p.set_external
-    track_order : bool | None
-        If True, set tracking and indexing of creation order for object attributes;
-        otherwise, dcpl.set_attr_creation_order(0) is called
-    dcpl : h5p.PropDCID | None
-        Dataset Creation Property List to use; if unspecified, an new dcpl is created
-
-    Returns
-    -------
-    np.ndarray | None
-        Data used to create the dataset
-    """
-    # Convert data to a C-contiguous ndarray
-    if data is not None and not isinstance(data, Empty):
-        # normalize strings -> np.dtype objects
-        if dtype is not None:
-            _dtype = np.dtype(dtype)
-        else:
-            _dtype = None
-
-        # Do not convert in memory input numpy data with the wrong dtype
-        # However, if we are going to a f2 datatype, pre-convert hee
-        # to workaround a possible h5py bug in the conversion.
-        if _dtype is not None and _dtype.kind == "f" and _dtype.itemsize == 2:
-            preconvert_dtype = _dtype
-        else:
-            # Special cases for vlen strings
-            preconvert_dtype = guess_dtype(data)
-        if preconvert_dtype is None and not isinstance(data, np.ndarray):
-            preconvert_dtype = _dtype
-
-        data = np.asarray(data, order="C", dtype=preconvert_dtype)
-
-    # Validate shape
-    if shape is None:
-        if data is None:
-            if dtype is None:
-                raise TypeError("One of data, shape or dtype must be specified.")
-            data = Empty(dtype)
-        shape = data.shape
-    else:
-        shape = (shape,) if isinstance(shape, int) else tuple(shape)
-        if data is not None and (
-            np.prod(shape, dtype=np.ulonglong)
-            != np.prod(data.shape, dtype=np.ulonglong)
-        ):
-            raise ValueError(
-                f"Shape tuple {shape} is incompatible with data shape {data.shape}"
-            )
-
-    if isinstance(maxshape, int):
-        maxshape = (maxshape,)
-
-    # Validate chunk shape
-    if isinstance(chunks, int) and not isinstance(chunks, bool):
-        chunks = (chunks,)
-
-    # The original make_new_dset errors here if the shape is less than the
-    # chunk size, but we avoid doing that as we cannot change the chunk size
-    # for a dataset for any version once it is created. See #34.
-
-    if isinstance(dtype, Datatype):
-        # Named types are used as-is
-        tid = dtype.id
-        dtype = tid.dtype  # Following code needs this
-    else:
-        # Validate dtype
-        if dtype is None and data is None:
-            dtype = np.dtype("=f4")
-        elif dtype is None and data is not None:
-            dtype = data.dtype
-        else:
-            dtype = np.dtype(dtype)
-        tid = h5t.py_create(dtype, logical=1)
-
-    # Legacy
-    if (
-        any((compression, shuffle, fletcher32, maxshape, scaleoffset))
-        and chunks is False
-    ):
-        raise ValueError(
-            "Chunked format required for given storage options:\n"
-            + textwrap.indent(
-                "\n".join(
-                    [
-                        f"compression: {compression}",
-                        f"shuffle: {shuffle}",
-                        f"fletcher32: {fletcher32}",
-                        f"maxshape: {maxshape}",
-                        f"scaleoffset: {scaleoffset}",
-                    ]
-                ),
-                "  ",
-            )
-        )
-
-    # Legacy
-    if compression is True:
-        if compression_opts is None:
-            compression_opts = 4
-        compression = "gzip"
-
-    # Legacy
-    if compression in _LEGACY_GZIP_COMPRESSION_VALS:
-        if compression_opts is not None:
-            raise TypeError(
-                "Conflict in compression options; "
-                f"if compression is one of {_LEGACY_GZIP_COMPRESSION_VALS},"
-                f"compression_opts must be None.\n"
-                + textwrap.indent(
-                    "\n".join(
-                        f"compression: {compression}",
-                        f"compression_opts: {compression_opts}",
-                    )
-                )
-            )
-        compression_opts = compression
-        compression = "gzip"
-    dcpl = filters.fill_dcpl(
-        dcpl or h5p.create(h5p.DATASET_CREATE),
-        shape,
-        dtype,
-        chunks,
-        compression,
-        compression_opts,
-        shuffle,
-        fletcher32,
-        maxshape,
-        scaleoffset,
-        external,
-    )
-
-    if fillvalue is not None:
-        fillvalue = np.array(fillvalue)
-        dcpl.set_fill_value(fillvalue)
-
-    if track_times in (True, False):
-        dcpl.set_obj_track_times(track_times)
-    elif track_times is not None:
-        raise TypeError("track_times must be either True or False")
-    if track_order == True:
-        dcpl.set_attr_creation_order(h5p.CRT_ORDER_TRACKED | h5p.CRT_ORDER_INDEXED)
-    elif track_order == False:
-        dcpl.set_attr_creation_order(0)
-    elif track_order is not None:
-        raise TypeError("track_order must be either True or False")
-
-    if maxshape is not None:
-        maxshape = tuple(m if m is not None else h5s.UNLIMITED for m in maxshape)
-
-    if isinstance(data, Empty):
-        raise NotImplementedError("Empty datasets are not supported.")
-    return data
-
-
 class InMemoryDataset(Dataset):
     """
     Class that looks like a h5py.Dataset but is backed by a versioned dataset
@@ -599,13 +418,12 @@ class InMemoryDataset(Dataset):
     in-memory only.
     """
 
-    def __init__(self, bind, parent, **kwargs):
+    def __init__(self, bind, parent, *, readonly=False):
         # Hold a reference to the original bind so h5py doesn't invalidate the id
         # XXX: We need to handle deallocation here properly when our object
         # gets deleted or closed.
         self.orig_bind = bind
-        super().__init__(InMemoryDatasetID(bind.id), **kwargs)
-        self._init_kwargs = kwargs
+        super().__init__(InMemoryDatasetID(bind.id), readonly=readonly)
         self._parent = parent
         self._attrs = dict(super().attrs)
 
@@ -660,45 +478,12 @@ class InMemoryDataset(Dataset):
     def compression_opts(self, value):
         self.parent.set_compression_opts(self.name, value)
 
-    def as_dtype(self, name, dtype, parent, casting="unsafe"):
-        """
-        Return a copy of `self` as a new dataset with the given `name` and `dtype`
-        in the group `parent`.
-
-        `casting` should be as in the numpy astype() method.
-
-        """
-        fillvalue = super().fillvalue
-        init_kwargs = self._init_kwargs.copy()
-        if fillvalue is not None:
-            fillvalue = fillvalue.astype(dtype, casting=casting)
-            init_kwargs.setdefault("fillvalue", fillvalue)
-
-        new_dataset = InMemoryDataset(
-            bind=self.orig_bind,
-            parent=parent,
-            **init_kwargs,
-        )
-
-        new_dataset.staged_changes = self.staged_changes.astype(dtype, casting=casting)
-        parent[name] = new_dataset
-        return new_dataset
-
     @property
-    def fillvalue(self) -> Any:
-        if super().fillvalue is not None:
-            return super().fillvalue
-        if self.dtype.metadata:
-            # Custom h5py string dtype. Make sure to use a fillvalue of ''
-            if "vlen" in self.dtype.metadata:
-                # h5py 3 reads str variable length datasets as bytes. See
-                # https://docs.h5py.org/en/stable/whatsnew/3.0.html#breaking-changes-deprecations.
-                if h5py_version.startswith("3") and self.dtype.metadata["vlen"] == str:
-                    return bytes()
-                return self.dtype.metadata["vlen"]()
-            elif "h5py_encoding" in self.dtype.metadata:
-                return self.dtype.type()
-        return np.zeros((), dtype=self.dtype)[()]
+    def dtype(self):
+        """Override Dataset.dtype to allow hot-swapping
+        equivalent dtypes, e.g. NpyStrings <-> object strings
+        """
+        return self.id.raw_data.dtype
 
     @property
     def shape(self) -> tuple[int, ...]:
@@ -706,11 +491,11 @@ class InMemoryDataset(Dataset):
 
     @property
     def size(self) -> int:
-        return int(np.prod(self.shape))
+        return math.prod(self.shape)
 
     @property
     def chunks(self):
-        return ChunkSize(self.id.chunks)
+        return self.id.chunks
 
     @property
     def attrs(self):
@@ -857,15 +642,7 @@ class InMemoryDataset(Dataset):
             if vlen == val.dtype:
                 if val.ndim > 1:
                     tmp = np.empty(shape=val.shape[:-1], dtype=object)
-                    tmp.ravel()[:] = [
-                        i
-                        for i in val.reshape(
-                            (
-                                np.prod(val.shape[:-1], dtype=np.ulonglong),
-                                val.shape[-1],
-                            )
-                        )
-                    ]
+                    tmp.ravel()[:] = val.reshape(-1, val.shape[-1])
                 else:
                     tmp = np.array([None], dtype=object)
                     tmp[0] = val
@@ -957,6 +734,7 @@ class DatasetLike:
     name
     shape
     dtype
+    attrs
     _fillvalue
     parent (the parent group)
     """
@@ -964,27 +742,26 @@ class DatasetLike:
     name: str
     shape: tuple[int, ...]
     dtype: np.dtype
-    _fillvalue: object | None
+    attrs: dict[str, Any]
+    _fillvalue: Any | None
     parent: InMemoryGroup
 
     @property
     def size(self) -> int:
-        return int(np.prod(self.shape))
+        return math.prod(self.shape)
 
     @property
-    def fillvalue(self) -> Any:
-        if self._fillvalue is not None:
-            return np.array([self._fillvalue], dtype=self.dtype)[0]
-        if self.dtype.metadata:
+    def fillvalue(self) -> np.generic:
+        fv = self._fillvalue
+        if fv is None and self.dtype.metadata:
             # Custom h5py string dtype. Make sure to use a fillvalue of ''
-            if "vlen" in self.dtype.metadata:
-                # h5py 3 reads str variable length datasets as bytes. See
-                # https://docs.h5py.org/en/stable/whatsnew/3.0.html#breaking-changes-deprecations.
-                if h5py_version.startswith("3") and self.dtype.metadata["vlen"] == str:
-                    return bytes()
-                return self.dtype.metadata["vlen"]()
+            if (vlen := self.dtype.metadata.get("vlen")) is not None:
+                fv = bytes() if vlen is str else vlen()
             elif "h5py_encoding" in self.dtype.metadata:
-                return b""
+                fv = bytes()
+
+        if fv is not None:
+            return np.asarray(fv, dtype=self.dtype)[()]
         return np.zeros((), dtype=self.dtype)[()]
 
     @property
@@ -1058,28 +835,23 @@ class InMemoryArrayDataset(DatasetLike):
     Class that looks like a h5py.Dataset but is backed by an array
     """
 
-    def __init__(self, name, array, parent, fillvalue=None, chunks=None):
+    def __init__(
+        self,
+        name: str,
+        array: np.ndarray,
+        *,
+        parent: InMemoryGroup,
+        fillvalue: Any | None = None,
+        chunks: tuple[int, ...] | None = None,
+    ):
         self.name = name
-        self._array = array  # May have a different dtype!
-        self._dtype = None  # Maybe overwritten by create_dataset
+        self._array = array
         self.attrs = {}
         self.parent = parent
         self._fillvalue = fillvalue
         if chunks is None:
             chunks = parent.chunks[name]
-        self._chunks = chunks
-
-    def as_dtype(self, name, dtype, parent, casting="unsafe"):
-        """
-        Return a copy of `self` as a new dataset with the given `name` and `dtype`
-        in the group `parent`.
-
-        `casting` should be as in the numpy astype() method.
-
-        """
-        return self.__class__(
-            name, self._array.astype(dtype, casting=casting), parent=parent
-        )
+        self.chunks = chunks
 
     @property
     def shape(self) -> tuple[int, ...]:
@@ -1087,21 +859,17 @@ class InMemoryArrayDataset(DatasetLike):
 
     @property
     def dtype(self) -> np.dtype:
-        return self._dtype or self._array.dtype
+        return self._array.dtype
 
     def __getitem__(self, item):
-        return np.asarray(self._array[item], dtype=self._dtype)[()]
+        return self._array[item]
 
     def __setitem__(self, item, value):
         self.parent._check_committed()
         self._array[item] = value
 
     def __array__(self, dtype=None):
-        return np.asarray(self._array, dtype=dtype or self._dtype)
-
-    @property
-    def chunks(self):
-        return self._chunks
+        return self._array
 
     def resize(self, size, axis=None):
         self.parent._check_committed()
@@ -1141,8 +909,6 @@ class InMemorySparseDataset(DatasetLike):
         if shape is None:
             raise TypeError("shape must be specified for sparse datasets")
         self.name = name
-        self.shape = shape
-        self.dtype = np.dtype(dtype)
         self.attrs = {}
         self._fillvalue = fillvalue
         if chunks in [True, None]:
@@ -1152,44 +918,29 @@ class InMemorySparseDataset(DatasetLike):
                 raise NotImplementedError(
                     "chunks must be specified for multi-dimensional datasets"
                 )
-        self.chunks = ChunkSize(chunks)
         self.parent = parent
-
         self.staged_changes = StagedChangesArray.full(
             shape=shape,
             chunk_size=tuple(chunks),
             dtype=dtype,
-            fill_value=self.fillvalue,
+            fill_value=fillvalue,
         )
 
     @property
     def data_dict(self) -> dict[Tuple, Slice | np.ndarray]:
         return _staged_changes_to_data_dict(self.staged_changes)
 
-    def as_dtype(self, name, dtype, parent, casting="unsafe"):
-        """
-        Return a copy of `self` as a new dataset with the given `name` and `dtype`
-        in the group `parent`.
+    @property
+    def shape(self):
+        return self.staged_changes.shape
 
-        `casting` should be as in the numpy astype() method.
+    @property
+    def chunks(self):
+        return self.staged_changes.chunk_size
 
-        """
-        if self.fillvalue is not None:
-            new_fillvalue = self.fillvalue.astype(dtype, casting=casting)
-        else:
-            new_fillvalue = None
-
-        out = type(self)(
-            name=name,
-            shape=(),
-            dtype=dtype,
-            parent=parent,
-            chunks=self.chunks,
-            fillvalue=new_fillvalue,
-        )
-        out.staged_changes = self.staged_changes.astype(dtype, casting=casting)
-        out.shape = self.shape
-        return out
+    @property
+    def dtype(self):
+        return self.staged_changes.dtype
 
     @classmethod
     def from_dataset(cls, dataset, parent=None):
@@ -1247,6 +998,8 @@ def _staged_changes_to_data_dict(
 
 
 class DatasetWrapper(DatasetLike):
+    dataset: InMemoryDataset | InMemoryArrayDataset | InMemorySparseDataset
+
     def __init__(self, dataset):
         self.dataset = dataset
 
@@ -1260,7 +1013,7 @@ class DatasetWrapper(DatasetLike):
             new_dataset = InMemoryArrayDataset(
                 self.name,
                 np.broadcast_to(value, self.shape).astype(self.dtype),
-                self.parent,
+                parent=self.parent,
                 fillvalue=self.fillvalue,
                 chunks=self.chunks,
             )


### PR DESCRIPTION
### `modify_metadata`
- Fixed bug where setting `fillvalue=0` would retain the previous fillvalue
- Speed up when the `fillvalue` doesn't change
- Added test for changing  `dtype` on sparse datasets
- Fixed bug when changing `dtype` and `fillvalue` at the same time, which could cause the new `fillvalue` to be transitorily cast to the old `dtype` and overflow, underflow, or lose definition

### `wrappers.py`
- Removed an _astonishing_ amount of dead or useless code
- Simplified code flow
- Removed "lazy" logic in `InMemoryArrayDataset` dtype. It was offering zero performance benefits compared to just eagerly converting input arrays from the users, while being ripe with complexity and bugs.
- Fixed bug that would lead to overflow/underflow/loss of definition after calling `__setitem__` on the initial version of a dataset, caused by the aforementioned lazy dtype logic:
```python
>>> ds = v.create_dataset("x", data=np.asarray([1,2], dtype=np.int8), dtype=np.int64)
>>> ds[0] = 300
OverflowError: Python integer 300 out of bounds for int8
```
- Fixed crashes in `create_dataset` when `chunks` was either a bare integer or `True`
- `create_dataset` will now explicitly disallow `chunks=False` (before it would lead to an uncontrolled crash)
- `create_dataset` will now warn for _all_ ignored kwargs, not just for `maxshape`
- The `.chunks` property would occasionally return an unnecessary `ndindex.ChunkType`; it now always returns a tuple of ints like in h5py
- Improved typing annotations
