### PR TITLE
Support conda-forge builds

### DIFF
--- a/ci/cp_pyx_to_py.py
+++ b/ci/cp_pyx_to_py.py
@@ -1,0 +1,18 @@
+"""Make a copy of Cython files with pure-python syntax (.py)[1] to .pyx.
+[1] https://cython.readthedocs.io/en/latest/src/tutorial/pure.html
+
+This is a hack to convince Meson to compile .py files with Cython.
+
+.. note::
+    Don't use the 'cp' shell command, as it fails on conda-forge Windows CI.
+"""
+import pathlib
+import shutil
+
+if __name__ == "__main__":
+    proj_dir = pathlib.Path(__file__).parent.parent / "versioned_hdf5"
+    for modname in ("cytools", "subchunk_map", "staged_changes"):
+        src = proj_dir / f"{modname}.py"
+        dst = proj_dir / f"{modname}.pyx"
+        print(f"Copy {src} -> {dst}")
+        shutil.copyfile(src, dst)

--- a/versioned_hdf5/meson.build
+++ b/versioned_hdf5/meson.build
@@ -58,8 +58,8 @@ cython_args = [
 # (you'll need to install all build dependencies first).
 
 # Hack to convince Meson to compile pure-python .py files with Cython
-# (read: https://cython.readthedocs.io/en/latest/src/tutorial/pure.html)
-run_command('cp', 'cytools.py', 'cytools.pyx', check: true)
+run_command('python', '../ci/cp_pyx_to_py.py', check: true)
+
 py.extension_module(
     'cytools',
     'cytools.pyx',
@@ -69,7 +69,6 @@ py.extension_module(
     cython_args: cython_args,
 )
 
-run_command('cp', 'subchunk_map.py', 'subchunk_map.pyx', check: true)
 py.extension_module(
     'subchunk_map',
     'subchunk_map.pyx',
@@ -79,7 +78,6 @@ py.extension_module(
     cython_args: cython_args,
 )
 
-run_command('cp', 'staged_changes.py', 'staged_changes.pyx', check: true)
 py.extension_module(
     'staged_changes',
     'staged_changes.pyx',


### PR DESCRIPTION
Fix failure to build on Windows in absence of bash.
Blocks https://github.com/conda-forge/versioned-hdf5-feedstock/pull/8