### PR TITLE
Upstream release: h5py conda package linked vs. hdf5 2.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,19 +7,20 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         env:
+          # See full documentation at docs/development.md
           - mindeps # Python 3.10, NumPy 1.24.4, hdf5 1.10, h5py 3.8, ndindex 1.5.1,
           # pinned build stack
-          - hdf5-112 # Python 3.10, NumPy 1.24.4, hdf5 1.12, h5py 3.8, latest ndindex
-          - hdf5-21 # Python 3.14, hdf5 2.1, latest versions of other dependencies
-          - np126 # Python 3.10, NumPy 1.26, latest versions of other dependencies
-          - np200 # Python 3.10, NumPy 2.0, latest versions of other dependencies
+          - hdf5-112 # Python 3.10, NumPy 1.24.4, hdf5 1.12, h5py 3.8
+          - hdf5-114 # Python 3.10, NumPy 2.2, hdf5 1.14
+          - np126 # Python 3.10, NumPy 1.26
+          - np200 # Python 3.10, NumPy 2.0
           # (Note: NumPy 2.0 has special cases not present in other versions)
-          - py310 # Python 3.10, NumPy 2.2, latest versions of other dependencies
-          - py311 # Python 3.11, latest versions of all dependencies
-          - py312 # Python 3.12, latest versions of all dependencies
-          - py313 # Python 3.13, latest versions of all dependencies
-          - py314 # Python 3.14, latest versions of all dependencies
-          - h5py-dev # Python 3.14, h5py git tip
+          - py310 # Python 3.10, NumPy 2.2
+          - py311 # Python 3.11
+          - py312 # Python 3.12
+          - py313 # Python 3.13
+          - py314 # Python 3.14
+          - h5py-dev # Python 3.14, h5py git tip (from sources)
         include:
           # Minimum dependencies on other platforms. The versions of hdf5 and h5py
           # vary due to brokennes of the binaries available for such an old stack.

--- a/docs/development.md
+++ b/docs/development.md
@@ -23,16 +23,19 @@ You can choose among the following:
 | ----------- | ------ | ------ | ----------- | --------- | ------- | ----------------------------------------------- |
 | `mindeps`   | 3.10   | 1.24.4 | 1.10 ~ 1.14 | 3.8 ~ 3.9 | 1.5.1   | Versions depend on platform; pinned build stack |
 | `hdf5-112`  | 3.10   | 1.24.4 | 1.12        | 3.8       | latest  | Not available on Windows                        |
-| `hdf5-21`   | 3.14   | latest | 2.1         | latest    | latest  |                                                 |
-| `np126`     | 3.10   | 1.26   | 1.14        | latest    | latest  | h5py conda package pins hdf5                    |
-| `np200`     | 3.10   | 2.0    | 1.14        | latest    | latest  | h5py conda package pins hdf5                    |
-| `py310`     | 3.10   | 2.2    | 1.14        | latest    | latest  | h5py conda package pins hdf5                    |
-| `py311`     | 3.11   | latest | 1.14        | latest    | latest  | h5py conda package pins hdf5                    |
-| `py312`     | 3.12   | latest | 1.14        | latest    | latest  | h5py conda package pins hdf5                    |
-| `py313`     | 3.13   | latest | 1.14        | latest    | latest  | h5py conda package pins hdf5                    |
-| `py314`     | 3.14   | latest | 1.14        | latest    | latest  | h5py conda package pins hdf5                    |
-| `default`   | latest | latest | 1.14        | latest    | latest  | h5py conda package pins hdf5                    |
-| `h5py-dev`  | latest | latest | 2.1         | git tip   | latest  |                                                 |
+| `hdf5-114`  | 3.10   | 2.2    | 1.14        | latest    | latest  |                                                 |
+| `np126`     | 3.10   | 1.26   | latest      | latest    | latest  |                                                 |
+| `np200`     | 3.10   | 2.0    | latest      | latest    | latest  |                                                 |
+| `py310`     | 3.10   | 2.2    | latest      | latest    | latest  |                                                 |
+| `py311`     | 3.11   | latest | latest      | latest    | latest  |                                                 |
+| `py312`     | 3.12   | latest | latest      | latest    | latest  |                                                 |
+| `py313`     | 3.13   | latest | latest      | latest    | latest  |                                                 |
+| `py314`     | 3.14   | latest | latest      | latest    | latest  |                                                 |
+| `default`   | latest | latest | latest      | latest    | latest  |                                                 |
+| `h5py-dev`  | latest | latest | latest      | git tip   | latest  |                                                 |
+
+*Note:* at the moment of writing, hdf5 latest is version 2.1.
+hdf5 2.0 is not available in conda-forge and is untested.
 
 ## Editable install
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -3760,56 +3760,47 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/zipp-3.23.1-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/zlib-1.3.2-h8088a28_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
-  hdf5-21:
+  hdf5-114:
     channels:
     - url: https://prefix.dev/conda-forge/
-    indexes:
-    - https://pypi.org/simple
     options:
       pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/asv-0.6.5-py314ha160325_3.conda
-      - conda: https://prefix.dev/conda-forge/noarch/asv_runner-0.2.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-auth-0.10.1-h2d2dd48_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-cal-0.9.13-h2c9d079_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-common-0.12.6-hb03c661_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-compression-0.3.2-h8b1a151_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-http-0.10.12-h4bacb7b_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-io-0.26.3-hc87160b_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-s3-0.11.5-h6d69fc9_5.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-sdkutils-0.2.4-h8b1a151_4.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-checksums-0.2.10-h8b1a151_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
-      - conda: https://prefix.dev/conda-forge/noarch/backports.zstd-1.3.0-py314h680f03e_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/backports.zstd-1.3.0-py310h69bd2ac_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/binutils_impl_linux-64-2.45.1-default_hfdba357_102.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/brotli-python-1.2.0-py314h3de4e8d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/blosc-1.21.6-he440d0b_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/brotli-python-1.2.0-py310hba01987_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://prefix.dev/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/c-blosc2-2.23.1-hc31b594_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
       - conda: https://prefix.dev/conda-forge/noarch/certifi-2026.4.22-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/cffi-2.0.0-py314h4a8dc5f_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cffi-2.0.0-py310he7384ee_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/click-8.3.2-pyhc90fa1f_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/cmarkgfm-2024.11.20-py314h5bd0f2a_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cmarkgfm-2024.11.20-py310h7c4b9e2_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/conda-gcc-specs-15.2.0-h53410ce_18.conda
-      - conda: https://prefix.dev/conda-forge/noarch/cpython-3.14.4-py314hd8ed1ab_100.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/cryptography-46.0.7-py314h7fe84b3_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/cython-3.2.4-py314h1807b08_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cpython-3.10.20-py310hd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cryptography-46.0.7-py310hb288b08_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cython-3.2.4-py310ha58568a_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/distlib-0.4.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/filelock-3.29.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/gcc-15.2.0-h0dff253_18.conda
       - conda: https://prefix.dev/conda-forge/linux-64/gcc_impl_linux-64-15.2.0-he420e7e_18.conda
       - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/hdf5-2.1.0-nompi_hd4fcb43_104.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/h5py-3.16.0-nompi_py310h4aa865e_102.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hdf5-1.14.6-nompi_h19486de_108.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hdf5plugin-6.0.0-py310h69abe24_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.152.1-pyha770c72_0.conda
@@ -3823,7 +3814,6 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/jaraco.context-6.1.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/jaraco.functools-4.4.0-pyhcf101f3_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/jeepney-0.9.0-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/json5-0.14.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
       - conda: https://prefix.dev/conda-forge/noarch/keyring-25.7.0-pyha804496_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
@@ -3847,8 +3837,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/liblapack-3.11.0-6_h47877c9_openblas.conda
       - conda: https://prefix.dev/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libopenblas-0.3.32-pthreads_h94d23a6_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libsanitizer-15.2.0-h90f66d4_18.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libsqlite-3.53.0-hf4e2dac_0.conda
@@ -3856,53 +3846,50 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
       - conda: https://prefix.dev/conda-forge/noarch/libstdcxx-devel_linux-64-15.2.0-hd446a21_118.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libuuid-2.42-h5347b49_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/meson-1.11.1-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/meson-python-0.19.0-pyh7e86bf3_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/more-itertools-11.0.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/ndindex-1.10.1-py314ha160325_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ndindex-1.10.1-py310hea6c23e_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/nh3-0.3.4-py310hd8a072f_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/ninja-1.13.2-h171cf75_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/numpy-2.4.3-py314h2b28147_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/numpy-2.2.6-py310hefbff90_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/packaging-26.1-pyhc364b38_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/patchelf-0.18.0-h3f2d84a_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pip-26.0.1-pyh145f28c_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pip-26.0.1-pyh8b19718_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/pkg-config-0.29.2-h4bc722e_1009.conda
-      - conda: https://prefix.dev/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pympler-1.1-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyproject-metadata-0.11.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyproject_hooks-1.2.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-env-1.6.0-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/python-3.14.4-habeac84_100_cp314.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/python-3.10.20-h3c07f61_0_cpython.conda
       - conda: https://prefix.dev/conda-forge/noarch/python-build-1.4.3-pyhc364b38_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/python-discovery-1.2.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/python-dotenv-1.2.2-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/python-gil-3.14.4-h4df99d1_100.conda
-      - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/pyyaml-6.0.3-py314h67df5f8_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python-gil-3.10.20-hd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.10-8_cp310.conda
       - conda: https://prefix.dev/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/readme_renderer-44.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/rfc3986-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/s2n-1.7.1-h1cbb8d7_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/secretstorage-3.4.1-py314hdafbbf9_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/secretstorage-3.4.1-py310hff52083_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/setuptools-scm-9.2.2-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
-      - conda: https://prefix.dev/conda-forge/noarch/tabulate-0.10.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://prefix.dev/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/twine-6.2.0-pyhcf101f3_0.conda
@@ -3910,55 +3897,46 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/virtualenv-21.2.4-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/wheel-0.46.3-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-3.23.1-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/zlib-1.3.2-h25fd6f3_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/zlib-ng-2.3.3-hceb46e0_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
-      - pypi: https://files.pythonhosted.org/packages/db/33/acd0ce6863b6c0d7735007df01815403f5589a21ff8c2e1ee2587a38f548/h5py-3.16.0.tar.gz
       linux-aarch64:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/asv-0.6.5-py314h02b5315_3.conda
-      - conda: https://prefix.dev/conda-forge/noarch/asv_runner-0.2.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-auth-0.10.1-h5c15aeb_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-cal-0.9.13-hc50a40c_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-common-0.12.6-he30d5cf_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-compression-0.3.2-h6f28e42_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-http-0.10.12-h8f13f89_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-io-0.26.3-h8d25f22_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-s3-0.11.5-h1747a43_5.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-sdkutils-0.2.4-h6f28e42_4.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-checksums-0.2.10-h6f28e42_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
-      - conda: https://prefix.dev/conda-forge/noarch/backports.zstd-1.3.0-py314h680f03e_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/backports.zstd-1.3.0-py310hfa1aa29_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.45.1-default_h5f4c503_102.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/brotli-python-1.2.0-py314h352cb57_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/blosc-1.21.6-hb4dfabd_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/brotli-python-1.2.0-py310hbe54bbb_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_9.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/c-ares-1.34.6-he30d5cf_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/c-blosc2-2.23.1-hde6442c_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
       - conda: https://prefix.dev/conda-forge/noarch/certifi-2026.4.22-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/cffi-2.0.0-py314h0bd77cf_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/cffi-2.0.0-py310h0826a50_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/click-8.3.2-pyhc90fa1f_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/cmarkgfm-2024.11.20-py314h51f160d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/cmarkgfm-2024.11.20-py310h5b55623_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/conda-gcc-specs-15.2.0-hc908511_18.conda
-      - conda: https://prefix.dev/conda-forge/noarch/cpython-3.14.4-py314hd8ed1ab_100.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/cryptography-46.0.7-py314h85c42a0_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/cython-3.2.4-py314h4c416a3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cpython-3.10.20-py310hd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/cryptography-46.0.7-py310h868a156_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/cython-3.2.4-py310h0d97cfb_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/dbus-1.16.2-h70963c4_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/distlib-0.4.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/filelock-3.29.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/gcc-15.2.0-h2e72a27_18.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-15.2.0-hcedddb3_18.conda
       - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5-2.1.0-nompi_h81b49a2_104.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/h5py-3.16.0-nompi_py310hce7682f_102.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5-1.14.6-nompi_hf95b8e7_108.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5plugin-6.0.0-py310hc8e4586_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.152.1-pyha770c72_0.conda
@@ -3971,7 +3949,6 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/jaraco.context-6.1.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/jaraco.functools-4.4.0-pyhcf101f3_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/jeepney-0.9.0-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/json5-0.14.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h05a177a_9.conda
       - conda: https://prefix.dev/conda-forge/noarch/keyring-25.7.0-pyha804496_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/keyutils-1.6.3-h86ecc28_0.conda
@@ -3995,8 +3972,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libiconv-1.18-h90929bb_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/liblapack-3.11.0-6_h88aeb00_openblas.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/liblzma-5.8.3-he30d5cf_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libmpdec-4.0.0-he30d5cf_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libnghttp2-1.68.1-hd3077d7_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libnsl-2.0.1-h86ecc28_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libopenblas-0.3.32-pthreads_h9d3fd7e_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libsanitizer-15.2.0-he19c465_18.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libsqlite-3.53.0-h022381a_0.conda
@@ -4004,7 +3981,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libstdcxx-15.2.0-hef695bb_18.conda
       - conda: https://prefix.dev/conda-forge/noarch/libstdcxx-devel_linux-aarch64-15.2.0-ha7b1723_118.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libuuid-2.42-h1022ec0_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libxcrypt-4.4.36-h31becfc_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libzlib-1.3.2-hdc9db2a_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/lz4-c-1.10.0-h5ad3122_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/meson-1.11.1-pyhcf101f3_0.conda
@@ -4014,43 +3993,38 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/ndindex-1.8-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/nh3-0.3.4-py310h8c58d24_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/ninja-1.13.2-hdc560ac_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/numpy-2.4.3-py314haac167e_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/numpy-2.2.6-py310h6e5608f_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/openssl-3.6.2-h546c87b_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/packaging-26.1-pyhc364b38_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/patchelf-0.18.0-h5ad3122_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/pcre2-10.47-hf841c20_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pip-26.0.1-pyh145f28c_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pip-26.0.1-pyh8b19718_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/pkg-config-0.29.2-hce167ba_1009.conda
-      - conda: https://prefix.dev/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pympler-1.1-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyproject-metadata-0.11.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyproject_hooks-1.2.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-env-1.6.0-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/python-3.14.4-hfd9ac0a_100_cp314.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/python-3.10.20-h28be5d3_0_cpython.conda
       - conda: https://prefix.dev/conda-forge/noarch/python-build-1.4.3-pyhc364b38_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/python-discovery-1.2.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/python-dotenv-1.2.2-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/python-gil-3.14.4-h4df99d1_100.conda
-      - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/pyyaml-6.0.3-py314h807365f_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python-gil-3.10.20-hd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.10-8_cp310.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/readline-8.3-hb682ff5_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/readme_renderer-44.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/rfc3986-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/s2n-1.7.1-h6629d95_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/secretstorage-3.4.1-py314ha42fa4b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/secretstorage-3.4.1-py310hbbe02a8_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/setuptools-scm-9.2.2-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/snappy-1.2.2-he774c54_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/sysroot_linux-aarch64-2.28-h585391f_9.conda
-      - conda: https://prefix.dev/conda-forge/noarch/tabulate-0.10.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/tk-8.6.13-noxft_h0dc03b3_103.conda
       - conda: https://prefix.dev/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/twine-6.2.0-pyhcf101f3_0.conda
@@ -4058,58 +4032,49 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/virtualenv-21.2.4-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/wheel-0.46.3-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/yaml-0.2.5-h80f16a2_3.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-3.23.1-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/zlib-1.3.2-hdc9db2a_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/zlib-ng-2.3.3-ha7cb516_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/zstd-1.5.7-h85ac4a6_6.conda
-      - pypi: https://files.pythonhosted.org/packages/db/33/acd0ce6863b6c0d7735007df01815403f5589a21ff8c2e1ee2587a38f548/h5py-3.16.0.tar.gz
       osx-64:
       - conda: https://prefix.dev/conda-forge/osx-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/asv-0.6.5-py314h21b9a27_3.conda
