### PR TITLE
Fix random test failure on CPUs with energy saving cores

### DIFF
--- a/tests/test_staged_changes.py
+++ b/tests/test_staged_changes.py
@@ -611,6 +611,10 @@ def test_big_O_performance():
         t1 = time.perf_counter()
         return t1 - t0
 
+    # Leave a very generous tolerance to prevent random failures when the
+    # benchmark runs once a performance core and another on an efficiency core.
+    RTOL = 2
+
     # trivially sized baseline: 5 chunks
     a = benchmark((1, 10))
 
@@ -618,13 +622,13 @@ def test_big_O_performance():
     # Test will trip if __getitem__ or __setitem__ perform a
     # full scan of slab_indices and/or slab_offsets anywhere
     b = benchmark((2_500, 4_000))
-    np.testing.assert_allclose(b, a, rtol=0.5)
+    np.testing.assert_allclose(b, a, rtol=RTOL)
 
     # 5 million chunks, long rulers
     # Test will trip if __getitem__ or __setitem__ construct or iterate upon a ruler as
     # long as the number of chunks along one axis, e.g. np.arange(mapper.n_chunks)
     c = benchmark((1, 10_000_000))
-    np.testing.assert_allclose(c, a, rtol=0.5)
+    np.testing.assert_allclose(c, a, rtol=RTOL)
 
 
 def test_dont_load_wholly_selected_chunks():


### PR DESCRIPTION
I just had this fail with a 50.1% difference; I strongly suspect it's due to my CPU having performance cores and efficiency cores.