### PR TITLE
Fix outstanding security issues with GH workflows

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,5 +1,6 @@
 name: Benchmarks
 on: [push, pull_request]
+permissions: {}
 jobs:
   benchmarks:
     runs-on: ubuntu-latest
@@ -11,13 +12,14 @@ jobs:
         env: ["mindeps", "bench"]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           # get correct version from setuptools_scm
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
-      - uses: prefix-dev/setup-pixi@v0
+      - uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0
         with:
           pixi-version: v0.67.2
           cache: true
@@ -36,7 +38,7 @@ jobs:
         run: pixi r -e ${{ matrix.env }} asv-run
 
       - name: Upload asv results
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: asv-results-${{ matrix.env }}
           path: .asv/results

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,18 +2,20 @@ name: Build docs
 on:
   pull_request:
   workflow_dispatch:
+permissions: {}
 
 jobs:
   build-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           # get correct version from setuptools_scm
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
-      - uses: prefix-dev/setup-pixi@v0
+      - uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0
         with:
           pixi-version: v0.67.2
           cache: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,13 +1,16 @@
 name: Linting
 
 on: [push, pull_request]
+permissions: {}
 
 jobs:
   linting:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: prefix-dev/setup-pixi@v0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0
         with:
           pixi-version: v0.67.2
           cache: true

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -7,11 +7,7 @@ on:
     types: [published]
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: write
-  pages: write
-  id-token: write
+permissions: {}
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # Cancel in-progress deployment jobs so only the latest one succeeds.
@@ -20,20 +16,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-and-deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+  build:
     runs-on: ubuntu-latest
     steps:
       # Always checkout master branch, even if triggered by a tag.
       # Otherwise sphinx-multiversion does not pull the master branch.
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: master
           fetch-tags: true # needed by sphinx-multiversion
+          persist-credentials: false
 
-      - uses: prefix-dev/setup-pixi@v0
+      - uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0
         with:
           pixi-version: v0.67.2
           cache: true
@@ -46,13 +40,22 @@ jobs:
         run: pixi r -e docs docs-multiversion
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: "docs/_build-multiversion/html"
 
-      - name: Deploy to GitHub Pages
+  deploy:
+    needs: build
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
         id: deployment
-        uses: actions/deploy-pages@v4

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -1,5 +1,7 @@
 name: Release Python Bindings to PyPI
 
+permissions: {}
+
 on:
   release:
     types: [published]
@@ -17,13 +19,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 💻 Checkout the repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           # get correct version from setuptools_scm
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
-      - uses: prefix-dev/setup-pixi@v0
+      - uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0
         with:
           pixi-version: v0.67.2
           cache: true
@@ -36,7 +39,7 @@ jobs:
         run: pixi r -e py314 twine-check
 
       - name: Upload sdist
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: sdist
           path: ./dist/*.tar.gz
@@ -83,7 +86,7 @@ jobs:
       id-token: write
     steps:
       - name: Retrieve wheels and sdist
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
         with:
           merge-multiple: true
           path: wheels/
@@ -92,14 +95,14 @@ jobs:
         run: ls -l wheels/
 
       - name: 🧪 Publish to PyPI Testing
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         if: ${{ inputs.test_pypi }}
         with:
           repository-url: https://test.pypi.org/legacy/
           packages-dir: wheels
 
       - name: 🎉 Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         if: ${{ !inputs.test_pypi }}
         with:
           packages-dir: wheels

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,6 @@
 name: Tests
 on: [push, pull_request]
+permissions: {}
 jobs:
   tests:
     runs-on: ${{ matrix.os }}
@@ -44,13 +45,14 @@ jobs:
 
       fail-fast: false
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           # get correct version from setuptools_scm
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
-      - uses: prefix-dev/setup-pixi@v0
+      - uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0
         with:
           pixi-version: v0.67.2
           cache: true

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -12,6 +12,7 @@ on:
       arch:
         required: true
         type: string
+permissions: {}
 
 env:
   H5PY_VERSION: "3.16.0"
@@ -22,13 +23,14 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0 # get the non-merge commit for PRs
           fetch-tags: true # include tags to get correct version from setuptools_scm
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: 3.12
 
@@ -66,7 +68,7 @@ jobs:
       # Windows environment setup
       - name: choco install dependencies (Windows)
         if: runner.os == 'Windows'
-        uses: crazy-max/ghaction-chocolatey@v4
+        uses: crazy-max/ghaction-chocolatey@dff3862348493b11fba2fbc49147b6d2dfe09b66 # v4
         with:
           args: install pkgconfiglite llvm
 
@@ -78,10 +80,13 @@ jobs:
 
       # Build the wheels
       - name: Triage the build
-        run: bash ./ci/triage_build.sh "${{ inputs.arch }}" "${{ github.event.pull_request.head.sha || github.sha }}" "${{ inputs.python-version }}"
+        run: bash ./ci/triage_build.sh "$ARCH" "${{ github.event.pull_request.head.sha || github.sha }}" "$PYTHONVERSION"
+        env:
+          ARCH: ${{ inputs.arch }}
+          PYTHONVERSION: ${{ inputs.python-version }}
 
       - name: Run cibuildwheel
-        uses: pypa/cibuildwheel@v3.4.0
+        uses: pypa/cibuildwheel@ee02a1537ce3071a004a6b08c41e72f0fdc42d9a # v3.4.0
         env:
           # Note that tool.cibuildwheel "skip" in pyproject.toml also limits what gets built
           CIBW_ARCHS: ${{ inputs.arch }}
@@ -112,7 +117,7 @@ jobs:
           zip ./*.whl ./*/RECORD
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: wheels-${{ inputs.os }}-${{inputs.arch}}-${{ inputs.python-version }}
           path: ./wheelhouse/*.whl
@@ -127,23 +132,24 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0 # get the non-merge commit for PRs
           fetch-tags: true # include tags to get correct version from setuptools_scm
+          persist-credentials: false
 
       - name: Prevent accidentally testing repository package
         run: rm -r versioned_hdf5
 
       - name: Retrieve wheel
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
         with:
           name: wheels-${{ inputs.os }}-${{inputs.arch}}-${{ inputs.python-version }}
           merge-multiple: true # Don't unzip into subdirectory
           path: wheels/
 
       - name: 🐍 Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ inputs.python-version }}
 


### PR DESCRIPTION
This PR fixes a number of issues with the CI configuration:

- Workflow-level permissions have been set to `none` for every category, meaning the `GITHUB_TOKEN` by default explicitly has no access to anything. This is fine for the majority of our workflows only need to checkout publicly accessible code (via `actions/checkout`), which doesn't require any permissions.
- For those jobs that require elevated permissions (`publish_docs.yml`, `pypi_publish.yml`), elevated permissions are _only_ set on jobs that require them, not all jobs (i.e. the entire workflow).
- We no longer persist `actions/checkout` credentials because we don't use git anywhere in these workflows.
- All action versions have been pinned to the hashes associated with the tags we were using before to prevent mutable-git-reference attacks.
- A few places where template injection was possible, I've moved the templates into environment variables (which are expanded by the shell, instead of in the action itself).

@crusaderky I used zizmor here to guide me on these fixes. We can make this a pre-commit hook or just use it in the lint action, if that makes sense to do so. Do you have a preference?