-      - conda: https://prefix.dev/conda-forge/noarch/asv_runner-0.2.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-auth-0.10.1-hfd47d4b_2.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-cal-0.9.13-hea39f9f_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-common-0.12.6-h8616949_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-compression-0.3.2-hb9ea233_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-http-0.10.12-h1037d30_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-io-0.26.3-hc95b61d_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-s3-0.11.5-hb15a67f_5.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-sdkutils-0.2.4-h901532c_4.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/aws-checksums-0.2.10-h31279ed_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
-      - conda: https://prefix.dev/conda-forge/noarch/backports.zstd-1.3.0-py314h680f03e_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/brotli-python-1.2.0-py314h3262eb8_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/backports.zstd-1.3.0-py310hedc14a4_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/blosc-1.21.6-hd145fbb_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/brotli-python-1.2.0-py310hab27952_1.conda
       - conda: https://prefix.dev/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_9.conda
       - conda: https://prefix.dev/conda-forge/osx-64/c-ares-1.34.6-hb5e19a0_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/c-blosc2-2.23.1-h548f922_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
       - conda: https://prefix.dev/conda-forge/osx-64/cctools-1030.6.3-llvm22_1_h0a1bb1c_4.conda
       - conda: https://prefix.dev/conda-forge/osx-64/cctools_impl_osx-64-1030.6.3-llvm22_1_h8fe25a2_4.conda
       - conda: https://prefix.dev/conda-forge/noarch/certifi-2026.4.22-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/cffi-2.0.0-py314h8ca4d5a_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/cffi-2.0.0-py310h062c7ae_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/clang-22-22.1.3-default_h3b8fe2e_1.conda
       - conda: https://prefix.dev/conda-forge/osx-64/clang-22.1.3-default_cfg_h93fe8ef_1.conda
       - conda: https://prefix.dev/conda-forge/osx-64/clang_impl_osx-64-22.1.3-default_he9bf3b8_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/click-8.3.2-pyhc90fa1f_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/cmarkgfm-2024.11.20-py314h03d016b_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/cmarkgfm-2024.11.20-py310h1b7cace_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/osx-64/compiler-rt-22.1.3-h694c41f_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/compiler-rt22-22.1.3-h1637cdf_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/compiler-rt22_osx-64-22.1.3-hcf80936_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/compiler-rt_osx-64-22.1.3-h694c41f_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/cpython-3.14.4-py314hd8ed1ab_100.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/cython-3.2.4-py314hf0dd12f_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/distlib-0.4.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cpython-3.10.20-py310hd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/cython-3.2.4-py310h4a90db6_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/filelock-3.29.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/hdf5-2.1.0-nompi_h3b1597d_104.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/h5py-3.16.0-nompi_py310hbc26044_102.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/hdf5-1.14.6-nompi_h13accda_108.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/hdf5plugin-6.0.0-py310hbffbd50_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.152.1-pyha770c72_0.conda
@@ -4122,7 +4087,6 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/jaraco.classes-3.4.0-pyhcf101f3_3.conda
       - conda: https://prefix.dev/conda-forge/noarch/jaraco.context-6.1.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/jaraco.functools-4.4.0-pyhcf101f3_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/json5-0.14.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/keyring-25.7.0-pyh534df25_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/krb5-1.22.2-h207b36a_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/ld64-956.6-llvm22_1_hc399b6d_4.conda
@@ -4145,7 +4109,6 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-64/liblapack-3.11.0-6_h859234e_openblas.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libllvm22-22.1.3-hab754da_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/liblzma-5.8.3-hbb4bfdb_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/libmpdec-4.0.0-hf3981d6_1.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libnghttp2-1.68.1-h70048d4_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libopenblas-0.3.32-openmp_h9e49c7b_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libsigtool-0.1.3-hc0f2934_0.conda
@@ -4157,38 +4120,35 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-64/llvm-openmp-22.1.4-h0d3cbff_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/llvm-tools-22-22.1.3-hc181bea_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/llvm-tools-22.1.3-h1637cdf_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/lz4-c-1.10.0-h240833e_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/meson-1.11.1-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/meson-python-0.19.0-pyh7e86bf3_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/more-itertools-11.0.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/ncurses-6.5-h0622a9a_3.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/ndindex-1.10.1-py314h21b9a27_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/ndindex-1.10.1-py310ha75780e_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/nh3-0.3.4-py310hb9b2626_1.conda
       - conda: https://prefix.dev/conda-forge/osx-64/ninja-1.13.2-hfc0b2d5_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/numpy-2.4.3-py314h7b24d9b_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/numpy-2.2.6-py310h07c5b4d_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/openssl-3.6.2-hc881268_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/packaging-26.1-pyhc364b38_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/patchelf-0.18.0-h92383a6_2.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pip-26.0.1-pyh145f28c_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pip-26.0.1-pyh8b19718_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/pkg-config-0.29.2-hf7e621a_1009.conda
-      - conda: https://prefix.dev/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pympler-1.1-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyproject-metadata-0.11.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyproject_hooks-1.2.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-env-1.6.0-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/python-3.14.4-h7c6738f_100_cp314.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/python-3.10.20-hea035f4_0_cpython.conda
       - conda: https://prefix.dev/conda-forge/noarch/python-build-1.4.3-pyhc364b38_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/python-discovery-1.2.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/python-dotenv-1.2.2-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/python-gil-3.14.4-h4df99d1_100.conda
-      - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/pyyaml-6.0.3-py314h10d0514_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python-gil-3.10.20-hd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.10-8_cp310.conda
       - conda: https://prefix.dev/conda-forge/osx-64/readline-8.3-h68b038d_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/readme_renderer-44.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
@@ -4198,8 +4158,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/setuptools-scm-9.2.2-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/sigtool-codesign-0.1.3-hc0f2934_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/snappy-1.2.2-h01f5ddf_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/tabulate-0.10.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/tapi-1600.0.11.8-h8d8e812_2.conda
       - conda: https://prefix.dev/conda-forge/osx-64/tk-8.6.13-h7142dee_3.conda
       - conda: https://prefix.dev/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
@@ -4208,58 +4168,49 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/virtualenv-21.2.4-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/wheel-0.46.3-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/yaml-0.2.5-h4132b18_3.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-3.23.1-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/zlib-1.3.2-hbb4bfdb_2.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/zlib-ng-2.3.3-h8bce59a_1.conda
       - conda: https://prefix.dev/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
-      - pypi: https://files.pythonhosted.org/packages/db/33/acd0ce6863b6c0d7735007df01815403f5589a21ff8c2e1ee2587a38f548/h5py-3.16.0.tar.gz
       osx-arm64:
       - conda: https://prefix.dev/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/asv-0.6.5-py314h93ecee7_3.conda
-      - conda: https://prefix.dev/conda-forge/noarch/asv_runner-0.2.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-auth-0.10.1-hcb83491_2.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-cal-0.9.13-h6ee9776_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-common-0.12.6-hc919400_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-compression-0.3.2-h3e7f9b5_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-http-0.10.12-h95cdebe_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-io-0.26.3-h4137820_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-s3-0.11.5-ha5d16b2_5.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-sdkutils-0.2.4-h16f91aa_4.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-checksums-0.2.10-h3e7f9b5_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
-      - conda: https://prefix.dev/conda-forge/noarch/backports.zstd-1.3.0-py314h680f03e_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/brotli-python-1.2.0-py314h3daef5d_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/backports.zstd-1.3.0-py310h2d60bed_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/blosc-1.21.6-h7dd00d9_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/brotli-python-1.2.0-py310h6123dab_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/c-ares-1.34.6-hc919400_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/c-blosc2-2.23.1-hf9886e1_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
       - conda: https://prefix.dev/conda-forge/osx-arm64/cctools-1030.6.3-llvm22_1_hbe26303_4.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/cctools_impl_osx-arm64-1030.6.3-llvm22_1_hb5e89dc_4.conda
       - conda: https://prefix.dev/conda-forge/noarch/certifi-2026.4.22-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/cffi-2.0.0-py314h44086f9_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/cffi-2.0.0-py310hf5b66c1_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/clang-22-22.1.3-default_hb52604d_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/clang-22.1.3-default_cfg_hb78b91e_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/clang_impl_osx-arm64-22.1.3-default_h17d1ed9_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/click-8.3.2-pyhc90fa1f_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/cmarkgfm-2024.11.20-py314hb84d1df_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/cmarkgfm-2024.11.20-py310h7bdd564_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/compiler-rt-22.1.3-hce30654_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/compiler-rt22-22.1.3-hd34ed20_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/compiler-rt22_osx-arm64-22.1.3-h7e67a1e_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/compiler-rt_osx-arm64-22.1.3-hce30654_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/cpython-3.14.4-py314hd8ed1ab_100.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/cython-3.2.4-py314hc6117b3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/distlib-0.4.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cpython-3.10.20-py310hd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/cython-3.2.4-py310h9a762d2_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/filelock-3.29.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/hdf5-2.1.0-nompi_hc95e3eb_104.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/h5py-3.16.0-nompi_py310h0c5f886_102.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/hdf5-1.14.6-nompi_had3affe_108.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/hdf5plugin-6.0.0-py310h529efbb_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.152.1-pyha770c72_0.conda
@@ -4271,7 +4222,6 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/jaraco.classes-3.4.0-pyhcf101f3_3.conda
       - conda: https://prefix.dev/conda-forge/noarch/jaraco.context-6.1.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/jaraco.functools-4.4.0-pyhcf101f3_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/json5-0.14.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/keyring-25.7.0-pyh534df25_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/krb5-1.22.2-h385eeb1_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/ld64-956.6-llvm22_1_h5b97f1b_4.conda
@@ -4296,7 +4246,6 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/liblapack-3.11.0-6_hd9741b5_openblas.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libllvm22-22.1.3-h89af1be_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libnghttp2-1.68.1-h8f3e76b_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libopenblas-0.3.32-openmp_he657e61_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libsigtool-0.1.3-h98dc951_0.conda
@@ -4308,6 +4257,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/llvm-openmp-22.1.4-hc7d1edf_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/llvm-tools-22-22.1.3-hb545844_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/llvm-tools-22.1.3-hd34ed20_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/lz4-c-1.10.0-h286801f_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/meson-1.11.1-pyhcf101f3_0.conda
@@ -4317,30 +4267,26 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/ndindex-1.8-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/nh3-0.3.4-py310h3b8a9b8_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/ninja-1.13.2-h49c215f_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/numpy-2.4.3-py314h1569ea8_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/numpy-2.2.6-py310h4d83441_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/openssl-3.6.2-hd24854e_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/packaging-26.1-pyhc364b38_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/patchelf-0.18.0-ha1acc90_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/pcre2-10.47-h30297fc_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pip-26.0.1-pyh145f28c_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pip-26.0.1-pyh8b19718_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/pkg-config-0.29.2-hde07d2e_1009.conda
-      - conda: https://prefix.dev/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pympler-1.1-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyproject-metadata-0.11.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyproject_hooks-1.2.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-env-1.6.0-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/python-3.14.4-h4c637c5_100_cp314.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/python-3.10.20-h1b19095_0_cpython.conda
       - conda: https://prefix.dev/conda-forge/noarch/python-build-1.4.3-pyhc364b38_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/python-discovery-1.2.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/python-dotenv-1.2.2-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/python-gil-3.14.4-h4df99d1_100.conda
-      - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/pyyaml-6.0.3-py314h6e9b3f0_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python-gil-3.10.20-hd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.10-8_cp310.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/readme_renderer-44.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
@@ -4350,8 +4296,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/setuptools-scm-9.2.2-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/sigtool-codesign-0.1.3-h98dc951_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/snappy-1.2.2-hada39a4_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/tabulate-0.10.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/tapi-1600.0.11.8-h997e182_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://prefix.dev/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
@@ -4360,51 +4306,42 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/virtualenv-21.2.4-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/wheel-0.46.3-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-3.23.1-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/zlib-1.3.2-h8088a28_2.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/zlib-ng-2.3.3-hed4e4f5_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
-      - pypi: https://files.pythonhosted.org/packages/db/33/acd0ce6863b6c0d7735007df01815403f5589a21ff8c2e1ee2587a38f548/h5py-3.16.0.tar.gz
       win-64:
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
-      - conda: https://prefix.dev/conda-forge/win-64/asv-0.6.5-py314h13fbf68_3.conda
-      - conda: https://prefix.dev/conda-forge/noarch/asv_runner-0.2.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/aws-c-auth-0.10.1-h5d51246_2.conda
-      - conda: https://prefix.dev/conda-forge/win-64/aws-c-cal-0.9.13-h46f3b43_1.conda
-      - conda: https://prefix.dev/conda-forge/win-64/aws-c-common-0.12.6-hfd05255_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/aws-c-compression-0.3.2-hcb3a2da_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/aws-c-http-0.10.12-h612f3e8_1.conda
-      - conda: https://prefix.dev/conda-forge/win-64/aws-c-io-0.26.3-h0d5b9f9_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/aws-c-s3-0.11.5-h87bd87b_5.conda
-      - conda: https://prefix.dev/conda-forge/win-64/aws-c-sdkutils-0.2.4-hcb3a2da_4.conda
-      - conda: https://prefix.dev/conda-forge/win-64/aws-checksums-0.2.10-hcb3a2da_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
-      - conda: https://prefix.dev/conda-forge/noarch/backports.zstd-1.3.0-py314h680f03e_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/brotli-python-1.2.0-py314he701e3d_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/backports.zstd-1.3.0-py310h458dff3_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/blosc-1.21.6-hfd34d9b_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/brotli-python-1.2.0-py310hfff998d_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_9.conda
+      - conda: https://prefix.dev/conda-forge/win-64/c-blosc2-2.23.1-h2af8807_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.4.22-h4c7d964_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
       - conda: https://prefix.dev/conda-forge/noarch/certifi-2026.4.22-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/cffi-2.0.0-py314h5a2d7ad_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/cffi-2.0.0-py310h29418f3_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/clang-22-22.1.3-default_hac490eb_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/clang-22.1.3-default_nocfg_hbb9487a_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/click-8.3.2-pyh6dadd2b_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/cmarkgfm-2024.11.20-py314h5a2d7ad_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/cmarkgfm-2024.11.20-py310h29418f3_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/compiler-rt22-22.1.3-h49e36cd_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/compiler-rt22_win-64-22.1.3-h49e36cd_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/cpython-3.14.4-py314hd8ed1ab_100.conda
-      - conda: https://prefix.dev/conda-forge/win-64/cython-3.2.4-py314h344ed54_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/distlib-0.4.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cpython-3.10.20-py310hd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/cython-3.2.4-py310h23e71ea_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/filelock-3.29.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/hdf5-2.1.0-nompi_hd96b29f_104.conda
+      - conda: https://prefix.dev/conda-forge/win-64/h5py-3.16.0-nompi_py310hb7e4da9_102.conda
+      - conda: https://prefix.dev/conda-forge/win-64/hdf5-1.14.6-nompi_hae35d4c_108.conda
+      - conda: https://prefix.dev/conda-forge/win-64/hdf5plugin-6.0.0-py310haedb6d2_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.152.1-pyha770c72_0.conda
@@ -4416,7 +4353,6 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/jaraco.classes-3.4.0-pyhcf101f3_3.conda
       - conda: https://prefix.dev/conda-forge/noarch/jaraco.context-6.1.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/jaraco.functools-4.4.0-pyhcf101f3_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/json5-0.14.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/keyring-25.7.0-pyh7428d3b_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/krb5-1.22.2-h0ea6238_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libaec-1.1.5-haf901d7_0.conda
@@ -4432,7 +4368,6 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/liblapack-3.11.0-6_hf9ab0e9_mkl.conda
       - conda: https://prefix.dev/conda-forge/win-64/libllvm22-22.1.3-h830ff33_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/liblzma-5.8.3-hfd05255_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libmpdec-4.0.0-hfd05255_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/libsqlite-3.53.0-hf5d6505_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libssh2-1.11.1-h9aa295b_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libwinpthread-12.0.0.r4.gg4f2fc60ca-h57928b3_10.conda
@@ -4441,39 +4376,36 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/libzlib-1.3.2-hfd05255_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/llvm-openmp-22.1.4-h4fa8253_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/llvm-tools-22.1.3-h752b59f_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/lz4-c-1.10.0-h2466b09_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/meson-1.11.1-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/meson-python-0.19.0-pyh7e86bf3_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/mkl-2025.3.1-hac47afa_11.conda
       - conda: https://prefix.dev/conda-forge/noarch/more-itertools-11.0.2-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/ndindex-1.10.1-py314h13fbf68_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/ndindex-1.10.1-py310h73ae2b4_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/nh3-0.3.4-py310ha413424_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/ninja-1.13.2-h477610d_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/numpy-2.4.3-py314h02f10f6_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/numpy-2.2.6-py310h4987827_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/openssl-3.6.2-hf411b9b_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/packaging-26.1-pyhc364b38_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/pcre2-10.47-hd2b5f0e_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pip-26.0.1-pyh145f28c_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pip-26.0.1-pyh8b19718_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/pkg-config-0.29.2-h88c491f_1009.conda
-      - conda: https://prefix.dev/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pympler-1.1-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyproject-metadata-0.11.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyproject_hooks-1.2.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-env-1.6.0-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/python-3.14.4-h4b44e0e_100_cp314.conda
+      - conda: https://prefix.dev/conda-forge/win-64/python-3.10.20-hc20f281_0_cpython.conda
       - conda: https://prefix.dev/conda-forge/noarch/python-build-1.4.3-pyhc364b38_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/python-discovery-1.2.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/python-dotenv-1.2.2-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/python-gil-3.14.4-h4df99d1_100.conda
-      - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
-      - conda: https://prefix.dev/conda-forge/win-64/pywin32-ctypes-0.2.3-py314h86ab7b2_3.conda
-      - conda: https://prefix.dev/conda-forge/win-64/pyyaml-6.0.3-py314h2359020_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python-gil-3.10.20-hd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.10-8_cp310.conda
+      - conda: https://prefix.dev/conda-forge/win-64/pywin32-ctypes-0.2.3-py310h5588dad_3.conda
       - conda: https://prefix.dev/conda-forge/noarch/readme_renderer-44.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
@@ -4481,8 +4413,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/setuptools-scm-9.2.2-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/snappy-1.2.2-h7fa0ca8_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/tabulate-0.10.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/tbb-2022.3.0-h3155e25_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/tk-8.6.13-h6ed50ae_3.conda
       - conda: https://prefix.dev/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
@@ -4495,14 +4427,12 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/vc-14.3-h41ae7f8_34.conda
       - conda: https://prefix.dev/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_34.conda
       - conda: https://prefix.dev/conda-forge/win-64/vcomp14-14.44.35208-h818238b_34.conda
