### PR TITLE
Filters overhaul; add shuffle, fletcher32, scaleoffset

### DIFF
--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -8,6 +8,7 @@ from numpy.testing import assert_equal
 
 from versioned_hdf5.backend import (
     DEFAULT_CHUNK_SIZE,
+    Filters,
     create_base_dataset,
     create_virtual_dataset,
     write_dataset,
@@ -742,12 +743,18 @@ def test_write_dataset_compression(h5file):
     nchunks = int(np.ceil(data.size / chunksize))
 
     slices1 = write_dataset(
-        h5file, "test_data", data, compression="gzip", compression_opts=3
+        h5file,
+        "test_data",
+        data,
+        filters=Filters(compression="gzip", compression_opts=3),
     )
 
     with pytest.raises(ValueError):
         write_dataset(
-            h5file, "test_data", np.ones((DEFAULT_CHUNK_SIZE,)), compression="lzf"
+            h5file,
+            "test_data",
+            np.ones((DEFAULT_CHUNK_SIZE,)),
+            filters=Filters(compression="lzf"),
         )
 
     with pytest.raises(ValueError):
@@ -755,8 +762,7 @@ def test_write_dataset_compression(h5file):
             h5file,
             "test_data",
             np.ones((DEFAULT_CHUNK_SIZE,)),
-            compression="gzip",
-            compression_opts=4,
+            filters=Filters(compression="gzip", compression_opts=4),
         )
 
     expected = {}

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -3,7 +3,7 @@ import pytest
 from ndindex import Slice, Tuple
 from numpy.testing import assert_equal
 
-from versioned_hdf5.backend import DEFAULT_CHUNK_SIZE
+from versioned_hdf5.backend import DEFAULT_CHUNK_SIZE, Filters
 from versioned_hdf5.versions import (
     all_versions,
     commit_version,
@@ -26,8 +26,7 @@ def test_create_version(h5file):
         version1,
         {"test_data": data},
         chunks={"test_data": chunks},
-        compression={"test_data": "gzip"},
-        compression_opts={"test_data": 3},
+        filters={"test_data": Filters(compression="gzip", compression_opts=3)},
     )
 
     version_bad = create_version_group(h5file, "version_bad", "")
@@ -38,14 +37,18 @@ def test_create_version(h5file):
     version_bad = create_version_group(h5file, "version_bad", "")
     with pytest.raises(ValueError):
         commit_version(
-            version_bad, {"test_data": data}, compression={"test_data": "lzf"}
+            version_bad,
+            {"test_data": data},
+            filters={"test_data": Filters(compression="lzf")},
         )
     delete_version(h5file, "version_bad", "version1")
 
     version_bad = create_version_group(h5file, "version_bad", "")
     with pytest.raises(ValueError):
         commit_version(
-            version_bad, {"test_data": data}, compression_opts={"test_data": 4}
+            version_bad,
+            {"test_data": data},
+            filters={"test_data": Filters(compression_opts=4)},
         )
     delete_version(h5file, "version_bad", "version1")
 
@@ -104,8 +107,7 @@ def test_create_version_chunks(h5file):
         version1,
         {"test_data": data},
         chunks={"test_data": chunks},
-        compression={"test_data": "gzip"},
-        compression_opts={"test_data": 3},
+        filters={"test_data": Filters(compression="gzip", compression_opts=3)},
     )
     version_bad = create_version_group(h5file, "version_bad", "")
     with pytest.raises(ValueError):
@@ -115,14 +117,18 @@ def test_create_version_chunks(h5file):
     version_bad = create_version_group(h5file, "version_bad", "")
     with pytest.raises(ValueError):
         commit_version(
-            version_bad, {"test_data": data}, compression={"test_data": "lzf"}
+            version_bad,
+            {"test_data": data},
+            filters={"test_data": Filters(compression="lzf")},
         )
     delete_version(h5file, "version_bad", "version1")
 
     version_bad = create_version_group(h5file, "version_bad", "")
     with pytest.raises(ValueError):
         commit_version(
-            version_bad, {"test_data": data}, compression_opts={"test_data": 4}
+            version_bad,
+            {"test_data": data},
+            filters={"test_data": Filters(compression_opts=4)},
         )
     delete_version(h5file, "version_bad", "version1")
 

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -306,32 +306,47 @@ def test_compression(vfile, group_name, name, sparse):
         assert ds.compression_opts == 5
 
 
