### PR TITLE
StagedChangesArray to accept AsTypeView as base slab

### DIFF
--- a/versioned_hdf5/meson.build
+++ b/versioned_hdf5/meson.build
@@ -6,6 +6,7 @@ py.install_sources(
         'hashtable.py',
         'replay.py',
         'tools.py',
+        'typing_.py',
         'versions.py',
         'wrappers.py',
     ],

--- a/versioned_hdf5/slicetools.pyx
+++ b/versioned_hdf5/slicetools.pyx
@@ -21,6 +21,7 @@ from libc.stdio cimport FILE, fclose
 from versioned_hdf5.cytools import np_hsize_t
 from versioned_hdf5.cytools cimport ceil_a_over_b, count2stop, hsize_t, stop2count
 from versioned_hdf5.tools import asarray
+from versioned_hdf5.typing_ import ArrayProtocol
 
 
 cdef FILE* fmemopen(void* buf, size_t size, const char* mode):
@@ -283,7 +284,7 @@ cdef Exception HDF5Error():
 
 
 cpdef void read_many_slices(
-    src: np.ndarray | h5py.Dataset,
+    src: ArrayProtocol,
     np.ndarray dst,
     src_start: ArrayLike,
     dst_start: ArrayLike,
@@ -302,7 +303,7 @@ cpdef void read_many_slices(
 
     Parameters
     ----------
-    src: np.ndarray | h5py.Dataset
+    src: np.ndarray | h5py.Dataset | other array-like object
         The source data to read from
     dst: np.ndarray
         The destination array to write to.
@@ -456,7 +457,7 @@ cpdef void read_many_slices(
     )
     # On 32-bit platforms, sizeof(hsize_t) == 8; sizeof(npy_intp) == 4
     # On 64-bit platforms, don't copy unnecessarily
-    dst_shape = asarray(dst_shape, np_hsize_t)
+    dst_shape = asarray(dst_shape, dtype=np_hsize_t)
 
     clipped_count = _clip_count(
         src_shape,
@@ -507,7 +508,7 @@ cdef np.ndarray _preproc_many_slices_idx(obj: ArrayLike, hsize_t ndim, bint fast
     if hasattr(obj, "dtype") and obj.dtype.kind != "u" and (obj < 0).any():
         raise OverflowError("index out of bounds for uint64")
     # Don't copy when converting from np.intp to uint64 on 64-bit platforms
-    cdef np.ndarray arr = asarray(obj, np_hsize_t)
+    cdef np.ndarray arr = asarray(obj, dtype=np_hsize_t)
 
     if arr.ndim not in (1, 2):
         raise ValueError("Coordinates arrays must have 1 or 2 dimensions")
@@ -644,7 +645,7 @@ cdef void _read_many_slices_fast (
 @cython.boundscheck(False)
 @cython.infer_types(True)
 cdef void _read_many_slices_slow (
-    src: np.ndarray | h5py.Dataset,
+    src: ArrayProtocol,
     np.ndarray dst,
     const hsize_t[:, :] src_start,
     const hsize_t[:, :] dst_start,
@@ -659,6 +660,7 @@ cdef void _read_many_slices_slow (
        This is to avoid replicating the complex machinery found in
        h5py.Dataset.__getitem__.
     2. src is a numpy array.
+    3. src is a numpy-like object, e.g. a h5py AsTypeView object.
 
     Performance notes
     -----------------

--- a/versioned_hdf5/staged_changes.py
+++ b/versioned_hdf5/staged_changes.py
@@ -491,7 +491,7 @@ class StagedChangesArray(MutableMapping[Any, T]):
         # Preprocess value parameter
         # Avoid double deep-copy of array-like objects that support the __array_*
         # interface (e.g. sparse arrays).
-        value = cast(NDArray[T], asarray(value, self.dtype))
+        value = cast(NDArray[T], asarray(value, dtype=self.dtype))
 
         if plan.value_shape != value.shape:
             value = np.broadcast_to(value, plan.value_shape)
@@ -1684,7 +1684,7 @@ def _chunks_in_selection(
 
     if idxidx:
         # Don't copy when converting from np.intp to uint64 on 64-bit platforms
-        columns = [asarray(nz_i, np_hsize_t) for nz_i in nz]
+        columns = [asarray(nz_i, dtype=np_hsize_t) for nz_i in nz]
     else:
         columns = [
             np.asarray(mapper.chunk_indices)[nz_i] for mapper, nz_i in zip(mappers, nz)

--- a/versioned_hdf5/subchunk_map.py
+++ b/versioned_hdf5/subchunk_map.py
@@ -570,7 +570,7 @@ class IntegerArrayMapper(IndexChunkMapper):
                 # O(n^2)
                 mask = (chunk_start <= self.idx) & (self.idx < chunk_stop)
                 # Don't copy when converting from np.intp to uint64 on 64-bit platforms
-                value_sub_idx = asarray(np.flatnonzero(mask), np_hsize_t)
+                value_sub_idx = asarray(np.flatnonzero(mask), dtype=np_hsize_t)
                 chunk_sub_idx = self.idx[value_sub_idx]
 
             if max_rows > n_sel_chunks:
@@ -825,7 +825,7 @@ def _maybe_array_idx_to_slice(idx: Any):  # -> NDArray[np_hsize_t] | slice:
         idx = np.flatnonzero(idx)
 
     # Don't copy when converting from np.intp to uint64 on 64-bit platforms
-    idx = asarray(idx, np_hsize_t)
+    idx = asarray(idx, dtype=np_hsize_t)
 
     if not idx.flags.writeable:
         # Cython doesn't support read-only views in pure Python mode,

--- a/versioned_hdf5/tests/test_slicetools.py
+++ b/versioned_hdf5/tests/test_slicetools.py
@@ -15,6 +15,7 @@ from ..slicetools import (
     read_many_slices,
     spaceid_to_slice,
 )
+from .test_typing import MinimalArray
 
 max_examples = 10_000
 
@@ -464,6 +465,15 @@ def test_read_many_slices_not_fast_read_ok(h5file):
 
     with pytest.raises(ValueError, match="fast transfer is not possible"):
         read_many_slices(src, dst, [[1]], [[0]], [[1]], fast=True)
+
+
+def test_read_many_slices_array_protocol():
+    """Test that the src array can be anything that implements ArrayProtocol"""
+    src = MinimalArray(np.arange(10))
+    dst = np.zeros(4, dtype=src.dtype)
+    expect = np.asarray([0, 2, 3, 0])
+    read_many_slices(src, dst, src_start=[(2,)], dst_start=[(1,)], count=[(2,)])
+    np.testing.assert_equal(dst, expect)
 
 
 def test_read_many_slices_fail():

--- a/versioned_hdf5/tests/test_tools.py
+++ b/versioned_hdf5/tests/test_tools.py
@@ -7,24 +7,25 @@ from hypothesis.extra import numpy as stnp
 from numpy.testing import assert_array_equal
 
 from ..tools import asarray, ix_with_slices
+from .test_typing import MinimalArray
 
 
 def test_asarray():
     a = np.array([1, -1], dtype="i2")
     b = asarray(a)
     assert b is a
-    b = asarray(a, "i2")
+    b = asarray(a, dtype="i2")
     assert b is a
-    b = asarray(a, "u2")
+    b = asarray(a, dtype="u2")
     assert_array_equal(b, a.astype("u2"), strict=True)
     assert b.base is a
-    b = asarray(a, "i4")
+    b = asarray(a, dtype="i4")
     assert_array_equal(b, a.astype("i4"), strict=True)
     assert b.base is None
 
     # Don't just test itemsize
     a = np.array([1, -1], dtype="i4")
-    b = asarray(a, "f4")
+    b = asarray(a, dtype="f4")
     assert_array_equal(b, a.astype("f4"), strict=True)
     assert b.base is None
 
@@ -57,6 +58,12 @@ def test_asarray():
     assert type(b) is type(a)
     assert b.base is None
     assert_array_equal(b, a.astype("i4"), strict=True)
+
+    a = MinimalArray(np.asarray([1], dtype="i8"))
+    b = asarray(a)
+    assert b is a
+    b = asarray(a, dtype="i8")
+    assert b is a
 
 
 @st.composite

--- a/versioned_hdf5/tests/test_typing.py
+++ b/versioned_hdf5/tests/test_typing.py
@@ -1,0 +1,62 @@
+import h5py
+import numpy as np
+import numpy.ma as ma
+import pytest
+from packaging.version import Version
+
+from ..typing_ import ArrayProtocol
+
+
+class MinimalArray:
+    """Minimal read-only NumPy array-like implementing the ArrayProtocol"""
+
+    def __init__(self, arr):
+        self._array = np.asarray(arr)
+        self._array.flags.writeable = False
+
+    @property
+    def shape(self):
+        return self._array.shape
+
+    @property
+    def ndim(self):
+        return self._array.ndim
+
+    @property
+    def dtype(self):
+        return self._array.dtype
+
+    def __getitem__(self, idx):
+        return type(self)(self._array[idx])
+
+    def __array__(self, dtype=None, copy=None):
+        """Needed to qualify as an ArrayLike and to be accepted
+        as the RHS of numpy.ndarray.__setitem__.
+        """
+        assert copy is not False
+        return self._array
+
+
+def test_array_protocol():
+    assert isinstance(MinimalArray(1), ArrayProtocol)
+    assert isinstance(np.array(1), ArrayProtocol)
+    assert isinstance(np.int64(1), ArrayProtocol)
+    assert not isinstance(1, ArrayProtocol)
+    assert not isinstance([1], ArrayProtocol)
+
+    # numpy subclasses implement ArrayProtocol
+    x = ma.masked_array([1, -1], mask=[0, 1], dtype="i2")
+    assert isinstance(x, ArrayProtocol)
+
+
+def test_array_protocol_h5_dataset(h5file):
+    """Test that h5py.Dataset is a ArrayProtocol"""
+    dset = h5file.create_dataset("x", shape=(10,), dtype="i2")
+    assert isinstance(dset, ArrayProtocol)
+
+
+@pytest.mark.skipif(Version(h5py.__version__) < Version("3.13"), reason="h5py#2550")
+def test_array_protocol_h5_astypeview(h5file):
+    """Test that h5py AsTypeView is a ArrayProtocol"""
+    dset = h5file.create_dataset("x", shape=(10,), dtype="i2")
+    assert isinstance(dset.astype("i4"), ArrayProtocol)

--- a/versioned_hdf5/typing_.py
+++ b/versioned_hdf5/typing_.py
@@ -17,7 +17,7 @@ from numpy.typing import DTypeLike, NDArray
 class ArrayProtocol(Protocol):
     """Minimal read-only NumPy array-like interface.
 
-    Not to be confused with numpy.testing.ArrayLike, which is any object that
+    Not to be confused with numpy.typing.ArrayLike, which is any object that
     can be coerced into a numpy array, including a nested list.
     """
 

--- a/versioned_hdf5/typing_.py
+++ b/versioned_hdf5/typing_.py
@@ -1,0 +1,37 @@
+"""Type annotations.
+
+Note: This module cannot be called 'typing' or 'types' as it will cause a
+collision in Cython with the standard library 'typing' and 'types' modules.
+(In Python, this issue was fixed in 3.0).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+import numpy as np
+from numpy.typing import DTypeLike, NDArray
+
+
+@runtime_checkable
+class ArrayProtocol(Protocol):
+    """Minimal read-only NumPy array-like interface.
+
+    Not to be confused with numpy.testing.ArrayLike, which is any object that
+    can be coerced into a numpy array, including a nested list.
+    """
+
+    @property
+    def shape(self) -> tuple[int, ...]: ...
+
+    @property
+    def ndim(self) -> int: ...
+
+    @property
+    def dtype(self) -> np.dtype: ...
+
+    def __getitem__(self, key: Any) -> ArrayProtocol: ...
+
+    def __array__(
+        self, dtype: DTypeLike | None = None, copy: bool | None = None
+    ) -> NDArray: ...


### PR DESCRIPTION
Tighten the API surface that a "numpy-like" object must expose in order to be accepted as as a StagedChangesArray base slab. This PR allows h5py `AsTypeView` objects to qualify, and is propaedeutic to implementing NpyStrings datasets (https://github.com/h5py/h5py/pull/2557)