-      - conda: https://prefix.dev/conda-forge/noarch/virtualenv-21.2.4-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/wheel-0.46.3-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
-      - conda: https://prefix.dev/conda-forge/win-64/yaml-0.2.5-h6a83c73_3.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-3.23.1-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/zlib-1.3.2-hfd05255_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/zlib-ng-2.3.3-h0261ad2_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
-      - pypi: https://files.pythonhosted.org/packages/db/33/acd0ce6863b6c0d7735007df01815403f5589a21ff8c2e1ee2587a38f548/h5py-3.16.0.tar.gz
   lint:
     channels:
     - url: https://prefix.dev/conda-forge/
@@ -5463,6 +5393,15 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-auth-0.10.1-h2d2dd48_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-cal-0.9.13-h2c9d079_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-common-0.12.6-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-compression-0.3.2-h8b1a151_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-http-0.10.12-h4bacb7b_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-io-0.26.3-hc87160b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-s3-0.11.5-h6d69fc9_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-sdkutils-0.2.4-h8b1a151_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-checksums-0.2.10-h8b1a151_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/backports.zstd-1.3.0-py310h69bd2ac_0.conda
@@ -5491,9 +5430,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/gcc-15.2.0-h0dff253_18.conda
       - conda: https://prefix.dev/conda-forge/linux-64/gcc_impl_linux-64-15.2.0-he420e7e_18.conda
       - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/h5py-3.16.0-nompi_py310h4aa865e_102.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/hdf5-1.14.6-nompi_h19486de_108.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/hdf5plugin-6.0.0-py310h69abe24_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/h5py-3.16.0-nompi_py310hb9a6f38_102.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hdf5-2.1.0-nompi_hd4fcb43_104.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hdf5plugin-6.0.0-py310h3812ed8_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.152.1-pyha770c72_0.conda
@@ -5578,6 +5517,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/rfc3986-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/s2n-1.7.1-h1cbb8d7_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/secretstorage-3.4.1-py310hff52083_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/setuptools-scm-9.2.2-pyhd8ed1ab_0.conda
@@ -5600,6 +5540,15 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-auth-0.10.1-h5c15aeb_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-cal-0.9.13-hc50a40c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-common-0.12.6-he30d5cf_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-compression-0.3.2-h6f28e42_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-http-0.10.12-h8f13f89_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-io-0.26.3-h8d25f22_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-s3-0.11.5-h1747a43_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-sdkutils-0.2.4-h6f28e42_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-checksums-0.2.10-h6f28e42_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/backports.zstd-1.3.0-py310hfa1aa29_0.conda
@@ -5628,9 +5577,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/gcc-15.2.0-h2e72a27_18.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-15.2.0-hcedddb3_18.conda
       - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/h5py-3.16.0-nompi_py310hce7682f_102.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5-1.14.6-nompi_hf95b8e7_108.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5plugin-6.0.0-py310hc8e4586_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/h5py-3.16.0-nompi_py310h5f766a5_102.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5-2.1.0-nompi_h81b49a2_104.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5plugin-6.0.0-py310hf20988d_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.152.1-pyha770c72_0.conda
@@ -5714,6 +5663,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/rfc3986-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/s2n-1.7.1-h6629d95_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/secretstorage-3.4.1-py310hbbe02a8_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/setuptools-scm-9.2.2-pyhd8ed1ab_0.conda
@@ -5736,6 +5686,15 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-auth-0.10.1-hfd47d4b_2.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-cal-0.9.13-hea39f9f_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-common-0.12.6-h8616949_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-compression-0.3.2-hb9ea233_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-http-0.10.12-h1037d30_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-io-0.26.3-hc95b61d_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-s3-0.11.5-hb15a67f_5.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-sdkutils-0.2.4-h901532c_4.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-checksums-0.2.10-h31279ed_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/osx-64/backports.zstd-1.3.0-py310hedc14a4_0.conda
@@ -5767,9 +5726,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/h5py-3.16.0-nompi_py310hbc26044_102.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/hdf5-1.14.6-nompi_h13accda_108.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/hdf5plugin-6.0.0-py310hbffbd50_5.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/h5py-3.16.0-nompi_py310h05ade02_102.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/hdf5-2.1.0-nompi_h3b1597d_104.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/hdf5plugin-6.0.0-py310he652b7c_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.152.1-pyha770c72_0.conda
@@ -5872,6 +5831,15 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-auth-0.10.1-hcb83491_2.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-cal-0.9.13-h6ee9776_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-common-0.12.6-hc919400_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-compression-0.3.2-h3e7f9b5_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-http-0.10.12-h95cdebe_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-io-0.26.3-h4137820_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-s3-0.11.5-ha5d16b2_5.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-sdkutils-0.2.4-h16f91aa_4.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-checksums-0.2.10-h3e7f9b5_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/backports.zstd-1.3.0-py310h2d60bed_0.conda
@@ -5903,9 +5871,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/h5py-3.16.0-nompi_py310h0c5f886_102.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/hdf5-1.14.6-nompi_had3affe_108.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/hdf5plugin-6.0.0-py310h529efbb_5.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/h5py-3.16.0-nompi_py310hcf53ec8_102.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/hdf5-2.1.0-nompi_hc95e3eb_104.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/hdf5plugin-6.0.0-py310h3eaa12b_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.152.1-pyha770c72_0.conda
@@ -6009,6 +5977,15 @@ environments:
       win-64:
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-auth-0.10.1-h5d51246_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-cal-0.9.13-h46f3b43_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-common-0.12.6-hfd05255_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-compression-0.3.2-hcb3a2da_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-http-0.10.12-h612f3e8_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-io-0.26.3-h0d5b9f9_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-s3-0.11.5-h87bd87b_5.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-sdkutils-0.2.4-hcb3a2da_4.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-checksums-0.2.10-hcb3a2da_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/backports.zstd-1.3.0-py310h458dff3_0.conda
@@ -6034,9 +6011,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/h5py-3.16.0-nompi_py310hb7e4da9_102.conda
-      - conda: https://prefix.dev/conda-forge/win-64/hdf5-1.14.6-nompi_hae35d4c_108.conda
-      - conda: https://prefix.dev/conda-forge/win-64/hdf5plugin-6.0.0-py310haedb6d2_5.conda
+      - conda: https://prefix.dev/conda-forge/win-64/h5py-3.16.0-nompi_py310h6359f78_102.conda
+      - conda: https://prefix.dev/conda-forge/win-64/hdf5-2.1.0-nompi_hd96b29f_104.conda
+      - conda: https://prefix.dev/conda-forge/win-64/hdf5plugin-6.0.0-py310hefaf402_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.152.1-pyha770c72_0.conda
@@ -6138,6 +6115,15 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-auth-0.10.1-h2d2dd48_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-cal-0.9.13-h2c9d079_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-common-0.12.6-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-compression-0.3.2-h8b1a151_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-http-0.10.12-h4bacb7b_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-io-0.26.3-hc87160b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-s3-0.11.5-h6d69fc9_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-sdkutils-0.2.4-h8b1a151_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-checksums-0.2.10-h8b1a151_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/backports.zstd-1.3.0-py310h69bd2ac_0.conda
@@ -6166,9 +6152,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/gcc-15.2.0-h0dff253_18.conda
       - conda: https://prefix.dev/conda-forge/linux-64/gcc_impl_linux-64-15.2.0-he420e7e_18.conda
       - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/h5py-3.16.0-nompi_py310h4aa865e_102.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/hdf5-1.14.6-nompi_h19486de_108.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/hdf5plugin-6.0.0-py310h69abe24_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/h5py-3.16.0-nompi_py310hb9a6f38_102.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hdf5-2.1.0-nompi_hd4fcb43_104.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hdf5plugin-6.0.0-py310h3812ed8_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.152.1-pyha770c72_0.conda
@@ -6252,6 +6238,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/rfc3986-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/s2n-1.7.1-h1cbb8d7_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/secretstorage-3.4.1-py310hff52083_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/setuptools-scm-9.2.2-pyhd8ed1ab_0.conda
@@ -6274,6 +6261,15 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-auth-0.10.1-h5c15aeb_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-cal-0.9.13-hc50a40c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-common-0.12.6-he30d5cf_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-compression-0.3.2-h6f28e42_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-http-0.10.12-h8f13f89_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-io-0.26.3-h8d25f22_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-s3-0.11.5-h1747a43_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-sdkutils-0.2.4-h6f28e42_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-checksums-0.2.10-h6f28e42_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/backports.zstd-1.3.0-py310hfa1aa29_0.conda
@@ -6302,9 +6298,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/gcc-15.2.0-h2e72a27_18.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-15.2.0-hcedddb3_18.conda
       - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/h5py-3.16.0-nompi_py310hce7682f_102.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5-1.14.6-nompi_hf95b8e7_108.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5plugin-6.0.0-py310hc8e4586_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/h5py-3.16.0-nompi_py310h5f766a5_102.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5-2.1.0-nompi_h81b49a2_104.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5plugin-6.0.0-py310hf20988d_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.152.1-pyha770c72_0.conda
@@ -6387,6 +6383,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/rfc3986-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/s2n-1.7.1-h6629d95_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/secretstorage-3.4.1-py310hbbe02a8_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/setuptools-scm-9.2.2-pyhd8ed1ab_0.conda
@@ -6409,6 +6406,15 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-auth-0.10.1-hfd47d4b_2.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-cal-0.9.13-hea39f9f_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-common-0.12.6-h8616949_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-compression-0.3.2-hb9ea233_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-http-0.10.12-h1037d30_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-io-0.26.3-hc95b61d_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-s3-0.11.5-hb15a67f_5.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-sdkutils-0.2.4-h901532c_4.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-checksums-0.2.10-h31279ed_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/osx-64/backports.zstd-1.3.0-py310hedc14a4_0.conda
@@ -6440,9 +6446,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/h5py-3.16.0-nompi_py310hbc26044_102.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/hdf5-1.14.6-nompi_h13accda_108.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/hdf5plugin-6.0.0-py310hbffbd50_5.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/h5py-3.16.0-nompi_py310h05ade02_102.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/hdf5-2.1.0-nompi_h3b1597d_104.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/hdf5plugin-6.0.0-py310he652b7c_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.152.1-pyha770c72_0.conda
@@ -6545,6 +6551,15 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-auth-0.10.1-hcb83491_2.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-cal-0.9.13-h6ee9776_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-common-0.12.6-hc919400_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-compression-0.3.2-h3e7f9b5_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-http-0.10.12-h95cdebe_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-io-0.26.3-h4137820_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-s3-0.11.5-ha5d16b2_5.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-sdkutils-0.2.4-h16f91aa_4.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-checksums-0.2.10-h3e7f9b5_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/backports.zstd-1.3.0-py310h2d60bed_0.conda
@@ -6576,9 +6591,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/h5py-3.16.0-nompi_py310h0c5f886_102.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/hdf5-1.14.6-nompi_had3affe_108.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/hdf5plugin-6.0.0-py310h529efbb_5.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/h5py-3.16.0-nompi_py310hcf53ec8_102.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/hdf5-2.1.0-nompi_hc95e3eb_104.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/hdf5plugin-6.0.0-py310h3eaa12b_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.152.1-pyha770c72_0.conda
@@ -6682,6 +6697,15 @@ environments:
       win-64:
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-auth-0.10.1-h5d51246_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-cal-0.9.13-h46f3b43_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-common-0.12.6-hfd05255_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-compression-0.3.2-hcb3a2da_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-http-0.10.12-h612f3e8_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-io-0.26.3-h0d5b9f9_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-s3-0.11.5-h87bd87b_5.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-sdkutils-0.2.4-hcb3a2da_4.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-checksums-0.2.10-hcb3a2da_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/backports.zstd-1.3.0-py310h458dff3_0.conda
@@ -6707,9 +6731,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/h5py-3.16.0-nompi_py310hb7e4da9_102.conda
-      - conda: https://prefix.dev/conda-forge/win-64/hdf5-1.14.6-nompi_hae35d4c_108.conda
-      - conda: https://prefix.dev/conda-forge/win-64/hdf5plugin-6.0.0-py310haedb6d2_5.conda
+      - conda: https://prefix.dev/conda-forge/win-64/h5py-3.16.0-nompi_py310h6359f78_102.conda
+      - conda: https://prefix.dev/conda-forge/win-64/hdf5-2.1.0-nompi_hd96b29f_104.conda
+      - conda: https://prefix.dev/conda-forge/win-64/hdf5plugin-6.0.0-py310hefaf402_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.152.1-pyha770c72_0.conda
@@ -6811,6 +6835,15 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-auth-0.10.1-h2d2dd48_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-cal-0.9.13-h2c9d079_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-common-0.12.6-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-compression-0.3.2-h8b1a151_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-http-0.10.12-h4bacb7b_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-io-0.26.3-hc87160b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-s3-0.11.5-h6d69fc9_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-sdkutils-0.2.4-h8b1a151_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-checksums-0.2.10-h8b1a151_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/backports.zstd-1.3.0-py310h69bd2ac_0.conda
@@ -6839,9 +6872,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/gcc-15.2.0-h0dff253_18.conda
       - conda: https://prefix.dev/conda-forge/linux-64/gcc_impl_linux-64-15.2.0-he420e7e_18.conda
       - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/h5py-3.16.0-nompi_py310h4aa865e_102.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/hdf5-1.14.6-nompi_h19486de_108.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/hdf5plugin-6.0.0-py310h69abe24_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/h5py-3.16.0-nompi_py310hb9a6f38_102.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hdf5-2.1.0-nompi_hd4fcb43_104.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hdf5plugin-6.0.0-py310h3812ed8_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.152.1-pyha770c72_0.conda
@@ -6925,6 +6958,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/rfc3986-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/s2n-1.7.1-h1cbb8d7_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/secretstorage-3.4.1-py310hff52083_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/setuptools-scm-9.2.2-pyhd8ed1ab_0.conda
@@ -6947,6 +6981,15 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-auth-0.10.1-h5c15aeb_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-cal-0.9.13-hc50a40c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-common-0.12.6-he30d5cf_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-compression-0.3.2-h6f28e42_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-http-0.10.12-h8f13f89_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-io-0.26.3-h8d25f22_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-s3-0.11.5-h1747a43_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-sdkutils-0.2.4-h6f28e42_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-checksums-0.2.10-h6f28e42_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/backports.zstd-1.3.0-py310hfa1aa29_0.conda
@@ -6975,9 +7018,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/gcc-15.2.0-h2e72a27_18.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-15.2.0-hcedddb3_18.conda
       - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/h5py-3.16.0-nompi_py310hce7682f_102.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5-1.14.6-nompi_hf95b8e7_108.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5plugin-6.0.0-py310hc8e4586_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/h5py-3.16.0-nompi_py310h5f766a5_102.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5-2.1.0-nompi_h81b49a2_104.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5plugin-6.0.0-py310hf20988d_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.152.1-pyha770c72_0.conda
@@ -7060,6 +7103,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/rfc3986-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/s2n-1.7.1-h6629d95_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/secretstorage-3.4.1-py310hbbe02a8_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/setuptools-scm-9.2.2-pyhd8ed1ab_0.conda
@@ -7082,6 +7126,15 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-auth-0.10.1-hfd47d4b_2.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-cal-0.9.13-hea39f9f_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-common-0.12.6-h8616949_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-compression-0.3.2-hb9ea233_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-http-0.10.12-h1037d30_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-io-0.26.3-hc95b61d_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-s3-0.11.5-hb15a67f_5.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-sdkutils-0.2.4-h901532c_4.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-checksums-0.2.10-h31279ed_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/osx-64/backports.zstd-1.3.0-py310hedc14a4_0.conda
@@ -7113,9 +7166,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/h5py-3.16.0-nompi_py310hbc26044_102.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/hdf5-1.14.6-nompi_h13accda_108.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/hdf5plugin-6.0.0-py310hbffbd50_5.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/h5py-3.16.0-nompi_py310h05ade02_102.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/hdf5-2.1.0-nompi_h3b1597d_104.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/hdf5plugin-6.0.0-py310he652b7c_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.152.1-pyha770c72_0.conda
@@ -7218,6 +7271,15 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-auth-0.10.1-hcb83491_2.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-cal-0.9.13-h6ee9776_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-common-0.12.6-hc919400_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-compression-0.3.2-h3e7f9b5_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-http-0.10.12-h95cdebe_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-io-0.26.3-h4137820_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-s3-0.11.5-ha5d16b2_5.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-sdkutils-0.2.4-h16f91aa_4.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-checksums-0.2.10-h3e7f9b5_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/backports.zstd-1.3.0-py310h2d60bed_0.conda
@@ -7249,9 +7311,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/h5py-3.16.0-nompi_py310h0c5f886_102.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/hdf5-1.14.6-nompi_had3affe_108.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/hdf5plugin-6.0.0-py310h529efbb_5.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/h5py-3.16.0-nompi_py310hcf53ec8_102.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/hdf5-2.1.0-nompi_hc95e3eb_104.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/hdf5plugin-6.0.0-py310h3eaa12b_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.152.1-pyha770c72_0.conda
@@ -7355,6 +7417,15 @@ environments:
       win-64:
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-auth-0.10.1-h5d51246_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-cal-0.9.13-h46f3b43_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-common-0.12.6-hfd05255_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-compression-0.3.2-hcb3a2da_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-http-0.10.12-h612f3e8_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-io-0.26.3-h0d5b9f9_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-s3-0.11.5-h87bd87b_5.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-sdkutils-0.2.4-hcb3a2da_4.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-checksums-0.2.10-hcb3a2da_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/backports.zstd-1.3.0-py310h458dff3_0.conda
@@ -7380,9 +7451,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/h5py-3.16.0-nompi_py310hb7e4da9_102.conda
-      - conda: https://prefix.dev/conda-forge/win-64/hdf5-1.14.6-nompi_hae35d4c_108.conda
-      - conda: https://prefix.dev/conda-forge/win-64/hdf5plugin-6.0.0-py310haedb6d2_5.conda
+      - conda: https://prefix.dev/conda-forge/win-64/h5py-3.16.0-nompi_py310h6359f78_102.conda
+      - conda: https://prefix.dev/conda-forge/win-64/hdf5-2.1.0-nompi_hd96b29f_104.conda
+      - conda: https://prefix.dev/conda-forge/win-64/hdf5plugin-6.0.0-py310hefaf402_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.152.1-pyha770c72_0.conda
@@ -7484,6 +7555,15 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-auth-0.10.1-h2d2dd48_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-cal-0.9.13-h2c9d079_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-common-0.12.6-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-compression-0.3.2-h8b1a151_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-http-0.10.12-h4bacb7b_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-io-0.26.3-hc87160b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-s3-0.11.5-h6d69fc9_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-sdkutils-0.2.4-h8b1a151_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-checksums-0.2.10-h8b1a151_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/backports.zstd-1.3.0-py311h6b1f9c4_0.conda
@@ -7512,9 +7592,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/gcc-15.2.0-h0dff253_18.conda
       - conda: https://prefix.dev/conda-forge/linux-64/gcc_impl_linux-64-15.2.0-he420e7e_18.conda
       - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/h5py-3.16.0-nompi_py311h0b2f468_102.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/hdf5-1.14.6-nompi_h19486de_108.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/hdf5plugin-6.0.0-py311h60fd0ea_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/h5py-3.16.0-nompi_py311hfef529e_102.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hdf5-2.1.0-nompi_hd4fcb43_104.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hdf5plugin-6.0.0-py311h41e6a36_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.152.1-pyha770c72_0.conda
