### PR TITLE
Tweak worfklow triggers

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,5 +1,17 @@
 name: Benchmarks
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: ["*"]
+  workflow_dispatch: # allows you to trigger manually
+
+# When this workflow is queued, automatically cancel any previous running
+# or pending jobs from the same branch
+concurrency:
+  group: benchmarks-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 jobs:
   benchmarks:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,7 +1,7 @@
 name: Benchmarks
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
     branches: ["*"]
   workflow_dispatch: # allows you to trigger manually

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -13,6 +13,12 @@ on:
         description: "Test release: publish on test.pypi.org"
         default: false
 
+# When this workflow is queued, automatically cancel any previous running
+# or pending jobs from the same branch
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-sdist:
     name: Build sdist

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,17 @@
 name: Tests
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: ["*"]
+  workflow_dispatch: # allows you to trigger manually
+
+# When this workflow is queued, automatically cancel any previous running
+# or pending jobs from the same branch
+concurrency:
+  group: pytest-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 jobs:
   tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,7 @@
 name: Tests
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
     branches: ["*"]
   workflow_dispatch: # allows you to trigger manually


### PR DESCRIPTION
- Immediately abort and restart tests when someone pushes again to a PR
- Don't run on PR branches of forks on every run
- Enable tests on manual trigger