### PR TITLE
read_many_slices NumPy->HDF5

### DIFF
--- a/benchmarks/read_many_slices.py
+++ b/benchmarks/read_many_slices.py
@@ -1,0 +1,87 @@
+import numpy as np
+from versioned_hdf5.slicetools import read_many_slices
+
+from .common import Benchmark
+
+# 1 KiB, 64 KiB, 1 MiB of float64 per chunk
+CHUNK_SIZES = [1024 // 8, 64 * 1024 // 8, 1024 * 1024 // 8]
+# Total bytes transferred per benchmark call ~16 MiB
+TOTAL_ELEMENTS = 16 * 1024 * 1024 // 8
+
+
+class TimeReadManySlicesNumPy:
+    """Benchmark read_many_slices with NumPy src and NumPy dst."""
+
+    params = [CHUNK_SIZES]
+    param_names = ["chunk_size"]
+
+    def setup(self, chunk_size):
+        rng = np.random.default_rng(42)
+        n_slices = TOTAL_ELEMENTS // chunk_size
+        # src is twice as large as dst so we can pick non-contiguous src offsets
+        self.src = rng.random(2 * TOTAL_ELEMENTS, dtype=np.float64)
+        self.dst = np.zeros(TOTAL_ELEMENTS, dtype=np.float64)
+        # Contiguous, chunk-aligned offsets in both src and dst
+        starts = (np.arange(n_slices) * chunk_size).reshape(-1, 1).astype(np.uint64)
+        self.src_start = starts
+        self.dst_start = starts
+        self.count = np.full((n_slices, 1), chunk_size, dtype=np.uint64)
+
+    def time_read_many_slices(self, chunk_size):
+        read_many_slices(self.src, self.dst, self.src_start, self.dst_start, self.count)
+
+
+class _TimeReadManySlicesH5Base(Benchmark):
+    """Common setup for h5py read/write benchmarks."""
+
+    params = [CHUNK_SIZES, [True, None, False]]
+    param_names = ["chunk_size", "fast"]
+
+    direction = ""  # "h5_to_np" or "np_to_h5"; overridden by subclasses
+
+    def setup(self, chunk_size, fast):
+        super().setup(chunk_size, fast)
+        rng = np.random.default_rng(42)
+        n_slices = TOTAL_ELEMENTS // chunk_size
+
+        self.np_arr = rng.random(TOTAL_ELEMENTS, dtype=np.float64)
+        # h5py dataset twice as large so source offsets can be non-contiguous if needed
+        self.h5_dset = self.file.create_dataset(
+            "data",
+            # Initialize with data so reads return something realistic
+            data=rng.random(2 * TOTAL_ELEMENTS, dtype=np.float64),
+            chunks=(chunk_size,),
+        )
+
+        starts = (np.arange(n_slices) * chunk_size).reshape(-1, 1).astype(np.uint64)
+        self.src_start = starts
+        self.dst_start = starts
+        self.count = np.full((n_slices, 1), chunk_size, dtype=np.uint64)
+
+
+class TimeReadManySlicesH5ToNp(_TimeReadManySlicesH5Base):
+    """Benchmark read_many_slices with h5py src and NumPy dst."""
+
+    def time_read_many_slices(self, chunk_size, fast):
+        read_many_slices(
+            self.h5_dset,
+            self.np_arr,
+            self.src_start,
+            self.dst_start,
+            self.count,
+            fast=fast,
+        )
+
+
+class TimeReadManySlicesNpToH5(_TimeReadManySlicesH5Base):
+    """Benchmark read_many_slices with numpy src and h5py dst."""
+
+    def time_read_many_slices(self, chunk_size, fast):
+        read_many_slices(
+            self.np_arr,
+            self.h5_dset,
+            self.src_start,
+            self.dst_start,
+            self.count,
+            fast=fast,
+        )

--- a/tests/test_slicetools.py
+++ b/tests/test_slicetools.py
@@ -255,15 +255,26 @@ def test_read_many_slices(h5file, args):
     # h5file fixture is not reset between hypothesis examples
     if "a" in h5file:
         del h5file["a"]
-    dset = h5file.create_dataset("a", data=src)
+    if "b" in h5file:
+        del h5file["b"]
+    src_dset = h5file.create_dataset("a", data=src)
+    dst_dset = h5file.create_dataset("b", shape=shape_to, dtype=src.dtype, fillvalue=0)
 
-    # Test h5py->numpy
+    # Test h5py->NumPy
     for kwargs in ({}, {"fast": True}, {"fast": False}):
         dst = np.zeros(shape_to, dtype=src.dtype)
         read_many_slices(
-            dset, dst, src_start, dst_start, count, src_step, dst_step, **kwargs
+            src_dset, dst, src_start, dst_start, count, src_step, dst_step, **kwargs
         )
         np.testing.assert_array_equal(dst, expect, strict=True)
+
+    # Test NumPy->h5py
+    for kwargs in ({}, {"fast": True}, {"fast": False}):
+        dst_dset[:] = 0
+        read_many_slices(
+            src, dst_dset, src_start, dst_start, count, src_step, dst_step, **kwargs
+        )
+        np.testing.assert_array_equal(dst_dset[:], expect, strict=True)
 
 
 @pytest.mark.parametrize("step", [1, 2, 3, 4, 5, 6])
@@ -438,14 +449,10 @@ def test_read_many_slices_noncontiguous_dst(h5file):
     np.testing.assert_equal(dst, expect)
 
     # h5py src only works in slow mode
-    with pytest.raises(NotImplementedError, match="contiguous"):
+    with pytest.raises(ValueError, match="fast transfer is not possible"):
         read_many_slices(
             src, dst[::2, ::3], [(0, 0), (2, 0)], [(0, 0), (2, 0)], (2, 4), fast=True
         )
-
-    # For the sake of awareness, user must explicitly pass fast=False
-    with pytest.raises(NotImplementedError, match="contiguous"):
-        read_many_slices(src, dst[::2, ::3], [(0, 0), (2, 0)], [(0, 0), (2, 0)], (2, 4))
 
 
 def test_read_many_slices_not_fast_read_ok(h5file):
@@ -498,11 +505,11 @@ def test_read_many_slices_fail():
         read_many_slices(np.array(0), np.array(0), [[]], [[]], [[]])
 
     # src.ndim != dst.ndim  # noqa: ERA001
-    with pytest.raises(ValueError, match="same dtype and dimensionality"):
+    with pytest.raises(ValueError, match="dimensionality mismatch"):
         read_many_slices(src.reshape(2, 2), dst, [[0]], [[0]], [[1]])
 
     # src.dtype != dst.dtype  # noqa: ERA001
-    with pytest.raises(ValueError, match="same dtype and dimensionality"):
+    with pytest.raises(ValueError, match="dtype mismatch"):
         read_many_slices(src.astype(float), dst, [[0]], [[0]], [[1]])
 
     # Fail to broadcast coordinates

--- a/versioned_hdf5/slicetools.pyx
+++ b/versioned_hdf5/slicetools.pyx
@@ -5,6 +5,7 @@ import cython
 import h5py
 from h5py import h5d
 
+cimport cython
 cimport numpy as np
 
 import numpy as np
@@ -51,6 +52,15 @@ cdef extern from "hdf5.h":
         hid_t file_space_id,
         hid_t dxpl_id,
         void* buf,
+    ) nogil
+
+    cdef herr_t H5Dwrite(
+        hid_t dset_id,
+        hid_t mem_type_id,
+        hid_t mem_space_id,
+        hid_t file_space_id,
+        hid_t dxpl_id,
+        const void* buf,
     ) nogil
 
     cdef hid_t H5E_DEFAULT = 0