@@ -7598,6 +7678,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/rfc3986-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/s2n-1.7.1-h1cbb8d7_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/secretstorage-3.4.1-py311h38be061_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/setuptools-scm-9.2.2-pyhd8ed1ab_0.conda
@@ -7620,6 +7701,15 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-auth-0.10.1-h5c15aeb_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-cal-0.9.13-hc50a40c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-common-0.12.6-he30d5cf_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-compression-0.3.2-h6f28e42_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-http-0.10.12-h8f13f89_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-io-0.26.3-h8d25f22_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-s3-0.11.5-h1747a43_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-sdkutils-0.2.4-h6f28e42_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-checksums-0.2.10-h6f28e42_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/backports.zstd-1.3.0-py311h6ce31b0_0.conda
@@ -7648,9 +7738,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/gcc-15.2.0-h2e72a27_18.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-15.2.0-hcedddb3_18.conda
       - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/h5py-3.16.0-nompi_py311h330c8c8_102.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5-1.14.6-nompi_hf95b8e7_108.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5plugin-6.0.0-py311hf6bb6b3_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/h5py-3.16.0-nompi_py311h8208d6c_102.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5-2.1.0-nompi_h81b49a2_104.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5plugin-6.0.0-py311h59c577c_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.152.1-pyha770c72_0.conda
@@ -7733,6 +7823,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/rfc3986-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/s2n-1.7.1-h6629d95_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/secretstorage-3.4.1-py311hfecb2dc_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/setuptools-scm-9.2.2-pyhd8ed1ab_0.conda
@@ -7755,6 +7846,15 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-auth-0.10.1-hfd47d4b_2.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-cal-0.9.13-hea39f9f_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-common-0.12.6-h8616949_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-compression-0.3.2-hb9ea233_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-http-0.10.12-h1037d30_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-io-0.26.3-hc95b61d_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-s3-0.11.5-hb15a67f_5.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-sdkutils-0.2.4-h901532c_4.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-checksums-0.2.10-h31279ed_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/osx-64/backports.zstd-1.3.0-py311hdc67420_0.conda
@@ -7786,9 +7886,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/h5py-3.16.0-nompi_py311h1d8f82b_102.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/hdf5-1.14.6-nompi_h13accda_108.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/hdf5plugin-6.0.0-py311hd6207b9_5.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/h5py-3.16.0-nompi_py311ha7e68cf_102.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/hdf5-2.1.0-nompi_h3b1597d_104.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/hdf5plugin-6.0.0-py311h6dfbe9f_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.152.1-pyha770c72_0.conda
@@ -7891,6 +7991,15 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-auth-0.10.1-hcb83491_2.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-cal-0.9.13-h6ee9776_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-common-0.12.6-hc919400_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-compression-0.3.2-h3e7f9b5_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-http-0.10.12-h95cdebe_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-io-0.26.3-h4137820_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-s3-0.11.5-ha5d16b2_5.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-sdkutils-0.2.4-h16f91aa_4.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-checksums-0.2.10-h3e7f9b5_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/backports.zstd-1.3.0-py311hee243d0_0.conda
@@ -7922,9 +8031,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/h5py-3.16.0-nompi_py311h6bee198_102.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/hdf5-1.14.6-nompi_had3affe_108.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/hdf5plugin-6.0.0-py311h0ea10f0_5.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/h5py-3.16.0-nompi_py311hf10ccac_102.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/hdf5-2.1.0-nompi_hc95e3eb_104.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/hdf5plugin-6.0.0-py311h554bcfb_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.152.1-pyha770c72_0.conda
@@ -8028,6 +8137,15 @@ environments:
       win-64:
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-auth-0.10.1-h5d51246_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-cal-0.9.13-h46f3b43_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-common-0.12.6-hfd05255_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-compression-0.3.2-hcb3a2da_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-http-0.10.12-h612f3e8_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-io-0.26.3-h0d5b9f9_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-s3-0.11.5-h87bd87b_5.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-sdkutils-0.2.4-hcb3a2da_4.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-checksums-0.2.10-hcb3a2da_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/backports.zstd-1.3.0-py311h71c1bcc_0.conda
@@ -8053,9 +8171,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/h5py-3.16.0-nompi_py311hc40ba4b_102.conda
-      - conda: https://prefix.dev/conda-forge/win-64/hdf5-1.14.6-nompi_hae35d4c_108.conda
-      - conda: https://prefix.dev/conda-forge/win-64/hdf5plugin-6.0.0-py311h25c9a92_5.conda
+      - conda: https://prefix.dev/conda-forge/win-64/h5py-3.16.0-nompi_py311ha643933_102.conda
+      - conda: https://prefix.dev/conda-forge/win-64/hdf5-2.1.0-nompi_hd96b29f_104.conda
+      - conda: https://prefix.dev/conda-forge/win-64/hdf5plugin-6.0.0-py311h727873e_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.152.1-pyha770c72_0.conda
@@ -8157,6 +8275,15 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-auth-0.10.1-h2d2dd48_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-cal-0.9.13-h2c9d079_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-common-0.12.6-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-compression-0.3.2-h8b1a151_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-http-0.10.12-h4bacb7b_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-io-0.26.3-hc87160b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-s3-0.11.5-h6d69fc9_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-sdkutils-0.2.4-h8b1a151_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-checksums-0.2.10-h8b1a151_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/backports.zstd-1.3.0-py312h90b7ffd_0.conda
@@ -8185,9 +8312,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/gcc-15.2.0-h0dff253_18.conda
       - conda: https://prefix.dev/conda-forge/linux-64/gcc_impl_linux-64-15.2.0-he420e7e_18.conda
       - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/h5py-3.16.0-nompi_py312ha4f8f14_102.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/hdf5-1.14.6-nompi_h19486de_108.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/hdf5plugin-6.0.0-py312hb944afc_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/h5py-3.16.0-nompi_py312ha829cd9_102.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hdf5-2.1.0-nompi_hd4fcb43_104.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hdf5plugin-6.0.0-py312h645ab66_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.152.1-pyha770c72_0.conda
@@ -8271,6 +8398,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/rfc3986-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/s2n-1.7.1-h1cbb8d7_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/secretstorage-3.4.1-py312h7900ff3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/setuptools-scm-9.2.2-pyhd8ed1ab_0.conda
@@ -8293,6 +8421,15 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-auth-0.10.1-h5c15aeb_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-cal-0.9.13-hc50a40c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-common-0.12.6-he30d5cf_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-compression-0.3.2-h6f28e42_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-http-0.10.12-h8f13f89_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-io-0.26.3-h8d25f22_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-s3-0.11.5-h1747a43_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-sdkutils-0.2.4-h6f28e42_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-checksums-0.2.10-h6f28e42_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/backports.zstd-1.3.0-py312h3d8e7d4_0.conda
@@ -8321,9 +8458,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/gcc-15.2.0-h2e72a27_18.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-15.2.0-hcedddb3_18.conda
       - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/h5py-3.16.0-nompi_py312hb54937b_102.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5-1.14.6-nompi_hf95b8e7_108.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5plugin-6.0.0-py312h67d4751_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/h5py-3.16.0-nompi_py312hfc41986_102.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5-2.1.0-nompi_h81b49a2_104.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5plugin-6.0.0-py312hf8637db_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.152.1-pyha770c72_0.conda
@@ -8406,6 +8543,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/rfc3986-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/s2n-1.7.1-h6629d95_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/secretstorage-3.4.1-py312h8025657_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/setuptools-scm-9.2.2-pyhd8ed1ab_0.conda
@@ -8428,6 +8566,15 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-auth-0.10.1-hfd47d4b_2.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-cal-0.9.13-hea39f9f_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-common-0.12.6-h8616949_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-compression-0.3.2-hb9ea233_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-http-0.10.12-h1037d30_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-io-0.26.3-hc95b61d_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-s3-0.11.5-hb15a67f_5.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-sdkutils-0.2.4-h901532c_4.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-checksums-0.2.10-h31279ed_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/osx-64/backports.zstd-1.3.0-py312h6917036_0.conda
@@ -8459,9 +8606,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/h5py-3.16.0-nompi_py312h53b4df1_102.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/hdf5-1.14.6-nompi_h13accda_108.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/hdf5plugin-6.0.0-py312h667c79f_5.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/h5py-3.16.0-nompi_py312h82c48cf_102.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/hdf5-2.1.0-nompi_h3b1597d_104.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/hdf5plugin-6.0.0-py312ha60f365_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.152.1-pyha770c72_0.conda
@@ -8564,6 +8711,15 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-auth-0.10.1-hcb83491_2.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-cal-0.9.13-h6ee9776_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-common-0.12.6-hc919400_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-compression-0.3.2-h3e7f9b5_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-http-0.10.12-h95cdebe_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-io-0.26.3-h4137820_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-s3-0.11.5-ha5d16b2_5.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-sdkutils-0.2.4-h16f91aa_4.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-checksums-0.2.10-h3e7f9b5_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/backports.zstd-1.3.0-py312h44dc372_0.conda
@@ -8595,9 +8751,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/h5py-3.16.0-nompi_py312hdd01ddf_102.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/hdf5-1.14.6-nompi_had3affe_108.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/hdf5plugin-6.0.0-py312h92c404d_5.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/h5py-3.16.0-nompi_py312h585e8c8_102.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/hdf5-2.1.0-nompi_hc95e3eb_104.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/hdf5plugin-6.0.0-py312h49adf7b_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.152.1-pyha770c72_0.conda
@@ -8701,6 +8857,15 @@ environments:
       win-64:
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-auth-0.10.1-h5d51246_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-cal-0.9.13-h46f3b43_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-common-0.12.6-hfd05255_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-compression-0.3.2-hcb3a2da_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-http-0.10.12-h612f3e8_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-io-0.26.3-h0d5b9f9_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-s3-0.11.5-h87bd87b_5.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-sdkutils-0.2.4-hcb3a2da_4.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-checksums-0.2.10-hcb3a2da_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/backports.zstd-1.3.0-py312h06d0912_0.conda
@@ -8726,9 +8891,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/h5py-3.16.0-nompi_py312h03cd2ba_102.conda
-      - conda: https://prefix.dev/conda-forge/win-64/hdf5-1.14.6-nompi_hae35d4c_108.conda
-      - conda: https://prefix.dev/conda-forge/win-64/hdf5plugin-6.0.0-py312h63f2bdf_5.conda
+      - conda: https://prefix.dev/conda-forge/win-64/h5py-3.16.0-nompi_py312h5ddec8c_102.conda
+      - conda: https://prefix.dev/conda-forge/win-64/hdf5-2.1.0-nompi_hd96b29f_104.conda
+      - conda: https://prefix.dev/conda-forge/win-64/hdf5plugin-6.0.0-py312hee59bae_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.152.1-pyha770c72_0.conda
@@ -8830,6 +8995,15 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-auth-0.10.1-h2d2dd48_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-cal-0.9.13-h2c9d079_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-common-0.12.6-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-compression-0.3.2-h8b1a151_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-http-0.10.12-h4bacb7b_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-io-0.26.3-hc87160b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-s3-0.11.5-h6d69fc9_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-sdkutils-0.2.4-h8b1a151_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-checksums-0.2.10-h8b1a151_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/backports.zstd-1.3.0-py313h18e8e13_0.conda
@@ -8858,9 +9032,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/gcc-15.2.0-h0dff253_18.conda
       - conda: https://prefix.dev/conda-forge/linux-64/gcc_impl_linux-64-15.2.0-he420e7e_18.conda
       - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/h5py-3.16.0-nompi_py313h253c126_102.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/hdf5-1.14.6-nompi_h19486de_108.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/hdf5plugin-6.0.0-py313h3437735_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/h5py-3.16.0-nompi_py313h22c32d4_102.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hdf5-2.1.0-nompi_hd4fcb43_104.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hdf5plugin-6.0.0-py313hdbdd960_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.152.1-pyha770c72_0.conda
@@ -8943,6 +9117,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/rfc3986-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/s2n-1.7.1-h1cbb8d7_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/secretstorage-3.4.1-py313h78bf25f_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/setuptools-scm-9.2.2-pyhd8ed1ab_0.conda
@@ -8965,6 +9140,15 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-auth-0.10.1-h5c15aeb_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-cal-0.9.13-hc50a40c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-common-0.12.6-he30d5cf_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-compression-0.3.2-h6f28e42_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-http-0.10.12-h8f13f89_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-io-0.26.3-h8d25f22_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-s3-0.11.5-h1747a43_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-sdkutils-0.2.4-h6f28e42_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-checksums-0.2.10-h6f28e42_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/backports.zstd-1.3.0-py313h3d57138_0.conda
@@ -8993,9 +9177,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/gcc-15.2.0-h2e72a27_18.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-15.2.0-hcedddb3_18.conda
       - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/h5py-3.16.0-nompi_py313h624fb37_102.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5-1.14.6-nompi_hf95b8e7_108.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5plugin-6.0.0-py313h59f7827_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/h5py-3.16.0-nompi_py313h14703b5_102.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5-2.1.0-nompi_h81b49a2_104.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5plugin-6.0.0-py313h900b84a_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.152.1-pyha770c72_0.conda
@@ -9077,6 +9261,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/rfc3986-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/s2n-1.7.1-h6629d95_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/secretstorage-3.4.1-py313h1258fbd_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/setuptools-scm-9.2.2-pyhd8ed1ab_0.conda
@@ -9099,6 +9284,15 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-auth-0.10.1-hfd47d4b_2.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-cal-0.9.13-hea39f9f_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-common-0.12.6-h8616949_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-compression-0.3.2-hb9ea233_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-http-0.10.12-h1037d30_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-io-0.26.3-hc95b61d_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-s3-0.11.5-hb15a67f_5.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-sdkutils-0.2.4-h901532c_4.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-checksums-0.2.10-h31279ed_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/osx-64/backports.zstd-1.3.0-py313h591e92b_0.conda
@@ -9130,9 +9324,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/h5py-3.16.0-nompi_py313hd52a848_102.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/hdf5-1.14.6-nompi_h13accda_108.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/hdf5plugin-6.0.0-py313ha1ae2fd_5.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/h5py-3.16.0-nompi_py313h15f83ed_102.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/hdf5-2.1.0-nompi_h3b1597d_104.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/hdf5plugin-6.0.0-py313hfdb907d_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.152.1-pyha770c72_0.conda
@@ -9236,6 +9430,15 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-auth-0.10.1-hcb83491_2.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-cal-0.9.13-h6ee9776_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-common-0.12.6-hc919400_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-compression-0.3.2-h3e7f9b5_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-http-0.10.12-h95cdebe_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-io-0.26.3-h4137820_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-s3-0.11.5-ha5d16b2_5.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-sdkutils-0.2.4-h16f91aa_4.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-checksums-0.2.10-h3e7f9b5_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/backports.zstd-1.3.0-py313h48bb75e_0.conda
@@ -9267,9 +9470,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/h5py-3.16.0-nompi_py313hc6ee213_102.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/hdf5-1.14.6-nompi_had3affe_108.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/hdf5plugin-6.0.0-py313hb22e04b_5.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/h5py-3.16.0-nompi_py313h2c4073f_102.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/hdf5-2.1.0-nompi_hc95e3eb_104.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/hdf5plugin-6.0.0-py313h9c23d4e_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.152.1-pyha770c72_0.conda
@@ -9374,6 +9577,15 @@ environments:
       win-64:
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-auth-0.10.1-h5d51246_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-cal-0.9.13-h46f3b43_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-common-0.12.6-hfd05255_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-compression-0.3.2-hcb3a2da_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-http-0.10.12-h612f3e8_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-io-0.26.3-h0d5b9f9_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-s3-0.11.5-h87bd87b_5.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-sdkutils-0.2.4-hcb3a2da_4.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-checksums-0.2.10-hcb3a2da_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/backports.zstd-1.3.0-py313h2a31948_0.conda
@@ -9399,9 +9611,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/h5py-3.16.0-nompi_py313hf7f959b_102.conda
-      - conda: https://prefix.dev/conda-forge/win-64/hdf5-1.14.6-nompi_hae35d4c_108.conda
-      - conda: https://prefix.dev/conda-forge/win-64/hdf5plugin-6.0.0-py313h1e823ac_5.conda
+      - conda: https://prefix.dev/conda-forge/win-64/h5py-3.16.0-nompi_py313hd050a09_102.conda
+      - conda: https://prefix.dev/conda-forge/win-64/hdf5-2.1.0-nompi_hd96b29f_104.conda
+      - conda: https://prefix.dev/conda-forge/win-64/hdf5plugin-6.0.0-py313h480876f_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.152.1-pyha770c72_0.conda
@@ -9504,6 +9716,15 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-auth-0.10.1-h2d2dd48_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-cal-0.9.13-h2c9d079_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-common-0.12.6-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-compression-0.3.2-h8b1a151_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-http-0.10.12-h4bacb7b_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-io-0.26.3-hc87160b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-s3-0.11.5-h6d69fc9_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-sdkutils-0.2.4-h8b1a151_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-checksums-0.2.10-h8b1a151_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.zstd-1.3.0-py314h680f03e_0.conda
@@ -9532,9 +9753,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/gcc-15.2.0-h0dff253_18.conda
       - conda: https://prefix.dev/conda-forge/linux-64/gcc_impl_linux-64-15.2.0-he420e7e_18.conda
       - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/h5py-3.16.0-nompi_py314hc32fe06_102.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/hdf5-1.14.6-nompi_h19486de_108.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/hdf5plugin-6.0.0-py314h068620f_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/h5py-3.16.0-nompi_py314hddf7a69_102.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hdf5-2.1.0-nompi_hd4fcb43_104.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hdf5plugin-6.0.0-py314h3f9f1dd_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.152.1-pyha770c72_0.conda
