### PR TITLE
Fix MacOS wheels CI

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -56,14 +56,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-13, macos-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-15-intel, macos-latest]
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         include:
           - os: ubuntu-latest
             arch: x86_64
           - os: ubuntu-24.04-arm
             arch: aarch64
-          - os: macos-13
+          - os: macos-15-intel
             arch: x86_64
           - os: macos-latest
             arch: arm64


### PR DESCRIPTION
macos-13 was browned out.
This PR builds on top of #469 and #467. To review before it's merged, please look only at the last commit https://github.com/deshaw/versioned-hdf5/pull/470/commits/13c4248866d9a20736a0c5ebcffca871827c582e.