-def test_compression_hotswap_to_inmemoryarraydataset(vfile):
-    """Test .compression and .compression_opts properties after DatasetWrapper hot-swaps
+def test_filters_hotswap_to_inmemoryarraydataset(vfile):
+    """Test .compression, .compression_opts, .shuffle, and .fletcher32 after
+    DatasetWrapper hot-swaps
     InMemoryDataset -> InMemoryArrayDataset -> InMemorySparseDataset.
     """
     with vfile.stage_version("r0") as v:
         ds = v.create_dataset(
-            "x", data=[1, 2], chunks=(2,), compression="gzip", compression_opts=5
+            "x",
+            data=[1, 2],
+            chunks=(2,),
+            compression="gzip",
+            compression_opts=5,
+            shuffle=True,
+            fletcher32=True,
         )
         assert ds.compression == "gzip"
         assert ds.compression_opts == 5
+        assert ds.shuffle
+        assert ds.fletcher32
 
     with vfile.stage_version("r1") as v:
         ds = v["x"]
         assert isinstance(ds.dataset, InMemoryDataset)
         assert ds.compression == "gzip"
         assert ds.compression_opts == 5
+        assert ds.shuffle
+        assert ds.fletcher32
 
         ds[:] = [3, 4]
         assert isinstance(ds.dataset, InMemoryArrayDataset)
         assert ds.compression == "gzip"
         assert ds.compression_opts == 5
+        assert ds.shuffle
+        assert ds.fletcher32
 
         ds.resize((3,))
         assert isinstance(ds.dataset, InMemorySparseDataset)
         assert ds.compression == "gzip"
         assert ds.compression_opts == 5
+        assert ds.shuffle
+        assert ds.fletcher32
 
 
 @pytest.mark.parametrize(

--- a/versioned_hdf5/api.py
+++ b/versioned_hdf5/api.py
@@ -322,9 +322,8 @@ class VersionedHDF5File:
                 group,
                 group.datasets(),
                 make_current=make_current,
-                chunks=group.chunks,
-                compression=group.compression,
-                compression_opts=group.compression_opts,
+                chunks=group._chunks,
+                filters=group._filters,
                 timestamp=timestamp,
             )
         except:

--- a/versioned_hdf5/backend.py
+++ b/versioned_hdf5/backend.py
@@ -5,6 +5,8 @@ import logging
 import os
 import textwrap
 from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from h5py import Dataset, VirtualLayout, h5s, h5z
@@ -16,6 +18,10 @@ from numpy.testing import assert_array_equal
 
 from versioned_hdf5.h5py_compat import HAS_NPYSTRINGS
 from versioned_hdf5.hashtable import Hashtable
+from versioned_hdf5.typing_ import DEFAULT, Default
+
+if TYPE_CHECKING:
+    from versioned_hdf5.wrappers import FiltersMixin
 
 DEFAULT_CHUNK_SIZE = 2**12
 DATA_VERSION = 4
@@ -68,6 +74,107 @@ def initialize(f):
     versions.attrs["data_version"] = DATA_VERSION
 
 
+@dataclass
+class Filters:
+    """Filters keyword arguments for create_dataset.
+
+    Not to be confused with h5py.Dataset._filters, which is a dict in the format
+
+    {
+        <compression name>: <compression_opts>,  # compression=None if missing
+        scaleoffset: <mangled>,  # scaleoffset=None if missing
+        shuffle: <mangled>,  # True if present; False if missing
+        fletcher32: None,  # True if present; False if missing
+    }
+
+    Note: you should not assume that the above is the complete content
+    of _dataset._filters. There may be custom/unknown filters present.
+    """
+
+    # See matching class wrappers.FiltersMixin
+    compression: Any | None | Default = DEFAULT
+    compression_opts: Any | None | Default = DEFAULT
+    scaleoffset: int | None | Default = DEFAULT
+    shuffle: bool | Default = DEFAULT
+    fletcher32: bool | Default = DEFAULT
+
+    def as_kwargs(self) -> dict[str, Any]:
+        """Convert to kwargs for create_dataset."""
+        return {k: v for k, v in self.__dict__.items() if v is not DEFAULT}
+
+    @staticmethod
+    def from_dataset(ds: Dataset | FiltersMixin) -> Filters:
+        """Reverse engineer create_dataset kwargs for the filters from an existing
+        h5py.Dataset.
+        """
+        compression = ds.compression
+        compression_opts = ds.compression_opts
+        # FIXME This should be fixable upstream. h5py would need to expose a hook for
+        # hdf5plugin / pytables to let them declare that a filter ID is a
+        # compression filter.
+
+        if compression is None and isinstance(ds, Dataset):
+            # From hdf5plugin._filters. Can't just try-import hdf5plugin because the same
+            # filter IDs are also defined by pytables.
+            CUSTOM_COMPRESSION_FILTERS = {
+                32001,  # Blosc
+                32026,  # Blosc2
+                307,  # Bzip2
+                32004,  # LZ4
+                32008,  # Bitshuffle
+                32013,  # ZFP
+                32015,  # Zstandard
+                32017,  # SZ
+                32024,  # SZ3
+                32018,  # FCIDECOMP
+                32028,  # SPERR
+            }
+
+            for filter_id in CUSTOM_COMPRESSION_FILTERS:
+                try:
+                    compression_opts = ds._filters[str(filter_id)]
+                    compression = filter_id
+                    break
+                except KeyError:
+                    pass
+
+            if compression is None:
+                # If we're using a bespoke compression, there's no way of knowing
+                # whether an unknown filter is a valid compression or some other
+                # kind of filter, so we issue a warning about assuming that it is
+                # the dataset's compression.
+                for k, v in ds._filters.items():
+                    try:
+                        k = int(k)
+                    except ValueError:
+                        continue
+                    compression, compression_opts = k, v
+                    logging.warning(
+                        "No default compression detected in this dataset. "
+                        f"Guessed {compression=} {compression_opts=} "
+                        f"from {ds._filters=}."
+                    )
+                    break
+
+        return Filters(
+            compression=compression,
+            compression_opts=compression_opts,
+            scaleoffset=ds.scaleoffset,
+            shuffle=ds.shuffle,
+            fletcher32=ds.fletcher32,
+        )
+
+    def overrides(self, other: Filters) -> bool:
+        """Return True if there are any filters that are explicitly set in self and
+        differ between self and other; False otherwise.
+        """
+        for k, v1 in self.__dict__.items():
+            v2 = getattr(other, k)
+            if v1 is not DEFAULT and v2 is not DEFAULT and v1 != v2:
+                return True
+        return False
+
+
 def create_base_dataset(
     f,
     name,
@@ -75,10 +182,9 @@ def create_base_dataset(
     shape=None,
     data=None,
     dtype=None,
-    chunks=True,
-    compression=None,
-    compression_opts=None,
+    chunks=None,
     fillvalue=None,
+    filters: Filters | None = None,
 ):
     # Validate shape (based on h5py._hl.dataset.make_new_dset)
     if shape is None:
@@ -96,6 +202,7 @@ def create_base_dataset(
             raise ValueError("Shape tuple is incompatible with data")
 
     ndims = len(shape)
+
     if isinstance(chunks, int) and not isinstance(chunks, bool):
         chunks = (chunks,)
     if chunks in [True, None]:
@@ -127,15 +234,15 @@ def create_base_dataset(
                 "Non-default fillvalue not supported for variable length strings"
             )
         fillvalue = None
+    kwargs = filters.as_kwargs() if filters is not None else {}
     dataset = group.create_dataset(
         "raw_data",
         shape=(0,) + chunks[1:],
         chunks=tuple(chunks),
         maxshape=(None,) + chunks[1:],
         dtype=dtype,
-        compression=compression,
-        compression_opts=compression_opts,
         fillvalue=fillvalue,
+        **kwargs,
     )
     dataset.attrs["chunks"] = chunks
     return write_dataset(f, name, data, chunks=chunks)
@@ -147,9 +254,8 @@ def write_dataset(
     data,
     chunks=None,
     dtype=None,
-    compression=None,
-    compression_opts=None,
     fillvalue=None,
+    filters: Filters | None = None,
 ):
     if name not in f["_version_data"]:
         return create_base_dataset(
@@ -158,9 +264,8 @@ def write_dataset(
             data=data,
             dtype=dtype,
             chunks=chunks,
-            compression=compression,
-            compression_opts=compression_opts,
             fillvalue=fillvalue,
+            filters=filters or Filters(),
         )
 
     ds = f["_version_data"][name]["raw_data"]
@@ -177,20 +282,16 @@ def write_dataset(
     if dtype is not None:
         check_compatible_dtypes(dtype, ds.dtype)
 
-    if (
-        compression
-        and compression not in ds._filters
-        or compression_opts
-        and compression_opts != ds._filters[ds.compression]
-    ):
+    if filters is not None and filters.overrides(Filters.from_dataset(ds)):
         available_filters = textwrap.indent(
             "\n".join(str(filter) for filter in get_available_filters()), "  "
         )
         raise ValueError(
-            "Compression options can only be specified for the first version of a "
-            "dataset.\n"
+            "Compression options and other filters can only be specified for the first "
+            "version of a dataset.\n"
             f"Dataset: {name}\n"
             f"Current filters: {ds._filters}\n"
+            f"New filters: {filters}\n"
             f"Available hdf5 compression types:\n{available_filters}"
         )
 

--- a/versioned_hdf5/replay.py
+++ b/versioned_hdf5/replay.py
@@ -614,7 +614,7 @@ def modify_metadata(
     - `chunks`: must be compatible with the dataset shape
     - `dtype`: all data in the dataset is cast to the new dtype
     - `fillvalue`: see the note below
-    - Filter settings (see `h5py.Group.create_dataset()`):
+    - Filter settings (see :meth:`h5py.Group.create_dataset`):
       - `compression`
       - `compression_opts`
       - `scaleoffset`
@@ -632,8 +632,8 @@ def modify_metadata(
     equal to the default value of the dtype (e.g., 0. for float dtypes).
 
     For filters, passing a value of None is not the same as omitting the argument.
-    For example, `compression=None` will decompress a dataset if it was compressed,
-    and `compression_opts=None` will revert to the default options for the compression
+    For example, ``compression=None`` will decompress a dataset if it was compressed,
+    and ``compression_opts=None`` will revert to the default options for the compression
     plugin, whereas omitting them will retain the previous preferences.
     """
     if isinstance(f, VersionedHDF5File):