@@ -9617,6 +9838,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/rfc3986-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/s2n-1.7.1-h1cbb8d7_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/secretstorage-3.4.1-py314hdafbbf9_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/setuptools-scm-9.2.2-pyhd8ed1ab_0.conda
@@ -9639,6 +9861,15 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-auth-0.10.1-h5c15aeb_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-cal-0.9.13-hc50a40c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-common-0.12.6-he30d5cf_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-compression-0.3.2-h6f28e42_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-http-0.10.12-h8f13f89_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-io-0.26.3-h8d25f22_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-s3-0.11.5-h1747a43_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-sdkutils-0.2.4-h6f28e42_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-checksums-0.2.10-h6f28e42_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.zstd-1.3.0-py314h680f03e_0.conda
@@ -9667,9 +9898,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/gcc-15.2.0-h2e72a27_18.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-15.2.0-hcedddb3_18.conda
       - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/h5py-3.16.0-nompi_py314h2a0c532_102.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5-1.14.6-nompi_hf95b8e7_108.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5plugin-6.0.0-py314hc4425fe_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/h5py-3.16.0-nompi_py314h96887de_102.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5-2.1.0-nompi_h81b49a2_104.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5plugin-6.0.0-py314ha8685b7_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.152.1-pyha770c72_0.conda
@@ -9751,6 +9982,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/rfc3986-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/s2n-1.7.1-h6629d95_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/secretstorage-3.4.1-py314ha42fa4b_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/setuptools-scm-9.2.2-pyhd8ed1ab_0.conda
@@ -9773,6 +10005,15 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-auth-0.10.1-hfd47d4b_2.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-cal-0.9.13-hea39f9f_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-common-0.12.6-h8616949_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-compression-0.3.2-hb9ea233_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-http-0.10.12-h1037d30_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-io-0.26.3-hc95b61d_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-s3-0.11.5-hb15a67f_5.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-c-sdkutils-0.2.4-h901532c_4.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/aws-checksums-0.2.10-h31279ed_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.zstd-1.3.0-py314h680f03e_0.conda
@@ -9804,9 +10045,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/h5py-3.16.0-nompi_py314hd1d8aca_102.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/hdf5-1.14.6-nompi_h13accda_108.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/hdf5plugin-6.0.0-py314hed58d6d_5.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/h5py-3.16.0-nompi_py314h58ac280_102.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/hdf5-2.1.0-nompi_h3b1597d_104.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/hdf5plugin-6.0.0-py314h787f6f2_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.152.1-pyha770c72_0.conda
@@ -9910,6 +10151,15 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-auth-0.10.1-hcb83491_2.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-cal-0.9.13-h6ee9776_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-common-0.12.6-hc919400_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-compression-0.3.2-h3e7f9b5_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-http-0.10.12-h95cdebe_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-io-0.26.3-h4137820_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-s3-0.11.5-ha5d16b2_5.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-sdkutils-0.2.4-h16f91aa_4.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-checksums-0.2.10-h3e7f9b5_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.zstd-1.3.0-py314h680f03e_0.conda
@@ -9941,9 +10191,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/h5py-3.16.0-nompi_py314hb49d8aa_102.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/hdf5-1.14.6-nompi_had3affe_108.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/hdf5plugin-6.0.0-py314hbe0a16a_5.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/h5py-3.16.0-nompi_py314h658a3ac_102.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/hdf5-2.1.0-nompi_hc95e3eb_104.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/hdf5plugin-6.0.0-py314h02eda3a_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.152.1-pyha770c72_0.conda
@@ -10048,6 +10298,15 @@ environments:
       win-64:
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-auth-0.10.1-h5d51246_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-cal-0.9.13-h46f3b43_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-common-0.12.6-hfd05255_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-compression-0.3.2-hcb3a2da_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-http-0.10.12-h612f3e8_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-io-0.26.3-h0d5b9f9_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-s3-0.11.5-h87bd87b_5.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-sdkutils-0.2.4-hcb3a2da_4.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-checksums-0.2.10-hcb3a2da_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.zstd-1.3.0-py314h680f03e_0.conda
@@ -10073,9 +10332,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/h5py-3.16.0-nompi_py314hc249e69_102.conda
-      - conda: https://prefix.dev/conda-forge/win-64/hdf5-1.14.6-nompi_hae35d4c_108.conda
-      - conda: https://prefix.dev/conda-forge/win-64/hdf5plugin-6.0.0-py314he70fd34_5.conda
+      - conda: https://prefix.dev/conda-forge/win-64/h5py-3.16.0-nompi_py314h02517ec_102.conda
+      - conda: https://prefix.dev/conda-forge/win-64/hdf5-2.1.0-nompi_hd96b29f_104.conda
+      - conda: https://prefix.dev/conda-forge/win-64/hdf5plugin-6.0.0-py314h79e82e5_5.conda
       - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.152.1-pyha770c72_0.conda
@@ -15642,13 +15901,6 @@ packages:
   requires_dist:
   - numpy>=1.21.2
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/db/33/acd0ce6863b6c0d7735007df01815403f5589a21ff8c2e1ee2587a38f548/h5py-3.16.0.tar.gz
-  name: h5py
-  version: 3.16.0
-  sha256: a0dbaad796840ccaa67a4c144a0d0c8080073c34c76d5a6941d6818678ef2738
-  requires_dist:
-  - numpy>=1.21.2
-  requires_python: '>=3.10'
 - conda: https://prefix.dev/conda-forge/linux-64/h5py-3.16.0-nompi_py310h4aa865e_102.conda
   sha256: e2f5169e2da674c83e678e7ec0ed6f969e5830a4bd23606ef610b2b18dde1090
   md5: e5f4aa8cdc28aa431bd54f4d8b2ed24f
@@ -15666,13 +15918,30 @@ packages:
   - pkg:pypi/h5py?source=hash-mapping
   size: 1252638
   timestamp: 1775581283560
-- conda: https://prefix.dev/conda-forge/linux-64/h5py-3.16.0-nompi_py311h0b2f468_102.conda
-  sha256: 61e3adb8218d57a2e7a91c7b4b4d338c3c0d23432ef0f2ed5bfc8d51f73735f3
-  md5: f476161e215ecee68daf16efbf209731
+- conda: https://prefix.dev/conda-forge/linux-64/h5py-3.16.0-nompi_py310hb9a6f38_102.conda
+  sha256: 5b5a401c2ee28b1f7eb3a060f51a01b9656c9b01a8960132cd5935afc1704dd4
+  md5: 7f5d5bf2d5d86f6b77682895f44b271e
   depends:
   - __glibc >=2.17,<3.0.a0
   - cached-property
-  - hdf5 >=1.14.6,<1.14.7.0a0
+  - hdf5 >=2.1.0,<3.0a0
+  - libgcc >=14
+  - numpy >=1.21,<3
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/h5py?source=hash-mapping
+  size: 1259075
+  timestamp: 1775581270235
+- conda: https://prefix.dev/conda-forge/linux-64/h5py-3.16.0-nompi_py311hfef529e_102.conda
+  sha256: 9495b6fe2a7b1cf0fded3c53252e964d968fa1fc87cf1ce76c4d9c5e8ab22385
+  md5: 5737f2130791c91aee8374ee0d4465de
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cached-property
+  - hdf5 >=2.1.0,<3.0a0
   - libgcc >=14
   - numpy >=1.23,<3
   - python >=3.11,<3.12.0a0
@@ -15681,15 +15950,15 @@ packages:
   license_family: BSD
   purls:
   - pkg:pypi/h5py?source=hash-mapping
-  size: 1353682
-  timestamp: 1775581279300
-- conda: https://prefix.dev/conda-forge/linux-64/h5py-3.16.0-nompi_py312ha4f8f14_102.conda
-  sha256: de9ec9b1b01b90f2da2d896a5835a2fd8049859aff0c6331ca4594327ec79a8b
-  md5: b270340809d19ae40ff9913f277b803a
+  size: 1359434
+  timestamp: 1775581283533
+- conda: https://prefix.dev/conda-forge/linux-64/h5py-3.16.0-nompi_py312ha829cd9_102.conda
+  sha256: 578ab0db104435ac003061e103789299720fc49b8b3e8401dabd5130a1ef8663
+  md5: c6e5cf708b01707fe4cd5e4dc56cf4cc
   depends:
   - __glibc >=2.17,<3.0.a0
   - cached-property
-  - hdf5 >=1.14.6,<1.14.7.0a0
+  - hdf5 >=2.1.0,<3.0a0
   - libgcc >=14
   - numpy >=1.23,<3
   - python >=3.12,<3.13.0a0
@@ -15698,15 +15967,15 @@ packages:
   license_family: BSD
   purls:
   - pkg:pypi/h5py?source=hash-mapping
-  size: 1335314
-  timestamp: 1775581269364
-- conda: https://prefix.dev/conda-forge/linux-64/h5py-3.16.0-nompi_py313h253c126_102.conda
-  sha256: 4247b5c4921abbdf3d493f55540fe7b4fdb99907c948d2d851f597dad0f737b4
-  md5: 1d2259f89c6d038ab7193e8c3961e067
+  size: 1339689
+  timestamp: 1775581278758
+- conda: https://prefix.dev/conda-forge/linux-64/h5py-3.16.0-nompi_py313h22c32d4_102.conda
+  sha256: 3def6d562885610497befa9dd81c685c53bb027309407797ad9918d4179dda21
+  md5: 37727e0bcda5059c33c83fdf5b13a9a1
   depends:
   - __glibc >=2.17,<3.0.a0
   - cached-property
-  - hdf5 >=1.14.6,<1.14.7.0a0
+  - hdf5 >=2.1.0,<3.0a0
   - libgcc >=14
   - numpy >=1.23,<3
   - python >=3.13,<3.14.0a0
@@ -15715,25 +15984,8 @@ packages:
   license_family: BSD
   purls:
   - pkg:pypi/h5py?source=hash-mapping
-  size: 1331707
-  timestamp: 1775581269133
-- conda: https://prefix.dev/conda-forge/linux-64/h5py-3.16.0-nompi_py314hc32fe06_102.conda
-  sha256: df8b14e4a6bff2db5678e297410f38fe69d5f37850865a35c46148355af320a5
-  md5: ef5ecbcea33d98087791c056247df30c
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - cached-property
-  - hdf5 >=1.14.6,<1.14.7.0a0
-  - libgcc >=14
-  - numpy >=1.23,<3
-  - python >=3.14,<3.15.0a0
-  - python_abi 3.14.* *_cp314
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/h5py?source=hash-mapping
-  size: 1336385
-  timestamp: 1775581248333
+  size: 1336531
+  timestamp: 1775581276561
 - conda: https://prefix.dev/conda-forge/linux-64/h5py-3.16.0-nompi_py314hddf7a69_102.conda
   sha256: 48e18f20bc1ff15433299dd77c20a4160eb29572eea799ae5a73632c6c3d7dfd
   md5: d93afa30018997705dd04513eeb5ac0f
@@ -15767,6 +16019,23 @@ packages:
   - pkg:pypi/h5py?source=hash-mapping
   size: 1140849
   timestamp: 1674499131725
+- conda: https://prefix.dev/conda-forge/linux-aarch64/h5py-3.16.0-nompi_py310h5f766a5_102.conda
+  sha256: f43bce643d3d415f7de6705d82d57a95a42b77b9c9bd106e020b5c0a996ebfa9
+  md5: b452a45af7cde372aa48e8b58d270709
+  depends:
+  - cached-property
+  - hdf5 >=2.1.0,<3.0a0
+  - libgcc >=14
+  - numpy >=1.21,<3
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/h5py?source=hash-mapping
+  size: 1234666
+  timestamp: 1775581706652
 - conda: https://prefix.dev/conda-forge/linux-aarch64/h5py-3.16.0-nompi_py310hce7682f_102.conda
   sha256: 041f0a90ce9c2060b8f9b000014bbfd3005c45ea54aea178b3a3b12e155fb1e5
   md5: d14cdb5312d50f6bae854e16d535baa4
@@ -15784,12 +16053,12 @@ packages:
   - pkg:pypi/h5py?source=hash-mapping
   size: 1229859
   timestamp: 1775581333710
-- conda: https://prefix.dev/conda-forge/linux-aarch64/h5py-3.16.0-nompi_py311h330c8c8_102.conda
-  sha256: 9b802ae142306eb7a926452406328e407219722ac871d0c9a6941d796f70a566
-  md5: 3c8f32b7239ec6ae3d1b9af89b89f3fe
+- conda: https://prefix.dev/conda-forge/linux-aarch64/h5py-3.16.0-nompi_py311h8208d6c_102.conda
+  sha256: 7579f238eb0fb34469f37ec652c2ff664b47dbb39b2b5ee8043c6101c16b3673
+  md5: 8b56660b8176e7a9ce8d84c556b88ff6
   depends:
   - cached-property
-  - hdf5 >=1.14.6,<1.14.7.0a0
+  - hdf5 >=2.1.0,<3.0a0
   - libgcc >=14
   - numpy >=1.23,<3
   - python >=3.11,<3.12.0a0
@@ -15799,14 +16068,14 @@ packages:
   license_family: BSD
   purls:
   - pkg:pypi/h5py?source=hash-mapping
-  size: 1333190
-  timestamp: 1775581320872
-- conda: https://prefix.dev/conda-forge/linux-aarch64/h5py-3.16.0-nompi_py312hb54937b_102.conda
-  sha256: f09f05c2af39cbcdc702dd44174c28220c6c98b42f31382d8eb1ede63ee1efa9
-  md5: f350490f2528bfe3369e8bb253d2f796
+  size: 1339385
+  timestamp: 1775581697883
+- conda: https://prefix.dev/conda-forge/linux-aarch64/h5py-3.16.0-nompi_py312hfc41986_102.conda
+  sha256: 246a5e8ad4a1c30001a1011a76e12d6878c7a131f207c156220b8569962005d2
+  md5: 2cd909b009a1c8b6b25bafc291a68306
   depends:
   - cached-property
-  - hdf5 >=1.14.6,<1.14.7.0a0
+  - hdf5 >=2.1.0,<3.0a0
   - libgcc >=14
   - numpy >=1.23,<3
   - python >=3.12,<3.13.0a0
@@ -15816,14 +16085,14 @@ packages:
   license_family: BSD
   purls:
   - pkg:pypi/h5py?source=hash-mapping
-  size: 1303952
-  timestamp: 1775581323449
-- conda: https://prefix.dev/conda-forge/linux-aarch64/h5py-3.16.0-nompi_py313h624fb37_102.conda
-  sha256: 5b6a2aea4f654543098ef0461d08aa8bdafc80ac9e2b6135589ae9d03fa4cbd0
-  md5: a7451a5b95481c63369255febf544c93
+  size: 1307373
+  timestamp: 1775581694707
+- conda: https://prefix.dev/conda-forge/linux-aarch64/h5py-3.16.0-nompi_py313h14703b5_102.conda
+  sha256: 68c57e101b3eb93c915c36ce2f6e5e0cc13c2946ad204d676d7512d10e5d6b67
+  md5: 1518d1382d79f1de6d5661ec02245610
   depends:
   - cached-property
-  - hdf5 >=1.14.6,<1.14.7.0a0
+  - hdf5 >=2.1.0,<3.0a0
   - libgcc >=14
   - numpy >=1.23,<3
   - python >=3.13,<3.14.0a0
@@ -15833,25 +16102,8 @@ packages:
   license_family: BSD
   purls:
   - pkg:pypi/h5py?source=hash-mapping
-  size: 1299105
-  timestamp: 1775581321191
-- conda: https://prefix.dev/conda-forge/linux-aarch64/h5py-3.16.0-nompi_py314h2a0c532_102.conda
-  sha256: d577f8d2371ff2595235e6678872410af32f00f55be0d993494598bf9342912b
-  md5: 4526e3622fe4e2e236676be1eaa344d9
-  depends:
-  - cached-property
-  - hdf5 >=1.14.6,<1.14.7.0a0
-  - libgcc >=14
-  - numpy >=1.23,<3
-  - python >=3.14,<3.15.0a0
-  - python >=3.14,<3.15.0a0 *_cp314
-  - python_abi 3.14.* *_cp314
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/h5py?source=hash-mapping
-  size: 1311150
-  timestamp: 1775581327679
+  size: 1302448
+  timestamp: 1775581709275
 - conda: https://prefix.dev/conda-forge/linux-aarch64/h5py-3.16.0-nompi_py314h96887de_102.conda
   sha256: 2949aa9b46bf96fa32b60db02040050df4f43dacb7f959cc0d4f55a3bed3e143
   md5: ea167ebd2b4588a888ef5c5915c5915f
