### PR TITLE
Use org-wide default CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+See https://github.com/deshaw/.github/blob/main/.github/CONTRIBUTING.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,0 @@
-# Contributing
-
-We love contributions! Before you can contribute, please [sign and submit this Contributor License Agreement (CLA)](https://www.deshaw.com/oss/cla),
-declaring that you have both the rights to your contribution and you grant us us the rights to use your contribution.
-This CLA is in place to protect all users of this project. You only need to sign this once for all projects using our CLA.


### PR DESCRIPTION
Use the deshaw org's default CONTRIBUTING.md community health file, located at https://github.com/deshaw/.github/blob/80087ec4b1eb10ad397978632dacc55c608973bf/.github/CONTRIBUTING.md

CC @mlucool