### PR TITLE
Fix handling of empty multidimensional datasets

### DIFF
--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -800,3 +800,29 @@ def test_create_empty_virtual_dataset(setup_vfile):
         assert_equal(ds, np.array([]))
         assert ds.shape == (0,)
         assert ds.size == 0
+
+def test_create_empty_multidimensional_virtual_dataset(setup_vfile):
+    """Check that creating an empty multidimensional virtual dataset writes no raw data.
+
+    See https://github.com/deshaw/versioned-hdf5/issues/430 for context.
+    """
+    name = "empty_dataset"
+
+    with setup_vfile(version_name="r0") as f:
+        write_dataset(f, name, np.array([[]]), chunks=(100, 100))
+        create_virtual_dataset(
+            f,
+            "r0",
+            name,
+            (0, 0),
+            {},
+        )
+
+        # Check that the raw data has only fill_value in it
+        assert_equal(f["_version_data"][name]["raw_data"][:], 0.0)
+
+        # Check that the virtual data is empty
+        ds = f["_version_data"]["versions"]["r0"][name][:]
+        assert_equal(ds, np.zeros((0, 0)))
+        assert ds.shape == (0, 0)
+        assert ds.size == 0

--- a/versioned_hdf5/backend.py
+++ b/versioned_hdf5/backend.py
@@ -447,7 +447,7 @@ def create_virtual_dataset(
     raw_data_name = raw_data.name.encode("utf-8")
 
     if len(raw_data) == 0:
-        layout = VirtualLayout(shape=(0,), dtype=raw_data.dtype)
+        layout = VirtualLayout(shape=tuple([0 for _ in shape]), dtype=raw_data.dtype)
     else:
         layout = VirtualLayout(shape, dtype=raw_data.dtype)
         layout._src_filenames.add(b".")


### PR DESCRIPTION
For empty multidimensional datasets we need to use a shape of the correct number of dimensions.

Previously we always picked `shape = (0,)` which led to the following error:
```
>>> # THIS CELL WAS AUTO-GENERATED BY PYFLYBY
>>> import h5py
>>> import tempfile
>>> from versioned_hdf5 import VersionedHDF5File
>>> # END AUTO-GENERATED BLOCK

>>> with tempfile.TemporaryDirectory() as tmp_dir:
...     with h5py.File(f'{tmp_dir}/data.h5', 'w') as f:
...         vf = VersionedHDF5File(f)
...         with vf.stage_version('v0') as sv:
...             sv.create_dataset('mask', dtype='i1', fillvalue=0, shape=(0, 0, 0, 0), chunks=(10, 1, 2, 250, 1))
...         with vf.stage_version('v1') as sv:
...             sv['mask'].resize((3, 41, 2, 277, 1))
...             sv['mask'][:] = 0
...         with vf.stage_version('v2') as sv:
...             # this will now fail
...             sv['mask']

---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[15], line 5
      3 vf = VersionedHDF5File(f)
      4 with vf.stage_version('v0') as sv:
----> 5     sv.create_dataset('mask', dtype='i1', fillvalue=0, shape=(0, 0, 0, 0), chunks=(10, 1, 2, 250, 1))
      6 with vf.stage_version('v1') as sv:
      7     sv['mask'].resize((3, 41, 2, 277, 1))

File /usr/local/python/python3/std/lib64/python3.11/site-packages/versioned_hdf5/wrappers.py:218, in InMemoryGroup.create_dataset(self, name, shape, dtype, data, fillvalue, **kwds)
    214 if "maxshape" in kwds and any(i != None for i in kwds["maxshape"]):
    215     warnings.warn(
    216         "The maxshape parameter is currently ignored for versioned datasets."
    217     )
--> 218 data = _make_new_dset(
    219     data=data, shape=shape, dtype=dtype, fillvalue=fillvalue, **kwds
    220 )
    221 if shape is None:
    222     shape = data.shape

File /usr/local/python/python3/std/lib64/python3.11/site-packages/versioned_hdf5/wrappers.py:551, in _make_new_dset(shape, dtype, data, chunks, compression, shuffle, fletcher32, maxshape, compression_opts, fillvalue, scaleoffset, track_times, external, track_order, dcpl)
    549     compression_opts = compression
    550     compression = "gzip"
--> 551 dcpl = filters.fill_dcpl(
    552     dcpl or h5p.create(h5p.DATASET_CREATE),
    553     shape,
    554     dtype,
    555     chunks,
    556     compression,
    557     compression_opts,
    558     shuffle,
    559     fletcher32,
    560     maxshape,
    561     scaleoffset,
    562     external,
    563 )
    565 if fillvalue is not None:
    566     fillvalue = np.array(fillvalue)

File /usr/local/python/python3/std/lib64/python3.11/site-packages/h5py/_hl/filters.py:181, in fill_dcpl(plist, shape, dtype, chunks, compression, compression_opts, shuffle, fletcher32, maxshape, scaleoffset, external, allow_unknown_filter, fill_time)
    178     if len(tpl) != len(shape):
    179         raise ValueError('"%s" must have same rank as dataset shape' % name)
--> 181 rq_tuple(chunks, 'chunks')
    182 rq_tuple(maxshape, 'maxshape')
    184 if compression is not None:

File /usr/local/python/python3/std/lib64/python3.11/site-packages/h5py/_hl/filters.py:179, in fill_dcpl.<locals>.rq_tuple(tpl, name)
    177     raise TypeError('"%s" argument must be None or a sequence object' % name)
    178 if len(tpl) != len(shape):
--> 179     raise ValueError('"%s" must have same rank as dataset shape' % name)

ValueError: "chunks" must have same rank as dataset shape
```

Fixes #430.