@@ -15885,6 +16137,22 @@ packages:
   - pkg:pypi/h5py?source=hash-mapping
   size: 1113137
   timestamp: 1674499084146
+- conda: https://prefix.dev/conda-forge/osx-64/h5py-3.16.0-nompi_py310h05ade02_102.conda
+  sha256: d2b8d17218bc9eb98cf31a23a66542b37c8b3751c5d56d8f07a5d7da285fb2e5
+  md5: 3278edbbb6ecb6453b7de7fdb5eeb210
+  depends:
+  - __osx >=11.0
+  - cached-property
+  - hdf5 >=2.1.0,<3.0a0
+  - numpy >=1.21,<3
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/h5py?source=hash-mapping
+  size: 1106896
+  timestamp: 1775581866927
 - conda: https://prefix.dev/conda-forge/osx-64/h5py-3.16.0-nompi_py310hbc26044_102.conda
   sha256: 33123312e04b901050a31fe4654748b703a0ff8295437cb4d52c6e7a05900bbf
   md5: 75229b8c21fcb2f628081515cc9aae3f
@@ -15901,13 +16169,13 @@ packages:
   - pkg:pypi/h5py?source=hash-mapping
   size: 1102072
   timestamp: 1775581714217
-- conda: https://prefix.dev/conda-forge/osx-64/h5py-3.16.0-nompi_py311h1d8f82b_102.conda
-  sha256: 6dfe128ad22e09ff89d91d579b19fe96c0495027c4cc0d068acfaf25f6512923
-  md5: 4371690b4a0133dfb62d3997b668134d
+- conda: https://prefix.dev/conda-forge/osx-64/h5py-3.16.0-nompi_py311ha7e68cf_102.conda
+  sha256: 0a4c211e80ffec89f568910b87790471319a59d9ab04db8e32b6d22f2eee351a
+  md5: f29ebc1fb2896ab15bf2712cf530e843
   depends:
   - __osx >=11.0
   - cached-property
-  - hdf5 >=1.14.6,<1.14.7.0a0
+  - hdf5 >=2.1.0,<3.0a0
   - numpy >=1.23,<3
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
@@ -15915,15 +16183,15 @@ packages:
   license_family: BSD
   purls:
   - pkg:pypi/h5py?source=hash-mapping
-  size: 1188831
-  timestamp: 1775581786866
-- conda: https://prefix.dev/conda-forge/osx-64/h5py-3.16.0-nompi_py312h53b4df1_102.conda
-  sha256: 632227065f84306b2f5822b22d10ba84fcd6f5b397b2d69a4c36d92e0ca2f31e
-  md5: 626ce477182eeedea956ea6a2c94ef14
+  size: 1196742
+  timestamp: 1775581895921
+- conda: https://prefix.dev/conda-forge/osx-64/h5py-3.16.0-nompi_py312h82c48cf_102.conda
+  sha256: 705c25f8ef6e3795f4add3dd34a0563698b07f5a3d1c6c920d4279a15beb0841
+  md5: 52167ce7748139f6ec29d8aa86e0ec38
   depends:
   - __osx >=11.0
   - cached-property
-  - hdf5 >=1.14.6,<1.14.7.0a0
+  - hdf5 >=2.1.0,<3.0a0
   - numpy >=1.23,<3
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
@@ -15931,15 +16199,15 @@ packages:
   license_family: BSD
   purls:
   - pkg:pypi/h5py?source=hash-mapping
-  size: 1183163
-  timestamp: 1775582252030
-- conda: https://prefix.dev/conda-forge/osx-64/h5py-3.16.0-nompi_py313hd52a848_102.conda
-  sha256: 07dafd7469521223e2de8912abda6e85782e359d4a67d5a169211649f161bb34
-  md5: 279b9853e8b875e3427a6e355e5865ce
+  size: 1188195
+  timestamp: 1775581932391
+- conda: https://prefix.dev/conda-forge/osx-64/h5py-3.16.0-nompi_py313h15f83ed_102.conda
+  sha256: 329d2b25a62ff3a4485b1b9e91f8248e542a773707f5f356e7993e8c0617b40e
+  md5: 5f6dba276231688a2f785babdf95ad1c
   depends:
   - __osx >=11.0
   - cached-property
-  - hdf5 >=1.14.6,<1.14.7.0a0
+  - hdf5 >=2.1.0,<3.0a0
   - numpy >=1.23,<3
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
@@ -15947,8 +16215,8 @@ packages:
   license_family: BSD
   purls:
   - pkg:pypi/h5py?source=hash-mapping
-  size: 1190899
-  timestamp: 1775581596875
+  size: 1197429
+  timestamp: 1775581955479
 - conda: https://prefix.dev/conda-forge/osx-64/h5py-3.16.0-nompi_py314h58ac280_102.conda
   sha256: ed5dbbcfe97862078f8703d28d2dee53985f29ef5629f5dca93a8ed5dddcdbd7
   md5: fce5f9ac23f2f8b9fa16cff36c9f33b0
@@ -15965,22 +16233,6 @@ packages:
   - pkg:pypi/h5py?source=hash-mapping
   size: 1207617
   timestamp: 1775581905623
-- conda: https://prefix.dev/conda-forge/osx-64/h5py-3.16.0-nompi_py314hd1d8aca_102.conda
-  sha256: dc67ac053fb4199fc899650eb323cb35e2f9a49816bb77ccf610066c97df0382
-  md5: 7dc73b286baa99b2abf400421c61626a
-  depends:
-  - __osx >=11.0
-  - cached-property
-  - hdf5 >=1.14.6,<1.14.7.0a0
-  - numpy >=1.23,<3
-  - python >=3.14,<3.15.0a0
-  - python_abi 3.14.* *_cp314
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/h5py?source=hash-mapping
-  size: 1199017
-  timestamp: 1775582052620
 - conda: https://prefix.dev/conda-forge/osx-64/h5py-3.8.0-nompi_py310h5555e59_100.conda
   sha256: 162899e1c1b47f95650bf6eed5f0a9f4e6b5261b1e07460ac39a84d8499b1f26
   md5: 14a3007607e01313e685ac4cc4fee69a
@@ -16013,13 +16265,30 @@ packages:
   - pkg:pypi/h5py?source=hash-mapping
   size: 1103506
   timestamp: 1775581597111
-- conda: https://prefix.dev/conda-forge/osx-arm64/h5py-3.16.0-nompi_py311h6bee198_102.conda
-  sha256: 891c83cb0ce9053bc4a531a6fe0807ab7a609c15139e84376b44160b1d01abc4
-  md5: 7eac2746f03d66c11a656ffaaa344577
+- conda: https://prefix.dev/conda-forge/osx-arm64/h5py-3.16.0-nompi_py310hcf53ec8_102.conda
+  sha256: 52ac401df6ff7b6c55837f00c5f9c836180ec40df8173696eacdc0b6bd62e15e
+  md5: 736594a0045aa58223c24d868062b6f9
   depends:
   - __osx >=11.0
   - cached-property
-  - hdf5 >=1.14.6,<1.14.7.0a0
+  - hdf5 >=2.1.0,<3.0a0
+  - numpy >=1.21,<3
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/h5py?source=hash-mapping
+  size: 1108137
+  timestamp: 1775583257878
+- conda: https://prefix.dev/conda-forge/osx-arm64/h5py-3.16.0-nompi_py311hf10ccac_102.conda
+  sha256: 3d8437c0633c9055228db8d1fa00daceea5137075bdbce4bb0f7747466da0b09
+  md5: 3921ef0b72feb738aa5f4107bb6bb084
+  depends:
+  - __osx >=11.0
+  - cached-property
+  - hdf5 >=2.1.0,<3.0a0
   - numpy >=1.23,<3
   - python >=3.11,<3.12.0a0
   - python >=3.11,<3.12.0a0 *_cpython
@@ -16028,15 +16297,15 @@ packages:
   license_family: BSD
   purls:
   - pkg:pypi/h5py?source=hash-mapping
-  size: 1185630
-  timestamp: 1775582314805
-- conda: https://prefix.dev/conda-forge/osx-arm64/h5py-3.16.0-nompi_py312hdd01ddf_102.conda
-  sha256: 68bf1ed50a983c4eea17bab8cb91e7b2bfd19b92f3846e2a057ab1bb78b5b1cd
-  md5: d6561da751793e9f534b175e070b19d3
+  size: 1193405
+  timestamp: 1775582985212
+- conda: https://prefix.dev/conda-forge/osx-arm64/h5py-3.16.0-nompi_py312h585e8c8_102.conda
+  sha256: 2ac08cff564c3b49f8a7f21eb9abdb81cad2fe2270ed1d48a5be05416d99f40c
+  md5: d5c7d8decb6113045ac8168f66ad1de2
   depends:
   - __osx >=11.0
   - cached-property
-  - hdf5 >=1.14.6,<1.14.7.0a0
+  - hdf5 >=2.1.0,<3.0a0
   - numpy >=1.23,<3
   - python >=3.12,<3.13.0a0
   - python >=3.12,<3.13.0a0 *_cpython
@@ -16045,15 +16314,15 @@ packages:
   license_family: BSD
   purls:
   - pkg:pypi/h5py?source=hash-mapping
-  size: 1180081
-  timestamp: 1775582311942
-- conda: https://prefix.dev/conda-forge/osx-arm64/h5py-3.16.0-nompi_py313hc6ee213_102.conda
-  sha256: ec38d68d23ac769156f7569ca97bf1ab792ffaa952fb976fba1f4be37d35e5b2
-  md5: a2a20614663904c625a76907aa0a394d
+  size: 1186119
+  timestamp: 1775583048662
+- conda: https://prefix.dev/conda-forge/osx-arm64/h5py-3.16.0-nompi_py313h2c4073f_102.conda
+  sha256: 9c36ee2e00a2909cc681cce0d18b944d9fe567e2e222b0b9c2c6e5763ae466a8
+  md5: 2aa4b5b086d03667f7950a6b01719a01
   depends:
   - __osx >=11.0
   - cached-property
-  - hdf5 >=1.14.6,<1.14.7.0a0
+  - hdf5 >=2.1.0,<3.0a0
   - numpy >=1.23,<3
   - python >=3.13,<3.14.0a0
   - python >=3.13,<3.14.0a0 *_cp313
@@ -16062,8 +16331,8 @@ packages:
   license_family: BSD
   purls:
   - pkg:pypi/h5py?source=hash-mapping
-  size: 1193209
-  timestamp: 1775582328126
+  size: 1196073
+  timestamp: 1775583215851
 - conda: https://prefix.dev/conda-forge/osx-arm64/h5py-3.16.0-nompi_py314h658a3ac_102.conda
   sha256: 0762ed080bf45ca475da96796a8883a6c719603c44fa9b07a5883785649a4a0f
   md5: ab9a6c652fd25407c9cf67b9b6b87496
@@ -16081,23 +16350,6 @@ packages:
   - pkg:pypi/h5py?source=hash-mapping
   size: 1203956
   timestamp: 1775583125726
-- conda: https://prefix.dev/conda-forge/osx-arm64/h5py-3.16.0-nompi_py314hb49d8aa_102.conda
-  sha256: 6f27b623cc51dca62a1094d4be5cf53eaffb61f97e6a6f159c780aceedd7b991
-  md5: 89abd846fe2692170eaed00842486ce1
-  depends:
-  - __osx >=11.0
-  - cached-property
-  - hdf5 >=1.14.6,<1.14.7.0a0
-  - numpy >=1.23,<3
-  - python >=3.14,<3.15.0a0
-  - python >=3.14,<3.15.0a0 *_cp314
-  - python_abi 3.14.* *_cp314
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/h5py?source=hash-mapping
-  size: 1200170
-  timestamp: 1775582717308
 - conda: https://prefix.dev/conda-forge/osx-arm64/h5py-3.8.0-nompi_py310h3419284_100.conda
   sha256: 8a5e6c383793871b0aa8c040f4c29aa0b53566b64299a449bdab8fe1a24f7e64
   md5: 4cc453fd3cfb33df546aa00a08435a55
@@ -16114,6 +16366,24 @@ packages:
   - pkg:pypi/h5py?source=hash-mapping
   size: 990075
   timestamp: 1674499661883
+- conda: https://prefix.dev/conda-forge/win-64/h5py-3.16.0-nompi_py310h6359f78_102.conda
+  sha256: 49219e91c11029754b60d972fc4a642da38aa4a23d0d6f894a603141e3393c89
+  md5: f8fc5762c29c355bc08fdccb9056a721
+  depends:
+  - cached-property
+  - hdf5 >=2.1.0,<3.0a0
+  - numpy >=1.21,<3
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/h5py?source=hash-mapping
+  size: 1008813
+  timestamp: 1775581480372
 - conda: https://prefix.dev/conda-forge/win-64/h5py-3.16.0-nompi_py310hb7e4da9_102.conda
   sha256: 0d6f9e2dde8167cd0c579610609e644e2d35f61e9820db6e8728c40dca6b8ab3
   md5: 45271504d1b2880ad7ea541b7d2db85c
@@ -16132,12 +16402,12 @@ packages:
   - pkg:pypi/h5py?source=hash-mapping
   size: 1006603
   timestamp: 1775581487436
-- conda: https://prefix.dev/conda-forge/win-64/h5py-3.16.0-nompi_py311hc40ba4b_102.conda
-  sha256: f29f62574fac417b1d08b4b6109824c58598712673684a0e6aece2e6809253b9
-  md5: 9115b1b05f7fa1b3c53a25f44c0aaafe
+- conda: https://prefix.dev/conda-forge/win-64/h5py-3.16.0-nompi_py311ha643933_102.conda
+  sha256: 4fbbaa9a7e2a76c2bb9c5e57283da819c38b1bcfacf42d44b88b14df96c58e7a
+  md5: f7dbec60ea42ffbf02383600033411d2
   depends:
   - cached-property
-  - hdf5 >=1.14.6,<1.14.7.0a0
+  - hdf5 >=2.1.0,<3.0a0
   - numpy >=1.23,<3
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
@@ -16148,14 +16418,14 @@ packages:
   license_family: BSD
   purls:
   - pkg:pypi/h5py?source=hash-mapping
-  size: 1112107
-  timestamp: 1775581461393
-- conda: https://prefix.dev/conda-forge/win-64/h5py-3.16.0-nompi_py312h03cd2ba_102.conda
-  sha256: aefa6f6882568f800150fe8d83698f4fd1c4ba4b042260d93cf1a503a460141c
-  md5: e00778685f838e9c7e40c8927b0f2a72
+  size: 1118145
+  timestamp: 1775581977376
+- conda: https://prefix.dev/conda-forge/win-64/h5py-3.16.0-nompi_py312h5ddec8c_102.conda
+  sha256: 721837b0a457a399d43a431fb55203f5b0adc640c7ffa453d0aa921f9b61f1c9
+  md5: c1973eb20afef124242b807fd28dea43
   depends:
   - cached-property
-  - hdf5 >=1.14.6,<1.14.7.0a0
+  - hdf5 >=2.1.0,<3.0a0
   - numpy >=1.23,<3
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
@@ -16166,14 +16436,14 @@ packages:
   license_family: BSD
   purls:
   - pkg:pypi/h5py?source=hash-mapping
-  size: 1085071
-  timestamp: 1775581446982
-- conda: https://prefix.dev/conda-forge/win-64/h5py-3.16.0-nompi_py313hf7f959b_102.conda
-  sha256: eb1fa288e76f320d5d190d150e6849e3501478de6ac338cf4b5172f6c95c787f
-  md5: 7175a2e76f26eeff49a60ad16862eecd
+  size: 1087976
+  timestamp: 1775581957329
+- conda: https://prefix.dev/conda-forge/win-64/h5py-3.16.0-nompi_py313hd050a09_102.conda
+  sha256: 5ee4b5608dd1c65b21268627cd590989e4de972ffe2b8e4fe5a93c8c8ed7f54e
+  md5: 9e9b344f00e7fa96311ae54de9370a6e
   depends:
   - cached-property
-  - hdf5 >=1.14.6,<1.14.7.0a0
+  - hdf5 >=2.1.0,<3.0a0
   - numpy >=1.23,<3
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
@@ -16184,8 +16454,8 @@ packages:
   license_family: BSD
   purls:
   - pkg:pypi/h5py?source=hash-mapping
-  size: 1089797
-  timestamp: 1775581429593
+  size: 1094946
+  timestamp: 1775582010212
 - conda: https://prefix.dev/conda-forge/win-64/h5py-3.16.0-nompi_py314h02517ec_102.conda
   sha256: 5ee88f1f691829d2430761a26a690c3d880e7cd41e40a4057131360a8904e0bd
   md5: 19bdd6358ce2be9ef29f92b1564db61d
@@ -16204,24 +16474,6 @@ packages:
   - pkg:pypi/h5py?source=hash-mapping
   size: 1101679
   timestamp: 1775582027560
