### PR TITLE
Build wheels in selected PRs

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -3,7 +3,7 @@ name: Release Python Bindings to PyPI
 on:
   release:
     types: [published]
-  # pull_request:
+  pull_request:  # Binary wheels are only built for PRs with the 'wheels' label
   workflow_dispatch:
     inputs:
       test_pypi:
@@ -31,7 +31,7 @@ jobs:
           sudo apt install -y libhdf5-dev
           pip install build twine
 
-      - name: 📦 Build the sdist and wheel
+      - name: 📦 Build the source tarball
         run: python -m build --sdist -o wheelhouse
 
       - name: List and check sdist
@@ -46,6 +46,7 @@ jobs:
           path: ./wheelhouse/*.tar.gz
 
   build-wheels:
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'wheels')
     name: 'Build wheels: ${{ matrix.os }} ${{ matrix.arch }} ${{ matrix.python-version }}'
     uses: ./.github/workflows/wheels.yml
     with:
@@ -55,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-13, macos-14]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-13, macos-latest]
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         include:
           - os: ubuntu-latest
@@ -64,7 +65,7 @@ jobs:
             arch: aarch64
           - os: macos-13
             arch: x86_64
-          - os: macos-14
+          - os: macos-latest
             arch: arm64
 
   publish:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -5,12 +5,12 @@
 - Before making a release, you need to make a changelog with the changes. The
   changelog is in `docs/changelog.md` (see {any}`changelog`).
 
-- It's a good idea to push up your changes as a GitHub PR before doing the
-  final release cut so that the CI runs all the tests. You can merge the PR
-  once the release is made.
-
-- Make sure to update version pinning in setup.py if necessary, e.g., if the
+- Make sure to update version pinning in `pyproject.toml` if necessary, e.g., if the
   minimum supported version of h5py or ndindex has changed.
+
+- It's a good idea to push your changes as a GitHub PR before doing the final release
+  cut so that the CI runs all the tests. Add the `wheels` tag to the PR to retest that
+  binary wheels are still building correctly.
 
 ## Doing the release
 
@@ -28,3 +28,7 @@ The bot will make a pull request to the [conda-forge
 feedstock](https://github.com/conda-forge/versioned-hdf5-feedstock/pulls)
 automatically. You will need to be listed as a maintainer in the recipe to be
 able to merge it. If you aren't, make a PR adding yourself.
+
+Before you merge the conda-forge PR, make sure that that the minimum requirements in
+`versioned-hdf5-feedstock/recipe/meta.yaml` are still aligned to those listed in
+`versioned-hdf5/pyproject.toml`.


### PR DESCRIPTION
A PR can now opt in to have the wheels CI run without waiting for a release. Just add the `wheels` label and reopen the PR.