### PR TITLE
Fix hashing validation with mix of str and bytes

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 
 import h5py
 import pytest
+from numpy.testing import assert_array_equal
 
 from versioned_hdf5 import VersionedHDF5File
 from versioned_hdf5.backend import initialize
@@ -356,3 +357,11 @@ def setup_vfile(tmp_path: str) -> Callable[[str | None, str | None], h5py.File]:
         return f
 
     return _setup_vfile
+
+
+def assert_slab_offsets(version, name, expect):
+    """Assert that the StagedChangesArray.slab_offsets matches the expectations.
+    This is useful to test chunk reuse.
+    """
+    ds = version[name]
+    assert_array_equal(ds.staged_changes.slab_offsets, expect)

--- a/versioned_hdf5/hashtable.py
+++ b/versioned_hdf5/hashtable.py
@@ -135,7 +135,7 @@ class Hashtable(MutableMapping):
                 # Use little-endian byte order (e.g. x86, ARM) for consistency
                 # everywhere, even on big-endian architectures (e.g. PowerPC).
                 hash_value.update(struct.pack("<Q", len(value)))
-                # Hash the buffer of bytes, bytearray, memoryview, etc.
+                # Hash the buffer of bytes.
                 hash_value.update(value)
         else:
             hash_value.update(np.ascontiguousarray(data))


### PR DESCRIPTION
This is part of NpyStrings work.

Fix bug where the `ENABLE_CHUNK_REUSE_VALIDATION` flag would trigger a false positive when the first element of an object array is bytes, but then later on there are str elements.