-- conda: https://prefix.dev/conda-forge/win-64/h5py-3.16.0-nompi_py314hc249e69_102.conda
-  sha256: 34880617136bfe9c3946fe767c1fef470d62b5ecd177410443af7a1e7f0927fb
-  md5: a97e08636b7aa2bb61b820082e8f5e4c
-  depends:
-  - cached-property
-  - hdf5 >=1.14.6,<1.14.7.0a0
-  - numpy >=1.23,<3
-  - python >=3.14,<3.15.0a0
-  - python_abi 3.14.* *_cp314
-  - ucrt >=10.0.20348.0
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/h5py?source=hash-mapping
-  size: 1097161
-  timestamp: 1775581481450
 - conda: https://prefix.dev/conda-forge/win-64/h5py-3.9.0-nompi_py310h727aef9_100.conda
   sha256: e9373ff7ecf3819c6ebf26ca946c76d291dfa06502a202a1fe289353c9e29607
   md5: 1a7b799dba2e313407f8181ad5badcfb
@@ -16644,6 +16896,29 @@ packages:
   - pkg:pypi/hdf5plugin?source=hash-mapping
   size: 4131043
   timestamp: 1674488350584
+- conda: https://prefix.dev/conda-forge/linux-64/hdf5plugin-6.0.0-py310h3812ed8_5.conda
+  sha256: a059c425c7c86a79200b664a570ef36fd51783ad580b3f8258557eb2e7411525
+  md5: 889822ea02a3628dc94227ceab6552f7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - blosc >=1.21.6,<2.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - c-blosc2 >=2.23.1,<2.24.0a0
+  - h5py >=3.0.0
+  - hdf5 >=2.1.0,<3.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libzlib >=1.3.2,<2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - zstd >=1.5.7,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/hdf5plugin?source=hash-mapping
+  size: 3378433
+  timestamp: 1774735893012
 - conda: https://prefix.dev/conda-forge/linux-64/hdf5plugin-6.0.0-py310h69abe24_5.conda
   sha256: d033b2951fbcd8ed91fdea9f4ff6278ab714e899fe418a77f39f716649733815
   md5: 4ee285c2b29de7c5f8174a08f17e3f49
@@ -16667,16 +16942,16 @@ packages:
   - pkg:pypi/hdf5plugin?source=hash-mapping
   size: 3371403
   timestamp: 1774735866908
-- conda: https://prefix.dev/conda-forge/linux-64/hdf5plugin-6.0.0-py311h60fd0ea_5.conda
-  sha256: 5bbb95e68fe40468d1f55df0494c932bc025c662931e6fcdc5956f16ccd94234
-  md5: 25623058b0001eb8d5c5a1398f5c3aac
+- conda: https://prefix.dev/conda-forge/linux-64/hdf5plugin-6.0.0-py311h41e6a36_5.conda
+  sha256: 216bde977c2c65ae437505cd51a71570254d058411ed80e3b866272bfe436ffc
+  md5: fef6e04ec38c22587a7611aee705935c
   depends:
   - __glibc >=2.17,<3.0.a0
   - blosc >=1.21.6,<2.0a0
   - bzip2 >=1.0.8,<2.0a0
   - c-blosc2 >=2.23.1,<2.24.0a0
   - h5py >=3.0.0
-  - hdf5 >=1.14.6,<1.14.7.0a0
+  - hdf5 >=2.1.0,<3.0a0
   - libgcc >=14
   - libstdcxx >=14
   - libzlib >=1.3.2,<2.0a0
@@ -16688,18 +16963,18 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/hdf5plugin?source=hash-mapping
-  size: 3381329
-  timestamp: 1774735879495
-- conda: https://prefix.dev/conda-forge/linux-64/hdf5plugin-6.0.0-py312hb944afc_5.conda
-  sha256: 370b40cd0d9828b1bdbabf48914fddfa4f12d77989dde6b19d713aaeaf01b151
-  md5: 9be9b0729097a41cf06f1b3384f3e5e1
+  size: 3387285
+  timestamp: 1774735881168
+- conda: https://prefix.dev/conda-forge/linux-64/hdf5plugin-6.0.0-py312h645ab66_5.conda
+  sha256: 70acb2afdd64426ace27c4336b123ed78c3bd778f6c50fd1f5ef16589a2bb9bc
+  md5: f53f4c4d971c430ae7bab9df2d9a0e19
   depends:
   - __glibc >=2.17,<3.0.a0
   - blosc >=1.21.6,<2.0a0
   - bzip2 >=1.0.8,<2.0a0
   - c-blosc2 >=2.23.1,<2.24.0a0
   - h5py >=3.0.0
-  - hdf5 >=1.14.6,<1.14.7.0a0
+  - hdf5 >=2.1.0,<3.0a0
   - libgcc >=14
   - libstdcxx >=14
   - libzlib >=1.3.2,<2.0a0
@@ -16711,18 +16986,18 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/hdf5plugin?source=hash-mapping
-  size: 3387264
-  timestamp: 1774735874937
-- conda: https://prefix.dev/conda-forge/linux-64/hdf5plugin-6.0.0-py313h3437735_5.conda
-  sha256: b31c26bb87b1690d0aa8e9d26fb3beb8433d0426401ab672151acc714ed00995
-  md5: af1e03fc271d8a810fc6acd24e0210ef
+  size: 3385468
+  timestamp: 1774735885169
+- conda: https://prefix.dev/conda-forge/linux-64/hdf5plugin-6.0.0-py313hdbdd960_5.conda
+  sha256: 761419953e0d6f8c1b4350fec925da3d0ae9d8912510532375d02eebc5d35b6d
+  md5: 4da834a5990833e8f2adc4cade759f71
   depends:
   - __glibc >=2.17,<3.0.a0
   - blosc >=1.21.6,<2.0a0
   - bzip2 >=1.0.8,<2.0a0
   - c-blosc2 >=2.23.1,<2.24.0a0
   - h5py >=3.0.0
-  - hdf5 >=1.14.6,<1.14.7.0a0
+  - hdf5 >=2.1.0,<3.0a0
   - libgcc >=14
   - libstdcxx >=14
   - libzlib >=1.3.2,<2.0a0
@@ -16734,31 +17009,8 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/hdf5plugin?source=hash-mapping
-  size: 3378731
-  timestamp: 1774735875205
-- conda: https://prefix.dev/conda-forge/linux-64/hdf5plugin-6.0.0-py314h068620f_5.conda
-  sha256: ce9198f594eca9358b508c3a81cc2f6f363e53d744a43e05befcd546a904526f
-  md5: efa6111c2d702275b785f318e117818b
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - blosc >=1.21.6,<2.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - c-blosc2 >=2.23.1,<2.24.0a0
-  - h5py >=3.0.0
-  - hdf5 >=1.14.6,<1.14.7.0a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libzlib >=1.3.2,<2.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - python >=3.14,<3.15.0a0
-  - python_abi 3.14.* *_cp314
-  - zstd >=1.5.7,<1.6.0a0
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/hdf5plugin?source=hash-mapping
-  size: 3383861
-  timestamp: 1774735891032
+  size: 3378570
+  timestamp: 1774735883244
 - conda: https://prefix.dev/conda-forge/linux-64/hdf5plugin-6.0.0-py314h3f9f1dd_5.conda
   sha256: 693d84bba1e0f6c55d47ffc80bdf50352933df7692a39bb5ca2c6d91cc3e7ad1
   md5: ff2992a94ae740b1d59208645875a05b
@@ -16822,15 +17074,38 @@ packages:
   - pkg:pypi/hdf5plugin?source=hash-mapping
   size: 3240142
   timestamp: 1774735932844
-- conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5plugin-6.0.0-py311hf6bb6b3_5.conda
-  sha256: e8e441856f549d1b7f7b602fa8d5b9ce4b24b2ab92cf2d901df43c564a2375c8
-  md5: 7016e9d85f8c3ad832a7c2a51eb19fd0
+- conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5plugin-6.0.0-py310hf20988d_5.conda
+  sha256: 74aa3b077cf4aa50741afa435e16792f8224021445fdaa998ec6c2ee02191d89
+  md5: 7c57446302086cdc8b85681ad8bd5f22
   depends:
   - blosc >=1.21.6,<2.0a0
   - bzip2 >=1.0.8,<2.0a0
   - c-blosc2 >=2.23.1,<2.24.0a0
   - h5py >=3.0.0
-  - hdf5 >=1.14.6,<1.14.7.0a0
+  - hdf5 >=2.1.0,<3.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libzlib >=1.3.2,<2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  - zstd >=1.5.7,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/hdf5plugin?source=hash-mapping
+  size: 3246203
+  timestamp: 1774735947725
+- conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5plugin-6.0.0-py311h59c577c_5.conda
+  sha256: f5fdb5b0bc41223dc343d3003e8cc3c601d5fd4c9dff2508bb8b014edff290cb
+  md5: cb7f8e27cb2bc17b20fd66dc5c6667be
+  depends:
+  - blosc >=1.21.6,<2.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - c-blosc2 >=2.23.1,<2.24.0a0
+  - h5py >=3.0.0
+  - hdf5 >=2.1.0,<3.0a0
   - libgcc >=14
   - libstdcxx >=14
   - libzlib >=1.3.2,<2.0a0
@@ -16843,17 +17118,17 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/hdf5plugin?source=hash-mapping
-  size: 3257371
-  timestamp: 1774735917138
-- conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5plugin-6.0.0-py312h67d4751_5.conda
-  sha256: 88d5992e645e2ec18c903bed4d686749eba89100dd14731ab6adb7aca099ac38
-  md5: ee10f76d9433f69d176a0f4cda43d883
+  size: 3253273
+  timestamp: 1774735922488
+- conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5plugin-6.0.0-py312hf8637db_5.conda
+  sha256: 61ac683342c1e237743d8d7748593a6a3a430f99cf54d336bd53e5f02d52efd1
+  md5: f820bc8c357358d376905cf678a1e65e
   depends:
   - blosc >=1.21.6,<2.0a0
   - bzip2 >=1.0.8,<2.0a0
   - c-blosc2 >=2.23.1,<2.24.0a0
   - h5py >=3.0.0
-  - hdf5 >=1.14.6,<1.14.7.0a0
+  - hdf5 >=2.1.0,<3.0a0
   - libgcc >=14
   - libstdcxx >=14
   - libzlib >=1.3.2,<2.0a0
@@ -16866,17 +17141,17 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/hdf5plugin?source=hash-mapping
-  size: 3243709
-  timestamp: 1774735936858
-- conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5plugin-6.0.0-py313h59f7827_5.conda
-  sha256: e3c9adde6718da757a45302f5357095ccf6c79e779303d9d22114855b1c390bf
-  md5: 0212a616ca06b885459bcb24adad43bb
+  size: 3252445
+  timestamp: 1774735917658
+- conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5plugin-6.0.0-py313h900b84a_5.conda
+  sha256: f142c1cf984b297100770952a79d7987d3ed2b97f4e4afa772ea1b90e8c8a34d
+  md5: b847d8589654719309462ab253af68d9
   depends:
   - blosc >=1.21.6,<2.0a0
   - bzip2 >=1.0.8,<2.0a0
   - c-blosc2 >=2.23.1,<2.24.0a0
   - h5py >=3.0.0
-  - hdf5 >=1.14.6,<1.14.7.0a0
+  - hdf5 >=2.1.0,<3.0a0
   - libgcc >=14
   - libstdcxx >=14
   - libzlib >=1.3.2,<2.0a0
@@ -16889,8 +17164,8 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/hdf5plugin?source=hash-mapping
-  size: 3250034
-  timestamp: 1774735925492
+  size: 3255044
+  timestamp: 1774735899490
 - conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5plugin-6.0.0-py314ha8685b7_5.conda
   sha256: a19757b65d85bd4094326d8b940c0e0bd5944f29b52c7d7532da08b9090e45dc
   md5: 1b38481942c0e1e410b13bc031f104a1
@@ -16914,29 +17189,6 @@ packages:
   - pkg:pypi/hdf5plugin?source=hash-mapping
   size: 3261871
   timestamp: 1774735929635
-- conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5plugin-6.0.0-py314hc4425fe_5.conda
-  sha256: ca52afa0874c801276340f58573517592f1e6029733dd76a52b71346ac5abe70
-  md5: f581d9503be628d02a158c27bc0c127a
-  depends:
-  - blosc >=1.21.6,<2.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - c-blosc2 >=2.23.1,<2.24.0a0
-  - h5py >=3.0.0
-  - hdf5 >=1.14.6,<1.14.7.0a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libzlib >=1.3.2,<2.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - python >=3.14,<3.15.0a0
-  - python >=3.14,<3.15.0a0 *_cp314
-  - python_abi 3.14.* *_cp314
-  - zstd >=1.5.7,<1.6.0a0
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/hdf5plugin?source=hash-mapping
-  size: 3257610
-  timestamp: 1774735948190
 - conda: https://prefix.dev/conda-forge/osx-64/hdf5plugin-4.1.1-py310h5099a21_0.conda
   sha256: 5d420f6ac5ac139d4eb8c2d48021ffdab2f8ed5f79ee49a9fe117dd85586e31b
   md5: 8a45468a15ecede4dc492e1fa4b56bfd
@@ -16974,16 +17226,38 @@ packages:
   - pkg:pypi/hdf5plugin?source=hash-mapping
   size: 2955582
   timestamp: 1774736256208
-- conda: https://prefix.dev/conda-forge/osx-64/hdf5plugin-6.0.0-py311hd6207b9_5.conda
-  sha256: acdcae7b25ad41a4401f52d790d14cf5088d8b6e572f4980e6adfddf89b89e85
-  md5: 567f61041ba7108533d140b2a597e9f6
+- conda: https://prefix.dev/conda-forge/osx-64/hdf5plugin-6.0.0-py310he652b7c_5.conda
+  sha256: 57abb2244a4a3e3a870fa5728075bf83951e3aec8ba007e9bc7c4cf4d5137ff8
+  md5: 8cb863b65f137696c75b7969d34f2798
   depends:
   - __osx >=11.0
   - blosc >=1.21.6,<2.0a0
   - bzip2 >=1.0.8,<2.0a0
   - c-blosc2 >=2.23.1,<2.24.0a0
   - h5py >=3.0.0
-  - hdf5 >=1.14.6,<1.14.7.0a0
+  - hdf5 >=2.1.0,<3.0a0
+  - libcxx >=19
+  - libzlib >=1.3.2,<2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - zstd >=1.5.7,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/hdf5plugin?source=hash-mapping
+  size: 2962872
+  timestamp: 1774736354781
+- conda: https://prefix.dev/conda-forge/osx-64/hdf5plugin-6.0.0-py311h6dfbe9f_5.conda
+  sha256: 27659e952fd677f1eb8e996668a564b4fcea58a8d34a4336868e43909f892ea0
+  md5: 0c6c9e896568c513e86650a4d6ea95ad
+  depends:
+  - __osx >=11.0
+  - blosc >=1.21.6,<2.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - c-blosc2 >=2.23.1,<2.24.0a0
+  - h5py >=3.0.0
+  - hdf5 >=2.1.0,<3.0a0
   - libcxx >=19
   - libzlib >=1.3.2,<2.0a0
   - lz4-c >=1.10.0,<1.11.0a0
@@ -16994,18 +17268,18 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/hdf5plugin?source=hash-mapping
-  size: 2966848
-  timestamp: 1774736197971
-- conda: https://prefix.dev/conda-forge/osx-64/hdf5plugin-6.0.0-py312h667c79f_5.conda
-  sha256: 3f4d83a764ab3f865887700bb5c7d8aa28d33509a8d700908ac22339ea7d939b
-  md5: 9f642d7da4e28ebcbe007022c37fef43
+  size: 2970692
+  timestamp: 1774736229685
+- conda: https://prefix.dev/conda-forge/osx-64/hdf5plugin-6.0.0-py312ha60f365_5.conda
+  sha256: 7139d2eeee69d6ced86da6684f1b1e47b4e3e6ed94d26c8c30e2a86a3c1e2920
+  md5: 7f09a94fedbed423ec49a7e5222bd6bc
   depends:
   - __osx >=11.0
   - blosc >=1.21.6,<2.0a0
   - bzip2 >=1.0.8,<2.0a0
   - c-blosc2 >=2.23.1,<2.24.0a0
   - h5py >=3.0.0
-  - hdf5 >=1.14.6,<1.14.7.0a0
+  - hdf5 >=2.1.0,<3.0a0
   - libcxx >=19
   - libzlib >=1.3.2,<2.0a0
   - lz4-c >=1.10.0,<1.11.0a0
@@ -17016,18 +17290,18 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/hdf5plugin?source=hash-mapping
-  size: 2962686
-  timestamp: 1774736218793
-- conda: https://prefix.dev/conda-forge/osx-64/hdf5plugin-6.0.0-py313ha1ae2fd_5.conda
-  sha256: 41b7efffebf5f0b42295468dd4d72fb784038b898985691ca9824987d7c9ab7f
-  md5: 90be662a00167730260aa11bc0b7195a
+  size: 2970117
+  timestamp: 1774736936489
+- conda: https://prefix.dev/conda-forge/osx-64/hdf5plugin-6.0.0-py313hfdb907d_5.conda
+  sha256: c8032a12c65edb807fc208336ba63db164a978bc352d76dd775137ef8f1faa7f
+  md5: 99a6c608588689c960059dafc5f4f41f
   depends:
   - __osx >=11.0
   - blosc >=1.21.6,<2.0a0
   - bzip2 >=1.0.8,<2.0a0
   - c-blosc2 >=2.23.1,<2.24.0a0
   - h5py >=3.0.0
-  - hdf5 >=1.14.6,<1.14.7.0a0
+  - hdf5 >=2.1.0,<3.0a0
   - libcxx >=19
   - libzlib >=1.3.2,<2.0a0
   - lz4-c >=1.10.0,<1.11.0a0