@@ -289,7 +299,7 @@ cdef Exception HDF5Error():
 
 cpdef void read_many_slices(
     src: ArrayProtocol,
-    np.ndarray dst,
+    dst: ArrayProtocol,
     src_start: ArrayLike,
     dst_start: ArrayLike,
     count: ArrayLike,
@@ -309,9 +319,17 @@ cpdef void read_many_slices(
     ----------
     src: np.ndarray | h5py.Dataset | other array-like object
         The source data to read from
-    dst: np.ndarray
+    dst: np.ndarray | h5py.Dataset | other numpy-like object
         The destination array to write to.
-        It must be C-contiguous and of the same dtype and dimensionality as src.
+
+        The following combinations of src and dst are optimized:
+
+        - src is a h5py.Dataset with simple extents; dst is a C-contiguous numpy array
+        - dst is a h5py.Dataset with simple extents; src is a C-contiguous numpy array
+
+        All other combinations are supported but fall back to a generic, pure-python
+        transfer.
+
     src_start: array-like
         The starting coordinates, a.k.a. offsets, of the slices in src.
         It must be a 2D array or array-like (e.g. list of lists) with the same number of
@@ -330,9 +348,13 @@ cpdef void read_many_slices(
         The stride of the slices when writing to dst.
         Same format as src_start. If omitted, default to 1.
     fast: bool, optional
-        If True, use the hdf5 C API directly to read the data if possible. This is when
-        src is a h5py dataset with a simple data type (see h5py.Dataset._fast_read_ok).
-        If False, use pure Python numpy syntax to slice src and dst.
+        If True, use the hdf5 C API directly to transfer the data. This is possible when
+        src is a h5py dataset with a simple data type (see h5py.Dataset._fast_read_ok)
+        and dst is a C-contiguous numpy array, or the other way around.
+        Raise if fast transfer is not possible.
+
+        If False, always use pure Python numpy syntax to slice src and dst.
+
         If omitted, determine automatically. It's recommended to omit this flag unless
         you're running a unit test or benchmark.
 
@@ -381,16 +403,17 @@ cpdef void read_many_slices(
 
     Performance notes
     -----------------
-    When reading from h5py, this function calls::
+    When reading/writing between h5py and a C-contiguous numpy array, this function
+    calls::
 
         H5Sselect_hyperslab(file_id, H5S_SELECT_SET, ...)
         H5Sselect_hyperslab(mem_id, H5S_SELECT_SET, ...)
-        H5DRead(...)
+        H5Dread(...) / H5Dwrite(...)
 
-    once per input row; see _read_many_slices_fast.
+    once per input row; see _read_many_slices_h5_to_np and _read_many_slices_np_to_h5.
 
     This is much faster than calling H5Sselect_hyperslab(..., H5S_SELECT_OR, ...) once
-    per input row followed by a single call to H5DRead, a.k.a. hyperslab fusion,
+    per input row followed by a single call to H5Dread, a.k.a. hyperslab fusion,
     due to a known issue in libhdf5:
     https://forum.hdfgroup.org/t/union-of-non-consecutive-hyperslabs-is-very-slow/5062
 
@@ -401,29 +424,27 @@ cpdef void read_many_slices(
     """
     # Begin input validation and preprocessing
 
-    ndim = dst.ndim
+    cdef int ndim = dst.ndim
     if ndim < 1:
         raise ValueError("must operate on at least one dimension")
-    if dst.dtype != src.dtype or ndim != src.ndim or not dst.flags.writeable:
-        raise ValueError(
-            "dst must be a writeable numpy array of the same dtype and dimensionality "
-            "as src"
-        )
-    if dst.size == 0 or not all(src.shape):
+    if src.ndim != ndim:
+        raise ValueError(f"dimensionality mismatch: {src.ndim=} != {dst.ndim=}")
+    if dst.dtype != src.dtype:
+        raise ValueError(f"dtype mismatch: {src.dtype=} != {dst.dtype=}")
+    if isinstance(dst, np.ndarray) and not dst.flags.writeable:
+        raise ValueError("dst must be writeable")
+    if dst.size == 0 or src.size == 0:
         return
 
-    cdef bint bfast = False
+    cdef bint fast_h5_to_np = False
+    cdef bint fast_np_to_h5 = False
     if fast is not False:
-        if isinstance(src, h5py.Dataset):
-            with phil:
-                bfast = src._fast_read_ok
-        if fast and not bfast:
-            raise ValueError("fast transfer is not possible with this source")
-
-    if bfast and not dst.flags.c_contiguous:
-        # TODO we could support non-C-contiguous arrays by doing
-        # arithmetic with starts and strides
-        raise NotImplementedError("dst must be C-contiguous for fast mode")
+        with phil:
+            fast_h5_to_np = _supports_fast_h5_np(src, dst)
+            fast_np_to_h5 = _supports_fast_h5_np(dst, src)
+        if fast is True and not fast_h5_to_np and not fast_np_to_h5:
+            raise ValueError("fast transfer is not possible with given src/dst arrays")
+    cdef bint bfast = fast_h5_to_np or fast_np_to_h5
 
     src_start = _preproc_many_slices_idx(src_start, ndim, bfast)
     dst_start = _preproc_many_slices_idx(dst_start, ndim, bfast)
@@ -455,10 +476,7 @@ cpdef void read_many_slices(
         raise ValueError("Coordinates arrays must have as many columns as src.ndim")
 
     cdef np.ndarray src_shape = np.array(src.shape, dtype=np_hsize_t)
-    cdef np.npy_intp[1] ndim_ptr = {ndim}
-    cdef np.ndarray dst_shape = np.PyArray_SimpleNewFromData(
-        1, ndim_ptr, np.NPY_INTP, <void*>dst.shape
-    )
+    cdef np.ndarray dst_shape = np.array(dst.shape, dtype=np_hsize_t)
     # On 32-bit platforms, sizeof(hsize_t) == 8; sizeof(npy_intp) == 4
     # On 64-bit platforms, don't copy unnecessarily
     dst_shape = asarray(dst_shape, dtype=np_hsize_t)
@@ -475,11 +493,24 @@ cpdef void read_many_slices(
 
     # End of input validation and preprocessing
 
-    if bfast:
-        _read_many_slices_fast(
+    if fast_h5_to_np:
+        _read_many_slices_h5_np(
             src,
             dst,
+            False,
             <hsize_t*>dst_shape.data,
+            src_start,
+            dst_start,
+            clipped_count,
+            src_stride,
+            dst_stride,
+        )
+    elif fast_np_to_h5:
+        _read_many_slices_h5_np(
+            dst,
+            src,
+            True,
+            <hsize_t*>src_shape.data,
             src_start,
             dst_start,
             clipped_count,
@@ -564,45 +595,69 @@ cdef hsize_t[:, :] _clip_count(
     return out
 
 
+cdef bint _supports_fast_h5_np(maybe_h5_dset, maybe_np_arr):
+    """Return True if we can use _read_many_slices_h5_np; False otherwise."""
+    return (
+        isinstance(maybe_h5_dset, h5py.Dataset)
+        and isinstance(maybe_np_arr, np.ndarray)
+        and maybe_h5_dset._fast_read_ok
+        and maybe_np_arr.flags.c_contiguous
+    )
+
+
 @cython.wraparound(False)
 @cython.boundscheck(False)
 @cython.infer_types(True)
-cdef void _read_many_slices_fast (
-    src: h5py.Dataset,
-    np.ndarray dst,
-    const hsize_t* dst_shape,
+cdef void _read_many_slices_h5_np (
+    h5_dset: h5py.Dataset,
+    np.ndarray np_arr,
+    bint write,
+    const hsize_t* np_arr_shape,
     const hsize_t[:, :] src_start,
     const hsize_t[:, :] dst_start,
     const hsize_t[:, :] count,
     const hsize_t[:, :] src_stride,
     const hsize_t[:, :] dst_stride,
 ):
-    """Implements read_many_slices data transfer when src is a h5py.Dataset with simple
-    extents only (h5py.Dataset._fast_read_ok).
+    """Implements read_many_slices data transfer between an h5py.Dataset with simple
+    extents (h5py.Dataset._fast_read_ok) and a C-contiguous numpy array.
 
     Performance notes
     -----------------
     See docstring of read_many_slices
     """
-    nslices, ndim = src_start.shape[:2]
-
     with phil:
         # h5py internals. See h5py/dataset.py and h5py/_selector.pyx.
-        dset_id: hid_t = src.id.id
+        dset_id: hid_t = h5_dset.id.id
         # must remain in scope for the id to remain valid
-        space = src.id.get_space()
+        space = h5_dset.id.get_space()
         file_space_id: hid_t = space.id
         # must remain in scope for the id to remain valid
-        mem_type = py_create(src.dtype)
+        mem_type = py_create(h5_dset.dtype)
         mem_type_id: hid_t = mem_type.id
 
         # libhdf5 is not thread safe (read comment about locking in h5py/_objects.pyx),
         # so we are wrapping everything in a reentrant lock (`with phil`).
         # We can however release the GIL to allow unrelated code to run in parallel.
         with nogil:
-            mem_space_id = H5Screate_simple(ndim, dst_shape, NULL)
+            nslices, ndim = src_start.shape[:2]
+
+            mem_space_id = H5Screate_simple(ndim, np_arr_shape, NULL)
             if mem_space_id == H5I_INVALID_HID:
                 raise HDF5Error()
+
+            if write:
+                src_space_id = mem_space_id
+                dst_space_id = file_space_id
+                io_func = cython.cast(
+                    # Force const void* buffer to void*
+                    "herr_t (*)(hid_t,  hid_t,  hid_t,  hid_t,  hid_t,  void *) nogil",
+                    H5Dwrite,
+                )
+            else:
+                src_space_id = file_space_id
+                dst_space_id = mem_space_id
+                io_func = H5Dread
 
             try:
                 for i in range(nslices):
@@ -612,7 +667,7 @@ cdef void _read_many_slices_fast (
                     else:
                         # count > 0 along all axes
                         if H5Sselect_hyperslab(
-                            file_space_id,
+                            src_space_id,
                             H5S_SELECT_SET,
                             &src_start[i, 0],
                             &src_stride[i, 0],
@@ -622,7 +677,7 @@ cdef void _read_many_slices_fast (
                             raise HDF5Error()
 
                         if H5Sselect_hyperslab(
-                            mem_space_id,
+                            dst_space_id,
                             H5S_SELECT_SET,
                             &dst_start[i, 0],
                             &dst_stride[i, 0],
@@ -631,13 +686,13 @@ cdef void _read_many_slices_fast (
                         ) < 0:
                             raise HDF5Error()
 
-                        if H5Dread(
+                        if io_func(
                             dset_id,
                             mem_type_id,
                             mem_space_id,
                             file_space_id,
                             H5P_DEFAULT,
-                            dst.data,
+                            np_arr.data,
                         ) < 0:
                             raise HDF5Error()
             finally:
@@ -650,26 +705,29 @@ cdef void _read_many_slices_fast (
 @cython.infer_types(True)
 cdef void _read_many_slices_slow (
     src: ArrayProtocol,
-    np.ndarray dst,
+    dst: ArrayProtocol,
     const hsize_t[:, :] src_start,
     const hsize_t[:, :] dst_start,
     const hsize_t[:, :] count,
     const hsize_t[:, :] src_stride,
     const hsize_t[:, :] dst_stride,
 ):
-    """Implements read_many_slices data transfer when fast transfer cannot be performed.
+    """Implements read_many_slices data transfer between two arbitrary Python objects
+    that support a basic NumPy-array-like duck-type API.
 
     This happens when:
-    1. src is a h5py.Dataset but h5py.Dataset._fast_read_ok returns False.
-       This is to avoid replicating the complex machinery found in
-       h5py.Dataset.__getitem__.
-    2. src is a numpy array.
-    3. src is a numpy-like object, e.g. a h5py AsTypeView object.
+    - src or dst is a h5py.Dataset but h5py.Dataset._fast_read_ok returns False.
+      This is to avoid replicating the complex machinery found in
+      h5py.Dataset.__getitem__/__setitem__;
+    - src or dst are non-contiguous NumPy arrays;
+    - both src and dst are NumPy arrays;
+    - either src and dst are arbitrary NumPy-like objects (neither NumPy nor h5py).
 
     Performance notes
     -----------------
-    There has been experimentation to bypass the Python slicing machinery by hacking the
-    numpy C API. While functionally successful, there was no material performance gain.
+    There has been experimentation to bypass the Python slicing machinery to implement
+    NumPy-to-NumPy transfers by hacking the NumPy C API. While functionally successful,
+    there was no material performance gain.
 
     An alternative approach would be to manually loop over the strides at least for
     basic item sizes (1, 2, 4, and 8 bytes). This has not been attempted yet.


### PR DESCRIPTION
Towards #398
Add functionality to `read_many_slices` to write from NumPy o HDF5.
Add performance benchmarks for the function.