@@ -695,6 +695,7 @@ def modify_metadata(
             filters.shuffle = shuffle
         if fletcher32 is not DEFAULT:
             filters.fletcher32 = fletcher32
+
         new_dataset.parent._set_filters(new_dataset.name, filters)
 
         return new_dataset

--- a/versioned_hdf5/typing_.py
+++ b/versioned_hdf5/typing_.py
@@ -7,6 +7,7 @@ collision in Cython with the standard library 'typing' and 'types' modules.
 
 from __future__ import annotations
 
+from enum import Enum
 from typing import Any, Protocol, runtime_checkable
 
 import numpy as np
@@ -66,3 +67,12 @@ class MutableArrayProtocol(Protocol):
     ) -> NDArray: ...
 
     def __setitem__(self, index: Any, value: ArrayLike) -> None: ...
+
+
+class Default(Enum):
+    """Sentinel for default argument values."""
+
+    DEFAULT = "default"
+
+
+DEFAULT = Default.DEFAULT


### PR DESCRIPTION
- Closes https://github.com/deshaw/versioned-hdf5/issues/449
- Rework the implementation of filters
- Add `shuffle`, `fletcher32`, and `scaleoffset` parameters to `create_dataset` and `modify_metadata`
- Fix bug where `modify_metadata` would revert `compression` and `compression_opts` to their default value when they are not explicitly listed. For example, `modify_metadata(ds, fillvalue=123)` would decompress a dataset! You now have to explicitly pass `modify_metadata(ds, compression=None)`.
- `.compression` and `.compression_opts`  properties now return the numerical IDs for custom compression filters (e.g. Blosc, Blosc2) in staged datasets. Note that this is unlike `h5py.Dataset.compression`, which incorrectly returns None.