@@ -17038,8 +17312,8 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/hdf5plugin?source=hash-mapping
-  size: 2965108
-  timestamp: 1774736438203
+  size: 2964099
+  timestamp: 1774736268133
 - conda: https://prefix.dev/conda-forge/osx-64/hdf5plugin-6.0.0-py314h787f6f2_5.conda
   sha256: fc1bada22b08991842ea56bd2375c60f88bad67861e0a7d4ad01223949bcac2f
   md5: 2dd48c4a3cadbd71685b8dc7a232c9ae
@@ -17062,28 +17336,6 @@ packages:
   - pkg:pypi/hdf5plugin?source=hash-mapping
   size: 2970698
   timestamp: 1774736421463
-- conda: https://prefix.dev/conda-forge/osx-64/hdf5plugin-6.0.0-py314hed58d6d_5.conda
-  sha256: 96cd4ed3099dde970b781f55f83a0ee38f5fb9fb7092cfcc84bdf5ad008022a4
-  md5: 08d58a64b0a61ae834fc9f2436804d7e
-  depends:
-  - __osx >=11.0
-  - blosc >=1.21.6,<2.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - c-blosc2 >=2.23.1,<2.24.0a0
-  - h5py >=3.0.0
-  - hdf5 >=1.14.6,<1.14.7.0a0
-  - libcxx >=19
-  - libzlib >=1.3.2,<2.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - python >=3.14,<3.15.0a0
-  - python_abi 3.14.* *_cp314
-  - zstd >=1.5.7,<1.6.0a0
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/hdf5plugin?source=hash-mapping
-  size: 2970803
-  timestamp: 1774736520433
 - conda: https://prefix.dev/conda-forge/osx-arm64/hdf5plugin-4.1.1-py310h11aeb80_0.conda
   sha256: cd2c2378a5ef6b38419825427f322a546386118f413bbb2f8829495b463f95a5
   md5: 4b2dd7adf6b0425a47734e3a866901ad
@@ -17100,6 +17352,29 @@ packages:
   - pkg:pypi/hdf5plugin?source=hash-mapping
   size: 3048224
   timestamp: 1674488976298
+- conda: https://prefix.dev/conda-forge/osx-arm64/hdf5plugin-6.0.0-py310h3eaa12b_5.conda
+  sha256: c26aaf3571a05850dae4dc426d6658cb537a40cd0902e7f677bc4c12c15acf2a
+  md5: f196ea894f5d5f820d9dc5df66670830
+  depends:
+  - __osx >=11.0
+  - blosc >=1.21.6,<2.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - c-blosc2 >=2.23.1,<2.24.0a0
+  - h5py >=3.0.0
+  - hdf5 >=2.1.0,<3.0a0
+  - libcxx >=19
+  - libzlib >=1.3.2,<2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  - zstd >=1.5.7,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/hdf5plugin?source=hash-mapping
+  size: 2783425
+  timestamp: 1774736278601
 - conda: https://prefix.dev/conda-forge/osx-arm64/hdf5plugin-6.0.0-py310h529efbb_5.conda
   sha256: f7dd4877d269d126156f1d50761a47cb99df7f6514a68d829bcabbd5e6c41302
   md5: 864b9a9243597832e9c77452d93eb2fc
@@ -17123,16 +17398,16 @@ packages:
   - pkg:pypi/hdf5plugin?source=hash-mapping
   size: 2775532
   timestamp: 1774736579540
-- conda: https://prefix.dev/conda-forge/osx-arm64/hdf5plugin-6.0.0-py311h0ea10f0_5.conda
-  sha256: 272898097e634d0d9020fd09ab74da2610585a7f2a0ff4daed6dd443262a5495
-  md5: c3b9eb3b34eb252d0a9276ba6c540983
+- conda: https://prefix.dev/conda-forge/osx-arm64/hdf5plugin-6.0.0-py311h554bcfb_5.conda
+  sha256: ee89a659c4e8895a024c92dbd4a4fbfd69868a19c7bfd1b07def867bd5f23fea
+  md5: 7180f4eaf30feb54dec880e8eacd0cff
   depends:
   - __osx >=11.0
   - blosc >=1.21.6,<2.0a0
   - bzip2 >=1.0.8,<2.0a0
   - c-blosc2 >=2.23.1,<2.24.0a0
   - h5py >=3.0.0
-  - hdf5 >=1.14.6,<1.14.7.0a0
+  - hdf5 >=2.1.0,<3.0a0
   - libcxx >=19
   - libzlib >=1.3.2,<2.0a0
   - lz4-c >=1.10.0,<1.11.0a0
@@ -17144,18 +17419,18 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/hdf5plugin?source=hash-mapping
-  size: 2784472
-  timestamp: 1774736333457
-- conda: https://prefix.dev/conda-forge/osx-arm64/hdf5plugin-6.0.0-py312h92c404d_5.conda
-  sha256: bfa30c3a65c96ee450505a9c726030c893c010106deff919f476b5a6c5111640
-  md5: d1e97cb99409cfe8a95fbb2c130cb694
+  size: 2794798
+  timestamp: 1774736410030
+- conda: https://prefix.dev/conda-forge/osx-arm64/hdf5plugin-6.0.0-py312h49adf7b_5.conda
+  sha256: eb59b53b597572fee0e140afec314169aed68b50a7e5a95b4680bde35eabab2f
+  md5: fd7e4ecaf9d4dba0cdf0b8178ad84889
   depends:
   - __osx >=11.0
   - blosc >=1.21.6,<2.0a0
   - bzip2 >=1.0.8,<2.0a0
   - c-blosc2 >=2.23.1,<2.24.0a0
   - h5py >=3.0.0
-  - hdf5 >=1.14.6,<1.14.7.0a0
+  - hdf5 >=2.1.0,<3.0a0
   - libcxx >=19
   - libzlib >=1.3.2,<2.0a0
   - lz4-c >=1.10.0,<1.11.0a0
@@ -17167,18 +17442,18 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/hdf5plugin?source=hash-mapping
-  size: 2782876
-  timestamp: 1774736424692
-- conda: https://prefix.dev/conda-forge/osx-arm64/hdf5plugin-6.0.0-py313hb22e04b_5.conda
-  sha256: 447b167e99bc44bcfb83608044bc52e7eb69767d8ef295117989ea054c092ae1
-  md5: b968ce9b630c62584d23e02cf54e8948
+  size: 2793564
+  timestamp: 1774736358459
+- conda: https://prefix.dev/conda-forge/osx-arm64/hdf5plugin-6.0.0-py313h9c23d4e_5.conda
+  sha256: 9408b35e05e63fc95a8aaee51ddaa840841313405f2a3f69f26128c602450377
+  md5: 6337e197bf633a1c9fd30ff14aba259e
   depends:
   - __osx >=11.0
   - blosc >=1.21.6,<2.0a0
   - bzip2 >=1.0.8,<2.0a0
   - c-blosc2 >=2.23.1,<2.24.0a0
   - h5py >=3.0.0
-  - hdf5 >=1.14.6,<1.14.7.0a0
+  - hdf5 >=2.1.0,<3.0a0
   - libcxx >=19
   - libzlib >=1.3.2,<2.0a0
   - lz4-c >=1.10.0,<1.11.0a0
@@ -17190,8 +17465,8 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/hdf5plugin?source=hash-mapping
-  size: 2787589
-  timestamp: 1774736604837
+  size: 2792356
+  timestamp: 1774736545418
 - conda: https://prefix.dev/conda-forge/osx-arm64/hdf5plugin-6.0.0-py314h02eda3a_5.conda
   sha256: 4d6fa278b49cac1ee32c376d5f5db7c0ea91212f0de56e54854e9f48cf815fb2
   md5: bc5e120926b518c45e9bd74bdf29864b
@@ -17215,29 +17490,6 @@ packages:
   - pkg:pypi/hdf5plugin?source=hash-mapping
   size: 2789987
   timestamp: 1774736284862
-- conda: https://prefix.dev/conda-forge/osx-arm64/hdf5plugin-6.0.0-py314hbe0a16a_5.conda
-  sha256: f2824bd723b44fe957d8b586f6d020582726e9ca3115f1c5f8ff642e86e05ac9
-  md5: ecc6085d5239231a96a42ea2026dc99b
-  depends:
-  - __osx >=11.0
-  - blosc >=1.21.6,<2.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - c-blosc2 >=2.23.1,<2.24.0a0
-  - h5py >=3.0.0
-  - hdf5 >=1.14.6,<1.14.7.0a0
-  - libcxx >=19
-  - libzlib >=1.3.2,<2.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - python >=3.14,<3.15.0a0
-  - python >=3.14,<3.15.0a0 *_cp314
-  - python_abi 3.14.* *_cp314
-  - zstd >=1.5.7,<1.6.0a0
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/hdf5plugin?source=hash-mapping
-  size: 2788523
-  timestamp: 1774736255348
 - conda: https://prefix.dev/conda-forge/win-64/hdf5plugin-6.0.0-py310haedb6d2_5.conda
   sha256: 6f316b28f44a22cdf5208e717a0e7a6116dcab860230144d84eab81e958d229a
   md5: 4903fb928d69263dc7e905f88d1e9842
@@ -17261,15 +17513,38 @@ packages:
   - pkg:pypi/hdf5plugin?source=hash-mapping
   size: 1769445
   timestamp: 1774735992743
-- conda: https://prefix.dev/conda-forge/win-64/hdf5plugin-6.0.0-py311h25c9a92_5.conda
-  sha256: b2daa4daedab114df507fe5566bcf42b3228e9dc494fa84c70d200ddfaa7c3b9
-  md5: 6925aa8116a13e39038bae1ffb31f35a
+- conda: https://prefix.dev/conda-forge/win-64/hdf5plugin-6.0.0-py310hefaf402_5.conda
+  sha256: 456cbe00327c3b157c84153a3a50ade0f08264494703a2d2bedb87c7a4b5aa5b
+  md5: 3d599bec2fde0619fbce22304491f9f6
   depends:
   - blosc >=1.21.6,<2.0a0
   - bzip2 >=1.0.8,<2.0a0
   - c-blosc2 >=2.23.1,<2.24.0a0
   - h5py >=3.0.0
-  - hdf5 >=1.14.6,<1.14.7.0a0
+  - hdf5 >=2.1.0,<3.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - zstd >=1.5.7,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/hdf5plugin?source=hash-mapping
+  size: 1770919
+  timestamp: 1774736011938
+- conda: https://prefix.dev/conda-forge/win-64/hdf5plugin-6.0.0-py311h727873e_5.conda
+  sha256: d2f77d9f33152691355d0cab25702aae656f97215a12cc5c4533e04bcaf7558e
+  md5: 394b8846467ea09cccf370db07f4b104
+  depends:
+  - blosc >=1.21.6,<2.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - c-blosc2 >=2.23.1,<2.24.0a0
+  - h5py >=3.0.0
+  - hdf5 >=2.1.0,<3.0a0
   - libzlib >=1.3.2,<2.0a0
   - lz4-c >=1.10.0,<1.11.0a0
   - python >=3.11,<3.12.0a0
@@ -17282,17 +17557,17 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/hdf5plugin?source=hash-mapping
-  size: 1781301
-  timestamp: 1774736032464
-- conda: https://prefix.dev/conda-forge/win-64/hdf5plugin-6.0.0-py312h63f2bdf_5.conda
-  sha256: dadc0b6a7f4ece52cd4c7c6277f3422b37440c7d359f945e6f9dba4935171643
-  md5: 5e7d795e72adcb304f56f3ae69bc2279
+  size: 1780960
+  timestamp: 1774736023420
+- conda: https://prefix.dev/conda-forge/win-64/hdf5plugin-6.0.0-py312hee59bae_5.conda
+  sha256: 54454669c33bd293e3cefd490fa33d37ad5cfc1fb6a4ac22393aabfaaf26c3ce
+  md5: e18739987b1ea507bbda1c308252335b
   depends:
   - blosc >=1.21.6,<2.0a0
   - bzip2 >=1.0.8,<2.0a0
   - c-blosc2 >=2.23.1,<2.24.0a0
   - h5py >=3.0.0
-  - hdf5 >=1.14.6,<1.14.7.0a0
+  - hdf5 >=2.1.0,<3.0a0
   - libzlib >=1.3.2,<2.0a0
   - lz4-c >=1.10.0,<1.11.0a0
   - python >=3.12,<3.13.0a0
@@ -17305,17 +17580,17 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/hdf5plugin?source=hash-mapping
-  size: 1776700
-  timestamp: 1774735985676
-- conda: https://prefix.dev/conda-forge/win-64/hdf5plugin-6.0.0-py313h1e823ac_5.conda
-  sha256: 8f878b4471fc83c41ae3b68889041ff081b9c623b77a6274ca6dd4e7c205620d
-  md5: 55429352ad3d749d46d90cb9496e4ba3
+  size: 1777243
+  timestamp: 1774736012567
+- conda: https://prefix.dev/conda-forge/win-64/hdf5plugin-6.0.0-py313h480876f_5.conda
+  sha256: 7fe449fc1df116d10ae2e249f46284f86112284a1a4513a3a1e578c805ca5e92
+  md5: 1da9a591f7b1edd818b2c0e83e2f69b0
   depends:
   - blosc >=1.21.6,<2.0a0
   - bzip2 >=1.0.8,<2.0a0
   - c-blosc2 >=2.23.1,<2.24.0a0
   - h5py >=3.0.0
-  - hdf5 >=1.14.6,<1.14.7.0a0
+  - hdf5 >=2.1.0,<3.0a0
   - libzlib >=1.3.2,<2.0a0
   - lz4-c >=1.10.0,<1.11.0a0
   - python >=3.13,<3.14.0a0
@@ -17328,8 +17603,8 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/hdf5plugin?source=hash-mapping
-  size: 1781427
-  timestamp: 1774736011157
+  size: 1779501
+  timestamp: 1774736020848
 - conda: https://prefix.dev/conda-forge/win-64/hdf5plugin-6.0.0-py314h79e82e5_5.conda
   sha256: f2b0f783f0ed9dee0e4a564380d4e29e5e7e34f6b6dd8dc98ae8a6dfef2fc633
   md5: 0496cbb79316a7235018d7b914cfd5e7
@@ -17353,29 +17628,6 @@ packages:
   - pkg:pypi/hdf5plugin?source=hash-mapping
   size: 1782056
   timestamp: 1774736001151
-- conda: https://prefix.dev/conda-forge/win-64/hdf5plugin-6.0.0-py314he70fd34_5.conda
-  sha256: 40a28a05729944580c28688ef4b0318c14641b65ac6684e5a9cbbaffba29d394
-  md5: e772bf037417a944b56957cfeb9f1934
-  depends:
-  - blosc >=1.21.6,<2.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - c-blosc2 >=2.23.1,<2.24.0a0
-  - h5py >=3.0.0
-  - hdf5 >=1.14.6,<1.14.7.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - python >=3.14,<3.15.0a0
-  - python_abi 3.14.* *_cp314
-  - ucrt >=10.0.20348.0
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  - zstd >=1.5.7,<1.6.0a0
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/hdf5plugin?source=hash-mapping
-  size: 1781015
-  timestamp: 1774735998720
 - conda: https://prefix.dev/conda-forge/linux-64/hicolor-icon-theme-0.17-ha770c72_3.conda
   sha256: 6d7e6e1286cb521059fe69696705100a03b006efb914ffe82a2ae97ecbae66b7
   md5: 129e404c5b001f3ef5581316971e3ea0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -278,7 +278,7 @@ llvm-tools = "=14"
 
 [tool.pixi.feature.hdf5-112]
 # hdf5 1.12.2 is the minimum version supported by h5py binaries in conda-forge.
-# On Windows it shows double-linking issues at runtime
+# On Windows it shows double-linking issues at runtime.
 platforms = ["linux-64", "linux-aarch64", "osx-64", "osx-arm64"]
 
 [tool.pixi.feature.hdf5-112.dependencies]
@@ -286,16 +286,8 @@ numpy = "=1.24.4" # Old versions of h5py trigger DeprecationWarning in newer Num
 h5py = "=3.8.0"
 hdf5 = "=1.12.2"
 
-[tool.pixi.feature.hdf5-21.dependencies]
-hdf5 = "=2.1"
-ndindex = "*"
-numpy = "*"
-
-[tool.pixi.feature.hdf5-21.pypi-dependencies]
-h5py = "*"
-
-[tool.pixi.feature.hdf5-21.pypi-options]
-no-binary = ["h5py"]
+[tool.pixi.feature.hdf5-114.dependencies]
+hdf5 = "=1.14"
 
 [tool.pixi.feature.np126.dependencies]
 numpy = "=1.26"
@@ -387,7 +379,7 @@ docs = { features = ["py314", "build", "docs"] }
 lint = { features = ["lint"], no-default-feature = true }
 mindeps = { features = ["py310", "mindeps", "build", "test", "bench"], no-default-feature = true }
 hdf5-112 = { features = ["py310", "hdf5-112", "build", "test", "filters"] }
-hdf5-21 = { features = ["py314", "hdf5-21", "build", "test", "bench"], no-default-feature = true }
+hdf5-114 = { features = ["py310", "hdf5-114", "build", "test", "filters"] }
 np126 = { features = ["py310", "np126", "build", "test", "filters"] }
 np200 = { features = ["py310", "np200", "build", "test", "filters"] }
 py310 = { features = ["py310", "build", "test", "filters"] }


### PR DESCRIPTION
Upstream conda-forge packages for hdf5 3.16 now exist for both hdf5=1.14 and hdf5=2.1.

Upgrade test matrix to adapt:
- remove environment  `hdf5-21` with pinned hdf5=2.1
- add environment `hdf5-114` with pinned hdf5=1.14
- environments `mindeps` and `hdf5-112` are unchanged
- all other environments automatically upgrade to hdf5 2.1 after `pixi update`
