### PR TITLE
NpyStrings benchmarks

### DIFF
--- a/benchmarks/hashtable.py
+++ b/benchmarks/hashtable.py
@@ -1,0 +1,50 @@
+import string
+
+import h5py
+import numpy as np
+
+from versioned_hdf5.hashtable import Hashtable
+
+from .common import Benchmark, require_npystrings
+
+
+class TimeHashtable(Benchmark):
+    params = [
+        ["f", "S", "O", "T"],
+        [1, 4, 8, 64, 256],
+    ]
+    param_names = ["dtype", "nbytes"]
+
+    CHUNKS = (100, 100)
+
+    def setup(self, dtype, nbytes):
+        super().setup()
+        if dtype == "f" and nbytes not in (4, 8):
+            raise NotImplementedError()
+        if dtype in ("f", "S"):
+            dtype = f"{dtype}{nbytes}"
+        if dtype == "O":  # object strings
+            dtype = h5py.string_dtype()
+        if dtype == "T":  # NpyStrings a.k.a. StringDType
+            require_npystrings()
+
+        # Not needed to benchmark hash() but required to initialize the
+        # Hashtable instance.
+        with self.vfile.stage_version("init") as sv:
+            # Create an initial empty hashtable
+            sv.create_dataset(
+                "x",
+                shape=self.CHUNKS,
+                chunks=self.CHUNKS,
+                dtype=dtype,
+                fillvalue=0 if dtype in ("f4", "f8") else "",
+            )
+        self.hashtable = Hashtable(self.file, "x")
+
+        if dtype in ("f4", "f8"):
+            self.chunk = self.rng.standard_normal(self.CHUNKS).astype(dtype)
+        else:
+            self.chunk = self.rand_strings(self.CHUNKS, 0, nbytes, dtype)
+
+    def time_hash(self, dtype, nbytes):
+        self.hashtable.hash(self.chunk)

--- a/benchmarks/strings.py
+++ b/benchmarks/strings.py
@@ -1,0 +1,90 @@
+import h5py
+
+from .common import Benchmark, require_npystrings
+
+
+class TimeStrings(Benchmark):
+    """Benchmark for string dtypes"""
+
+    params = [
+        ["h5py", "versioned_hdf5"],
+        ["S", "O", "T"],
+        [1, 8, 64, 256],
+    ]
+    param_names = ["library", "dtype", "max_nchars"]
+
+    SHAPE = (200, 200)
+    CHUNKS = (100, 100)
+
+    def setup(self, library, dtype, max_nchars):
+        super().setup()
+        if dtype == "S":
+            dtype = f"S{max_nchars}"
+        elif dtype == "O":  # object strings
+            dtype = h5py.string_dtype()
+        elif dtype == "T":  # NpyStrings a.k.a. StringDType
+            require_npystrings()
+
+        self.data1 = self.rand_strings(self.SHAPE, 0, max_nchars, dtype)
+        self.data2 = self.rand_strings(self.SHAPE, 0, max_nchars, dtype)
+
+        if library == "h5py":
+            self.file.create_dataset("x", data=self.data1, chunks=self.CHUNKS)
+            self.reopen()
+            self.ds = self.file["x"]
+        else:
+            with self.vfile.stage_version("v0") as sv:
+                sv.create_dataset("x", data=self.data1, chunks=self.CHUNKS)
+            self.reopen()
+            self.ctx = self.vfile.stage_version("v1")
+            sv = self.ctx.__enter__()
+            self.ds = sv["x"]
+
+    def time_getitem(self, library, dtype, max_nchars):
+        if dtype == "T":
+            res = self.ds.astype("T")[:]
+        elif dtype == "S":
+            res = self.ds[:].astype("U")
+        else:
+            assert dtype == "O"
+            res = self.ds.asstr()[:]
+
+    def time_setitem(self, library, dtype, max_nchars):
+        self.assert_clean_setup()
+        self.ds[:] = self.data2
+
+    def time_update_identical(self, library, dtype, max_nchars):
+        self.assert_clean_setup()
+        self.ds[:] = self.data1
+        if library == "versioned_hdf5":
+            self.ctx.__exit__(None, None, None)
+            del self.ctx
+
+    def time_update_different(self, library, dtype, max_nchars):
+        self.assert_clean_setup()
+        self.ds[:] = self.data2
+        if library == "versioned_hdf5":
+            self.ctx.__exit__(None, None, None)
+            del self.ctx
+
+    def time_read_write_loop_same_chunk(self, library, dtype, max_nchars):
+        self.assert_clean_setup()
+        view = self.ds.astype("T") if dtype == "T" else self.ds
+        for i in range(0, self.ds.shape[0], 2):
+            self.ds[i + 1, :] = view[i, :][::-1]
+
+    def time_read_write_loop_different_chunk(self, library, dtype, max_nchars):
+        self.assert_clean_setup()
+        view = self.ds.astype("T") if dtype == "T" else self.ds
+        for i in range(0, self.ds.shape[0] // 2):
+            self.ds[-i - 1, :] = view[i, :][::-1]
+
+    def time_read_write_loop_fast_astype(self, library, dtype, max_nchars):
+        self.assert_clean_setup()
+        for i in range(0, self.ds.shape[0], 2):
+            self.ds[i + 1, :] = self.ds.astype("T")[i, :][::-1]
+
+    def teardown(self, library, dtype, max_nchars):
+        if hasattr(self, "ctx"):
+            self.ctx.__exit__(None, None, None)
+        super().teardown()

--- a/benchmarks/strings.py
+++ b/benchmarks/strings.py
@@ -82,7 +82,8 @@ class TimeStrings(Benchmark):
     def time_read_write_loop_fast_astype(self, library, dtype, max_nchars):
         self.assert_clean_setup()
         for i in range(0, self.ds.shape[0], 2):
-            self.ds[i + 1, :] = self.ds.astype("T")[i, :][::-1]
+            view = self.ds.astype("T") if dtype == "T" else self.ds
+            self.ds[i + 1, :] = view[i, :][::-1]
 
     def teardown(self, library, dtype, max_nchars):
         if hasattr(self, "ctx"):


### PR DESCRIPTION
- Blocked by and incorporates https://github.com/deshaw/versioned-hdf5/pull/442.
- #427 enables dtype="T" and fixes `astype` test failures

See only final commit.
**tip:** you can pip-install a different branch (#427), switch back to this branch, and run `asv run --python=same --quick`