### PR TITLE
Redesign the commit stage: `StagedChangesArray.commit()`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,6 +20,17 @@ author = "Quansight"
 # with the -W flag in the Makefile.
 nitpicky = True
 
+# These internal modules are not documented via autodoc, so Sphinx can't
+# resolve cross-references to them. Ignore them in nitpicky mode.
+nitpick_ignore = [
+    ("py:class", "versioned_hdf5.hashtable.Hashtable"),
+    ("py:meth", "versioned_hdf5.staged_changes.StagedChangesArray.commit"),
+    ("py:meth", "versioned_hdf5.hashtable.Hashtable.hash"),
+    ("py:mod", "versioned_hdf5.hash"),
+    ("py:mod", "versioned_hdf5.replay"),
+    ("py:func", "versioned_hdf5.backend.commit_staged_changes"),
+]
+
 # -- General configuration ---------------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,17 +20,6 @@ author = "Quansight"
 # with the -W flag in the Makefile.
 nitpicky = True
 
-# These internal modules are not documented via autodoc, so Sphinx can't
-# resolve cross-references to them. Ignore them in nitpicky mode.
-nitpick_ignore = [
-    ("py:class", "versioned_hdf5.hashtable.Hashtable"),
-    ("py:meth", "versioned_hdf5.staged_changes.StagedChangesArray.commit"),
-    ("py:meth", "versioned_hdf5.hashtable.Hashtable.hash"),
-    ("py:mod", "versioned_hdf5.hash"),
-    ("py:mod", "versioned_hdf5.replay"),
-    ("py:func", "versioned_hdf5.backend.commit_staged_changes"),
-]
-
 # -- General configuration ---------------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be

--- a/docs/staged_changes.rst
+++ b/docs/staged_changes.rst
@@ -51,6 +51,19 @@ e.g.::
   slabs[0][ 0:10]* slabs[2][20:30]  slabs[0][0:10]*
   slabs[0][ 0:10]* slabs[2][10:20]  slabs[0][0:10]*
 
+In addition to the slabs, the ``StagedChangesArray`` holds a ``hash_tables`` list which
+is kept exactly parallel to ``slabs`` (same length; ``None`` wherever the matching slab
+is ``None``). ``hash_tables[i]`` is a NumPy array with dtype ``uint64`` and shape ``(n,
+4)`` (256 bits rows), where n is the number of chunks in ``slabs[i]`` along axis 0; each
+row holds one SHA256 digest, so ``hash_tables[i][j, :]`` is the hash of the chunk at
+``slabs[i][j * chunk_size[0]:(j + 1) * chunk_size[0]]``.
+
+These hashes are used by
+:ref:`commit <staged_changes_commit>` to deduplicate chunks.
+The hashes of the staged slabs are computed on demand at commit time (so if a staged
+chunk is created and then deleted, it is not unnecessarily hashed). The hashes of the
+base slab are loaded from disk.
+
 In order to be performant, operations are chained together in a way that minimizes
 Python interaction and is heavily optimized with Cython. To this extent, each user
 request (``__getitem__``, ``__setitem__``, ``resize()``, or ``load()``) is broken down
@@ -91,11 +104,13 @@ The source array-like can be either:
 - the full slab (a broadcasted numpy array);
 - the value parameter of the ``__setitem__`` method.
 
-The destination array (always an actual ``numpy.ndarray``) can be either:
+The destination array can be either:
 
-- a staged slab, shifted by ``slab_offsets``;
+- a staged slab (a numpy array in memory), shifted by ``slab_offsets``;
 - the return value of the ``__getitem__`` method, which is created empty at the
-  beginning of the method call and then progressively filled slice by slice.
+  beginning of the method call and then progressively filled slice by slice;
+- a new base slab created by ``commit()``, which is a view to an extension of the
+  ``raw_data`` ``h5py.Dataset``.
 
 
 Plans
@@ -124,8 +139,8 @@ where ``dset`` is a staged versioned_hdf5 dataset, you can run::
 
     SetItemPlan<value_shape=(3, 3), value_view=[:, :], append 2 empty slabs,
     7 slice transfers among 3 slab pairs, drop 0 slabs>
-      slabs.append(np.empty((6, 2)))  # slabs[2]
-      slabs.append(np.empty((2, 2)))  # slabs[3]
+      slabs.append(empty((6, 2)))  # slabs[2]
+      slabs.append(empty((2, 2)))  # slabs[3]
       # 3 transfers from slabs[1] to slabs[2]
       slabs[2][0:2, 0:2] = slabs[1][10:12, 0:2]
       slabs[2][2:4, 0:2] = slabs[1][18:20, 0:2]
@@ -318,6 +333,93 @@ selects all chunks in that lie on a base slab and transfers them to a brand new 
 slab.
 
 
+.. _staged_changes_commit:
+
+``commit()`` algorithm
+----------------------
+To *commit* is to take all the chunks that lie on staged slabs and move them to a single
+brand new base slab (backed by HDF5), deduplicating them along the way. It is the
+inverse of ``load()``: where ``load()`` copies the base slabs into a new staged slab,
+``commit()`` copies the (surviving) staged slabs into a new base slab and then drops all
+the staged slabs.
+
+Before commit
+^^^^^^^^^^^^^
+The ``StagedChangesArray.slabs`` list is accompanied by a paired ``hash_tables`` list.
+``hash_tables[1]``, which matches ``slabs[1]`` which is the h5py ``raw_data`` dataset,
+is loaded from h5py into memory. When ``__setitem__`` etc. append a new staged slab to
+``slabs``, they also append a ``None`` placeholder to ``hash_tables``: hashes are
+computed lazily at commit time, not eagerly at ``__setitem__`` time.
+
+Commit process
+^^^^^^^^^^^^^^
+Committing is broken down into the following stages:
+
+1. Define a ``HashPlan`` to discover which chunks don't have a known hash. This
+   typically translates to all staged chunks that were not deleted by later
+   mutations, plus the full slab. The output is a table of hashing instructions (slab,
+   selection of the slab to hash, target location on the ``hash_tables``) which is
+   similar in design to the table produced by the various plans that result in copying
+   data between slabs.
+2. Execute the ``HashPlan`` to generate the hashes. This is performed by Cython without
+   ever involving the Python API, so that it remains performant for small chunks.
+3. Define a ``CommitPlan``, which:
+
+   a. reads the hashes of the staged chunks that were just generated, plus the hashes of
+      all the chunks on the base slabs from HDF5;
+   b. drops duplicate staged chunks (any that are identical to the full chunk, a base
+      chunk on HDF5, or another staged chunk);
+   c. plans to copy the unique staged chunks to a new base slab;
+   d. updates ``slab_indices`` and ``slab_offsets`` so that all chunks that were
+      previously pointing to a staged slab now point to the full slab, an old base slab,
+      or the new base slab.
+
+4. Allocate a new base slab with a `np.empty`-like callback that was provided by the
+   wrapper. Under the hood, the function extends the h5py `raw_data` dataset and returns
+   a view to the new surface. `StagedChangesArray` doesn't know anything about this -
+   from it's point of view it's just a writeable NumPy-like array.
+5. Execute the ``CommitPlan``. The low-level Cython function that performs the transfer
+   drops the generic Numpy-like abstraction and takes a specialised code path to copy
+   from dense NumPy to HDF5. Again the iteration does not involve any Python API.
+6. Dereference the staged slabs (remove them from the ``staged_slabs`` list entirely;
+   don't just replace them with None's)
+7. Return control to the wrapper, which just needs to append the new ``hash_table`` to
+   ``raw_data``'s hash table on h5py.
+
+Nuances and caveats
+^^^^^^^^^^^^^^^^^^^
+Because ``hash_tables[i][j, :]`` always contains the hash of ``slabs[i][j *
+chunk_size[0]:(j+1)*chunk_size[0]``, one needs to be careful when writing to disk a slab
+that ends with an edge chunk: it must not be trimmed at the bottom.
+
+``CommitPlan`` scans *all* available hashes, including those of chunks that were in
+previous versions, which are still on ``slabs[1]`` (a.k.a. ``raw_data``) have since been
+deleted. This can resuscitate an old chunk after its deletion.
+
+When ``CommitPlan`` finds a duplicate chunk, the slab with the lowest index wins the
+tie:
+
+1. the full slab always wins, which means that if the user calls ``__setitem__`` to
+   completely fill a chunk with the ``fill_value``, nothing will be written on disk;
+2. then the base slabs win, meaning if the user calls ``__setitem__`` to write to a
+   chunk values that are identical to any chunk already on disk, nothing gets written;
+3. finally the lowest (arbitrary) staged chunk wins, meaning that two identical stage
+   chunks result in only one chunk being written.
+
+For sake of simplicity, ``CommitPlan`` is blind to the geometry of edge chunks. To
+compensate, staged slabs are initialised to the ``fill_value``, so that the cells of an
+edge chunk that lie beyond the array boundary hold the ``fill_value`` rather than
+uninitialised memory; this keeps the layout deterministic when ``commit()`` later copies
+whole chunks (padding included) to HDF5.
+
+A new base slab is appended *only if at least one staged chunk survives deduplication*.
+If every staged chunk turns out to be a duplicate of a base or full chunk (or there are
+no staged chunks at all), nothing is written: no new base slab is created and
+``n_base_slabs`` is left unchanged; the staged chunks are simply repointed to their
+duplicates before the staged slabs are dropped. Crucially, this may mean you end up with
+a new *version* without any new *data* (the new version is a remix of pre-existing
+chunks).
+
 Reclaiming memory
 -----------------
 Each plan that mutates the state - ``SetItemPlan``, ``ResizePlan``, and ``LoadPlan`` -
@@ -393,11 +495,24 @@ API interaction
           label="staged_changes.py";
 
           StagedChangesArray;
-          Plans [
-              label="GetItemPlan\nSetItemPlan\nResizePlan\nLoadPlan\nChangesPlan";
-          ]
+          getitem [label="__getitem__()"]
+          setitem [label="__setitem__()"]
+          resize [label="resize()"]
+          load [label="load()"]
+          changes [label="changes()"]
+          commit [label="commit()"]
+          all_plans [label="All \*Plan classes", style="dashed"]
 
-          StagedChangesArray -> Plans -> TransferPlan;
+          StagedChangesArray -> getitem -> GetItemPlan -> TransferPlan;
+          StagedChangesArray -> setitem -> SetItemPlan -> TransferPlan;
+          StagedChangesArray -> resize -> ResizePlan -> TransferPlan;
+          StagedChangesArray -> load -> LoadPlan -> TransferPlan;
+          StagedChangesArray -> changes -> ChangesPlan;
+          StagedChangesArray -> commit -> CommitPlan -> TransferPlan;
+          commit -> HashPlan -> HashSlabPlan;
+
+          # No actual dependency; just a positioning hack
+          HashPlan -> all_plans [style="invis"]
       }
 
       subgraph cluster_2 {
@@ -417,18 +532,24 @@ API interaction
       }
 
       subgraph cluster_4 {
-          label="versions.py";
-          commit_version;
+          label="hash.pyx";
+          hash_slab;
+          libcrypto_api [label="libcrypto C API (via Cython)"]
       }
+
+      libcrypto [label="libcrypto (OpenSSL)"];
+      hash_slab -> libcrypto_api -> libcrypto;
 
       user -> DatasetWrapper;
 
       InMemoryDataset -> StagedChangesArray;
       InMemoryDataset -> build_slab_indices_and_offsets;
       InMemorySparseDataset -> StagedChangesArray;
-      Plans -> IndexChunkMapper;
       TransferPlan -> read_many_slices;
       TransferPlan -> read_many_slices_param_nd;
+      HashSlabPlan -> hash_slab;
+
+      all_plans -> IndexChunkMapper;
 
       InMemorySparseDataset -> commit_version;
       InMemoryArrayDataset -> commit_version;
@@ -436,6 +557,8 @@ API interaction
 
       h5py;
       commit_version -> h5py;
+      commit_version -> changes;
+      commit_version -> commit;
       hdf5_file [label="HDF5 file"; shape=cylinder];
       h5py -> hdf5_file;
       hdf5_c -> hdf5_file;

--- a/docs/staged_changes.rst
+++ b/docs/staged_changes.rst
@@ -406,12 +406,6 @@ tie:
 3. finally the lowest (arbitrary) staged chunk wins, meaning that two identical stage
    chunks result in only one chunk being written.
 
-For sake of simplicity, ``CommitPlan`` is blind to the geometry of edge chunks. To
-compensate, staged slabs are initialised to the ``fill_value``, so that the cells of an
-edge chunk that lie beyond the array boundary hold the ``fill_value`` rather than
-uninitialised memory; this keeps the layout deterministic when ``commit()`` later copies
-whole chunks (padding included) to HDF5.
-
 A new base slab is appended *only if at least one staged chunk survives deduplication*.
 If every staged chunk turns out to be a duplicate of a base or full chunk (or there are
 no staged chunks at all), nothing is written: no new base slab is created and

--- a/tests/test_staged_changes.py
+++ b/tests/test_staged_changes.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import hashlib
 import sys
+import textwrap
 import time
 from typing import Any, Literal
 
@@ -15,7 +17,7 @@ from versioned_hdf5.staged_changes import StagedChangesArray
 from versioned_hdf5.tools import NP_GE_200
 
 from .test_subchunk_map import idx_st, shape_chunks_st
-from .test_typing import MinimalArray
+from .test_typing import MinimalArray, MinimalMutableArray
 
 max_examples = 10_000
 
@@ -161,6 +163,27 @@ def test_staged_array(args):
 
     # Test __iter__
     assert_array_equal(list(arr), list(expect), strict=True)
+
+    # Commit: consolidate all staged chunks into a new base slab. The data must be
+    # unchanged, there must be no staged slabs left, and changes() (now reading from
+    # base slabs only) must still reconstruct the array.
+    prev_base_slabs = arr.n_base_slabs
+    arr.commit()
+    assert arr.n_base_slabs in (prev_base_slabs, prev_base_slabs + 1)
+    assert arr.n_staged_slabs == 0
+
+    for _, slab_idx, chunk in arr.changes():
+        assert slab_idx in list(range(1, prev_base_slabs + 2))
+        assert isinstance(chunk, tuple)
+        assert all(isinstance(s, slice) for s in chunk)
+
+    for i, (slab, ht) in enumerate(zip(arr.slabs, arr.hash_tables, strict=True)):
+        if slab is None:
+            assert ht is None
+        # Pre-existing base slabs may not have a hash table
+        elif i == prev_base_slabs + 1:
+            assert ht is not None
+    assert_array_equal(arr, expect, strict=True)
 
 
 def test_array_protocol_setitem():
@@ -316,6 +339,8 @@ def test_has_changes():
     assert a[2:2].shape == (0,)
     a[0] = 1
     assert a.has_changes
+    a.commit()  # commit() resets has_changes
+    assert not a.has_changes
 
     a = StagedChangesArray.full((4,), chunk_size=(2,))
     a.resize((6,))
@@ -526,6 +551,53 @@ def test_astype_base_slabs():
         a.astype("i2", base_slabs=[np.array([6], dtype="i2"), None])
     with pytest.raises(ValueError, match="shape"):
         a.astype("i2", base_slabs=[np.array([[6, 7]], dtype="i2"), None])
+
+
+def test_astype_wipes_hashes():
+    base = np.array([1, 2], dtype=np.int64)
+    a = StagedChangesArray.from_array(base, chunk_size=(2,), as_base_slabs=False)
+    assert a.n_base_slabs == 0
+    assert a.hash_tables[1] is None
+    a.commit()
+    assert a.n_base_slabs == 1
+    expect_hash = [
+        [
+            15475097508508859130,
+            14309329822420762989,
+            1054910637374818680,
+            16249530140865467715,
+        ]
+    ]
+    assert_array_equal(a.hash_tables[1], expect_hash)
+
+    b = a.astype(float)
+    assert a.n_base_slabs == 1
+    assert_array_equal(a.hash_tables[1], expect_hash)
+    assert b.n_base_slabs == 1
+    assert b.hash_tables[1] is None
+
+
+@pytest.mark.skipif(not NP_GE_200, reason="StringDType requires numpy >=2")
+def test_astype_object_to_str_keeps_hashes():
+    """In object string <-> StringDType conversions the data doesn't change,
+    so the hashes of the swapped base slabs are not invalidated.
+    """
+    base = np.array(["aa", "bb"], dtype=object)
+    ht = np.full((1, 4), 1337, dtype=np.uint64)
+    a = StagedChangesArray(
+        shape=(2,),
+        chunk_size=(2,),
+        base_slabs=[base],
+        slab_indices=[1],
+        slab_offsets=[0],
+        fill_value="",
+        base_hash_tables=[ht],
+    )
+    dtype = np.dtypes.StringDType()
+    b = a.astype(dtype, base_slabs=[base.astype(dtype)])
+    assert b.dtype == dtype
+    assert_array_equal(b.base_hash_tables[0], ht)
+    assert_array_equal(b, base.astype(dtype), strict=True)
 
 
 class TestAsTypeLazy:
@@ -866,7 +938,7 @@ def test_repr():
     r = repr(a._setitem_plan((0, 2)))
     assert "append 1 empty slab" in r, r
     assert "2 slice transfers among 2 slab pairs" in r, r
-    assert "slabs.append(np.empty((2, 1)))  # slabs[4]" in r, r
+    assert "slabs.append(empty((2, 1)))  # slabs[4]" in r, r
     assert "slabs[4][0:2, 0:1] = slabs[0][0:2, 0:1]" in r, r
     assert "slabs[4][0:1, 0:1] = value[0:1, 0:1]" in r, r
     assert "[[3 2 4]]" in r, r  # updated slab_indices
@@ -883,7 +955,7 @@ def test_repr():
     assert "append 1 empty slab" in r, r
     assert "2 slice transfers among 1 slab pair" in r, r
     assert "drop 1 slab" in r, r
-    assert "slabs.append(np.empty((2, 4)))  # slabs[2]" in r, r
+    assert "slabs.append(empty((2, 4)))  # slabs[2]" in r, r
     assert "slabs[2][0:1, 0:2] = slabs[1][0:1, 0:2]" in r, r
     assert "slabs[1] = None" in r, r
 
@@ -1002,6 +1074,20 @@ def test_invalid_parameters():
             ValueError, match="Cannot return a ndarray view of a StagedChangesArray"
         ):
             np.asarray(a, copy=False)
+
+
+def test_invalid_base_hash_tables():
+    kwargs = dict(
+        shape=(4,),
+        chunk_size=(2,),
+        base_slabs=[np.arange(4, dtype="i8")],
+        slab_indices=[1, 1],
+        slab_offsets=[0, 2],
+    )
+    with pytest.raises(ValueError, match="hash_table.shape"):
+        StagedChangesArray(**kwargs, base_hash_tables=[np.zeros((1, 4), dtype="u8")])
+    with pytest.raises(ValueError, match="shorter"):
+        StagedChangesArray(**kwargs, base_hash_tables=[])
 
 
 def assert_tuple_of_ints(x: object) -> None:
@@ -1197,3 +1283,480 @@ def test_from_array_as_staged_slabs_6():
     a[:] = -1
     assert_array_equal(a, [-1, -1, -1])
     assert_array_equal(arr, [0, 1, 2])
+
+
+# ---------------------------------------------------------------------------
+# Committing staged changes: hashing and deduplication
+# ---------------------------------------------------------------------------
+
+
+def _baseline_hash_row(chunk: np.ndarray) -> np.ndarray:
+    """The SHA256 of a chunk, as 4x uint64 (one hash_tables row).
+    Does not cover VLEN dtypes (object strings or NpyStrings).
+    """
+    h = hashlib.sha256()
+    h.update(np.ascontiguousarray(chunk))
+    h.update(str(chunk.shape).encode("ascii"))
+    return np.frombuffer(h.digest(), dtype=np.uint64)
+
+
+def _baseline_hash_table(base_slab: np.ndarray, cs0: int) -> np.ndarray:
+    """Position-indexed hash table for a chunk-aligned 1D base slab, as the on-disk
+    legacy hash table would be inverted into.
+    """
+    n = base_slab.shape[0] // cs0
+    ht = np.zeros((n, 4), dtype=np.uint64)
+    for j in range(n):
+        ht[j] = _baseline_hash_row(base_slab[j * cs0 : (j + 1) * cs0])
+    return ht
+
+
+def test_commit_basic():
+    """commit() consolidates staged slabs into one new base slab, preserving data."""
+    a = StagedChangesArray.full((6,), chunk_size=(2,), fill_value=42)
+    a[0:2] = [1, 2]
+    a[2:4] = [3, 4]
+    assert a.n_staged_slabs == 2
+    expect = np.array([1, 2, 3, 4, 42, 42])
+    assert_array_equal(a, expect)
+
+    a.commit()
+    assert a.n_staged_slabs == 0
+    # full() has no base slab, so the new base slab is the only one, at index 1.
+    assert a.n_base_slabs == 1
+    assert len(a.slabs) == 2  # [full slab, new base slab]
+    assert_array_equal(a, expect)
+    # Third chunk is entirely fill_value -> deduplicated to the full slab, not written.
+    assert_array_equal(a.slab_indices, [1, 1, 0])
+    assert_array_equal(a.slab_offsets, [0, 2, 0])
+    # New base slab holds exactly the two non-fill chunks.
+    assert a.slabs[1].shape == (4,)
+
+
+def test_commit_dedup_staged_vs_staged():
+    """Identical staged chunks are stored once in the new base slab."""
+    a = StagedChangesArray.full((6,), chunk_size=(2,), fill_value=0)
+    a[0:2] = [7, 8]
+    a[2:4] = [7, 8]  # identical to chunk 0
+    a[4:6] = [9, 9]  # distinct
+    a.commit()
+    assert_array_equal(a, [7, 8, 7, 8, 9, 9])
+    # chunks 0 and 1 share the same offset; chunk 2 is distinct
+    assert_array_equal(a.slab_indices, [1, 1, 1])
+    assert_array_equal(a.slab_offsets, [0, 0, 2])
+    assert a.slabs[1].shape == (4,)  # only two unique chunks written
+
+
+def test_commit_dedup_staged_vs_base():
+    """A staged chunk identical to an existing base (raw_data) chunk becomes
+    a reference to it and is not rewritten.
+    """
+    base = np.array([7, 8, 50, 60], dtype="i8")  # chunk0=[7,8], chunk1=[50,60]
+    a = StagedChangesArray(
+        shape=(4,),
+        chunk_size=(2,),
+        base_slabs=[base],
+        slab_indices=[1, 1],
+        slab_offsets=[0, 2],
+        base_hash_tables=[_baseline_hash_table(base, 2)],
+    )
+    assert_array_equal(a.base_hash_tables[0], _baseline_hash_table(base, 2))
+    a[2:4] = [7, 8]  # now identical to base chunk 0
+    assert_array_equal(a, [7, 8, 7, 8])
+    assert_array_equal(a.slab_indices, [1, 2])
+    assert_array_equal(a.slab_offsets, [0, 0])
+    a.commit()
+    # Both chunks reference base slab 1; the staged chunk deduped to base offset 0.
+    assert_array_equal(a.slab_indices, [1, 1])
+    assert_array_equal(a.slab_offsets, [0, 0])
+    # Every staged chunk deduplicated against the base slab, so nothing was written and
+    # no new base slab was appended.
+    assert a.n_base_slabs == 1
+    assert len(a.slabs) == 2
+    assert_array_equal(a, [7, 8, 7, 8])
+
+
+def test_commit_base_wins_over_staged():
+    """When a chunk matches both a base and (the same value on) another staged chunk,
+    the base slab wins (lowest slab index).
+    """
+    base = np.array([7, 8], dtype="i8")
+    a = StagedChangesArray(
+        shape=(6,),
+        chunk_size=(2,),
+        base_slabs=[base],
+        slab_indices=[1, 0, 0],
+        slab_offsets=[0, 0, 0],
+        base_hash_tables=[_baseline_hash_table(base, 2)],
+    )
+    a[2:4] = [7, 8]  # staged, == base chunk
+    a[4:6] = [7, 8]  # staged, == base chunk
+    assert_array_equal(a.slab_indices, [1, 2, 3])
+    assert_array_equal(a.slab_offsets, [0, 0, 0])
+    a.commit()
+    assert_array_equal(a, [7, 8, 7, 8, 7, 8])
+    # All three reference the single base chunk; nothing new written, so no new base
+    # slab was appended.
+    assert_array_equal(a.slab_indices, [1, 1, 1])
+    assert_array_equal(a.slab_offsets, [0, 0, 0])
+    assert a.n_base_slabs == 1
+    assert len(a.slabs) == 2
+
+
+def test_commit_duplicate_base_hashes():
+    """When two identical chunks exist on the base slabs, the first one
+    encountered wins and the other contributes no deduplication candidate.
+    """
+    base = np.array([7, 8, 7, 8], dtype="i8")  # two identical chunks
+    a = StagedChangesArray(
+        shape=(6,),
+        chunk_size=(2,),
+        base_slabs=[base],
+        slab_indices=[1, 1, 0],
+        slab_offsets=[0, 2, 0],
+        base_hash_tables=[_baseline_hash_table(base, 2)],
+    )
+    a[4:6] = [7, 8]
+    assert_array_equal(a.slab_indices, [1, 1, 2])
+    assert_array_equal(a.slab_offsets, [0, 2, 0])
+    a.commit()
+    assert_array_equal(a.slab_indices, [1, 1, 1])
+    assert_array_equal(a.slab_offsets, [0, 2, 0])
+    assert a.n_base_slabs == 1  # Nothing was written
+    # Base chunks keep their mapping; the staged chunk
+    # is deduplicated to the first occurrence
+    assert_array_equal(a.slab_indices, [1, 1, 1])
+    assert_array_equal(a.slab_offsets, [0, 2, 0])
+    assert_array_equal(a, [7, 8, 7, 8, 7, 8])
+
+
+def test_commit_reuses_dereferenced_base_chunk():
+    """All base-slab hashes are considered, even of chunks no longer referenced by the
+    virtual array (e.g. deleted versions ago but still in raw_data).
+    """
+    base = np.array([10, 11, 20, 21, 30, 31], dtype="i8")
+    a = StagedChangesArray(
+        shape=(2,),  # only references base chunk 0
+        chunk_size=(2,),
+        base_slabs=[base],
+        slab_indices=[1],
+        slab_offsets=[0],
+        base_hash_tables=[_baseline_hash_table(base, 2)],
+    )
+    a.resize((4,))  # add a full chunk
+    a[2:4] = [30, 31]  # identical to the dereferenced base chunk 2
+    assert_array_equal(a, [10, 11, 30, 31])
+    assert_array_equal(a.slab_indices, [1, 2])
+    assert_array_equal(a.slab_offsets, [0, 0])
+    a.commit()
+    # The staged chunk is deduplicated onto the dereferenced base chunk at offset 2.
+    assert_array_equal(a, [10, 11, 30, 31])
+    assert_array_equal(a.slab_indices, [1, 1])
+    assert_array_equal(a.slab_offsets, [0, 4])
+    assert a.n_base_slabs == 1  # no new base slab written
+    assert len(a.slabs) == 2
+
+
+def test_commit_dedup_against_previous_commit():
+    """The hash table of the base slab created by a previous commit() is used to
+    deduplicate later staged chunks.
+    """
+    a = StagedChangesArray.full((4,), chunk_size=(2,))
+
+    a[0:2] = [1, 2]
+    a.commit()
+    assert a.n_base_slabs == 1
+    assert_array_equal(a.slab_indices, [1, 0])
+    assert_array_equal(a.slab_offsets, [0, 0])
+    assert_array_equal(a, [1, 2, 0, 0])
+
+    a[2:4] = [1, 2]  # Identical to the chunk committed above
+    a.commit()
+    assert a.n_base_slabs == 1  # Nothing new was written
+    assert_array_equal(a.slab_indices, [1, 1])
+    assert_array_equal(a.slab_offsets, [0, 0])
+    assert_array_equal(a, [1, 2, 1, 2])
+
+
+def test_commit_skips_dereferenced_staged_chunks():
+    """A staged chunk that was dropped by resize(), while other chunks on its slab
+    remain in use, is not committed.
+    """
+    a = StagedChangesArray.full((4,), chunk_size=(2,))
+    a[:] = [1, 2, 3, 4]  # One staged slab with two chunks
+    a.resize((2,))  # Chunk 1 is dropped; its slab is still referenced by chunk 0
+    a.commit()
+    assert_array_equal(a, [1, 2])
+    assert a.slabs[1].shape == (2,)  # Only the referenced chunk was written
+    assert a.hash_tables[1].shape == (1, 4)
+
+
+def test_commit_with_dropped_staged_slabs():
+    """commit() when a staged slab was entirely dropped by resize()"""
+    a = StagedChangesArray.full((4,), chunk_size=(2,))
+    a[0:2] = [1, 2]
+    a[2:4] = [3, 4]  # Second staged slab
+    assert len(a.slabs) == 3
+    assert a.n_base_slabs == 0
+    a.resize((2,))  # Drop it
+    assert a.slabs[2] is None
+
+    a.commit()
+    assert len(a.slabs) == len(a.hash_tables) == 2
+    assert a.n_base_slabs == 1
+    assert a.slabs[1].shape == (2,)
+    assert a.hash_tables[1].shape == (1, 4)
+    assert_array_equal(a, [1, 2])
+
+
+def test_commit_ignores_zeroed_base_hashes():
+    """An all-zero row in a base hash table means 'hash unknown': the chunk doesn't
+    contribute a deduplication candidate.
+    """
+    base = np.array([1, 2, 3, 4], dtype="i8")
+    ht = _baseline_hash_table(base, 2)
+    ht[1] = 0
+    a = StagedChangesArray(
+        shape=(4,),
+        chunk_size=(2,),
+        base_slabs=[base],
+        slab_indices=[1, 1],
+        slab_offsets=[0, 2],
+        base_hash_tables=[ht],
+    )
+    a[2:4] = [3, 4]  # Identical to base chunk 1, whose hash is zeroed
+    a.commit()
+    assert a.n_base_slabs == 2  # Not deduplicated: written to a new base slab
+    assert_array_equal(a.slab_indices, [1, 2])
+    assert_array_equal(a, [1, 2, 3, 4])
+
+
+def test_commit_dedup_edge_chunks():
+    """Edge chunks are hashed on their visible area only and deduplicate normally."""
+    a = StagedChangesArray.full((4, 5), chunk_size=(2, 2))
+    a[0:2, 4] = [9, 9]
+    a[2:4, 4] = [9, 9]  # Identical to the edge chunk above
+    a[0:2, 0] = [8, 8]
+    a.commit()
+    expect = np.zeros((4, 5))
+    expect[:, 4] = 9
+    expect[0:2, 0] = 8
+    assert_array_equal(a, expect)
+    assert_array_equal(a.slab_indices, [[1, 0, 1], [0, 0, 1]])
+    assert_array_equal(a.slab_offsets, [[2, 0, 0], [0, 0, 0]])
+    assert a.slabs[1].shape == (4, 2)  # Two unique chunks
+
+
+def test_commit_multidim_and_edges():
+    """commit() works for multidimensional arrays with edge chunks."""
+    rng = np.random.default_rng(0)
+    base = rng.integers(1000, size=(5, 5)).astype("i8")
+    a = StagedChangesArray.from_array(base.copy(), chunk_size=(2, 3), fill_value=0)
+    a[0, 0] = 999
+    a[4, 4] = 888  # bottom-right edge chunk
+    expect = base.copy()
+    expect[0, 0] = 999
+    expect[4, 4] = 888
+    assert_array_equal(a, expect)
+    a.commit()
+    assert a.n_staged_slabs == 0
+    assert_array_equal(a, expect, strict=True)
+
+
+def test_commit_no_staged_chunks():
+    """commit() on an array without staged chunks has nothing to write, so it does not
+    append a new base slab."""
+    a = StagedChangesArray.from_array(np.arange(4), chunk_size=(2,))
+    n_before = a.n_base_slabs
+    a.commit()
+    assert a.n_staged_slabs == 0
+    assert a.n_base_slabs == n_before
+    assert_array_equal(a, [0, 1, 2, 3])
+
+
+def test_commit_size_zero():
+    """commit() on a size-0 array is a well-behaved no-op-ish operation."""
+    a = StagedChangesArray.full((0,), chunk_size=(2,))
+    a.commit()
+    assert a.shape == (0,)
+    assert a.n_staged_slabs == 0
+    assert_array_equal(a, np.empty((0,)))
+
+
+def test_commit_empty_callback():
+    """The ``empty`` callback replicates numpy.empty and receives the new slab shape."""
+    calls = []
+
+    def my_empty(shape, dtype):
+        calls.append((shape, dtype))
+        return np.empty(shape, dtype=dtype)
+
+    a = StagedChangesArray.full((4,), chunk_size=(2,), dtype="i4")
+    a[0:2] = [1, 2]
+    a.commit(empty=my_empty)
+    assert len(calls) == 1
+    assert calls[0][0] == (2,)  # one surviving chunk * chunk_size[0]
+    assert calls[0][1] == np.dtype("i4")
+    assert_array_equal(a, np.array([1, 2, 0, 0], dtype="i4"), strict=True)
+
+
+def test_commit_writes_through_callback():
+    """The callback's returned array is where the chunks actually land (mirrors the
+    InMemoryDataset wrapper writing into a raw_data view).
+    """
+    surface = np.full((2,), -1, dtype="i8")
+
+    def my_empty(shape, dtype):
+        assert shape == (2,)
+        assert dtype == np.dtype("i8")
+        return surface  # pre-allocated destination
+
+    a = StagedChangesArray.full((2,), chunk_size=(2,), dtype="i8")
+    a[:] = [5, 6]
+    a.commit(empty=my_empty)
+    assert_array_equal(surface, [5, 6])  # written straight into our buffer
+    assert a.slabs[a.n_base_slabs] is surface
+
+
+def test_commit_empty_callback_non_ndarray():
+    """The empty callback may return a non-ndarray MutableArrayProtocol.
+
+    This is important for the InMemoryDataset wrapper, which uses a callback that
+    returns a view of the raw_data hdf5 dataset.
+    """
+    dst = MinimalMutableArray(np.full((2,), -1, dtype="i8"))
+    a = StagedChangesArray.full((3,), chunk_size=(2,), dtype="i8")
+    a[0:2] = [5, 6]
+    a.commit(empty=lambda *_args, **_kwargs: dst)
+    assert a.slabs[1] is dst
+    assert_array_equal(np.asarray(a), [5, 6, 0])
+
+
+def test_commit_readonly():
+    a = StagedChangesArray.full((2,), chunk_size=(2,))
+    a[:] = [1, 2]
+    a.writeable = False
+    with pytest.raises(ValueError, match="read-only"):
+        a.commit()
+
+
+def test_commit_after_copy_is_cow():
+    """commit() on one CoW sibling does not affect the other."""
+    a = StagedChangesArray.full((4,), chunk_size=(2,), fill_value=0)
+    a[0:2] = [1, 2]
+    b = a.copy()
+    a.commit()
+    assert_array_equal(a, [1, 2, 0, 0])
+    assert_array_equal(b, [1, 2, 0, 0])
+    assert a.n_staged_slabs == 0
+    assert b.n_staged_slabs == 1  # b still has the staged slab
+
+
+def test_commit_after_astype():
+    a = StagedChangesArray.full((4,), chunk_size=(2,), dtype="i1")
+    a[0:2] = [1, 2]
+    b = a.astype("i4")
+    b.commit()
+    assert b.dtype == "i4"
+    assert b.n_staged_slabs == 0
+    assert_array_equal(b, np.array([1, 2, 0, 0], dtype="i4"), strict=True)
+
+
+def test_commit_after_refill():
+    a = StagedChangesArray.full((4,), chunk_size=(2,), fill_value=0)
+    a[0:2] = [1, 2]
+    b = a.refill(9)
+    b.commit()
+    assert_array_equal(b, [1, 2, 9, 9])
+    # chunk 1 is entirely the new fill_value -> stays on the full slab
+    assert_array_equal(b.slab_indices, [1, 0])
+
+
+def test_commit_string_dtype():
+    a = StagedChangesArray.from_array(
+        np.array(["aaa", "bbb", "ccc", "aaa"], dtype="U3"),
+        chunk_size=(2,),
+        fill_value="zzz",
+    )
+    a[0] = "ddd"
+    a[2:4] = ["aaa", "aaa"]
+    expect = np.array(["ddd", "bbb", "aaa", "aaa"], dtype="U3")
+    assert_array_equal(a, expect, strict=True)
+    a.commit()
+    assert a.n_staged_slabs == 0
+    assert_array_equal(a, expect, strict=True)
+
+
+def test_hash_tables_parallel_to_slabs():
+    """hash_tables stays the same length as slabs, with None wherever a slab is None."""
+    a = StagedChangesArray.from_array(np.arange(6), chunk_size=(2,))
+
+    def check(arr):
+        assert len(arr.hash_tables) == len(arr.slabs)
+        for i, (slab, ht) in enumerate(zip(arr.slabs, arr.hash_tables, strict=True)):
+            if i == 0:
+                assert slab is not None
+            # Hashes are computed lazily (full, base, and staged slabs alike), so a
+            # present slab may still have ht=None. The firm invariant is the reverse:
+            # a dropped slab (None) never keeps a hash table.
+            if slab is None:
+                assert ht is None
+            if ht is not None:
+                assert ht.dtype == np.uint64
+                assert ht.shape[1] == 4
+
+    check(a)
+    a[0] = 9  # __setitem__ appends a staged slab
+    check(a)
+    a.resize((10,))  # enlarge -> append slab
+    check(a)
+    a.resize((2,))  # shrink -> drop slabs
+    check(a)
+    a.load()
+    check(a)
+    b = a.copy()
+    check(b)
+    a.commit()
+    check(a)
+
+
+def test_commit_repr():
+    a = StagedChangesArray.full((2, 10), chunk_size=(2, 2), fill_value=0)
+    a[0, 0:6] = [1, 2, 1, 2, 3, 4]  # create slabs[1] (note the duplicate chunk)
+    a[1, 7] = 5  # create slabs[2]
+
+    r = repr(a._hash_plan())
+    expect = """
+HashPlan<5 chunks over 3 slabs>
+  # hash 1 chunks of slabs[0]
+  hash_tables[0] = np.empty((1, sizeof(sha256)))
+  hash_tables[0][0] = hash(slabs[0][0:2, :2])
+  # hash 3 chunks of slabs[1]
+  hash_tables[1] = np.empty((3, sizeof(sha256)))
+  hash_tables[1][0] = hash(slabs[1][0:2, :2])
+  hash_tables[1][1] = hash(slabs[1][2:4, :2])
+  hash_tables[1][2] = hash(slabs[1][4:6, :2])
+  # hash 1 chunks of slabs[2]
+  hash_tables[2] = np.empty((1, sizeof(sha256)))
+  hash_tables[2][0] = hash(slabs[2][0:2, :2])
+    """
+    assert r == textwrap.dedent(expect).strip()
+
+    a._calc_hashes()
+
+    r = repr(a._commit_plan())
+    print(r)
+    expect = """
+CommitPlan<append 1 empty slabs, 3 slice transfers among 2 slab pairs, drop 0 slabs>
+  slabs.append(empty((6, 2)))  # slabs[1]
+  # 2 transfers from slabs[1] to slabs[3]
+  slabs[3][0:2, 0:2] = slabs[1][0:2, 0:2]
+  slabs[3][2:4, 0:2] = slabs[1][4:6, 0:2]
+  # 1 transfers from slabs[2] to slabs[3]
+  slabs[3][4:6, 0:2] = slabs[2][0:2, 0:2]
+slab_indices:
+[[1 1 1 1 0]]
+slab_offsets:
+[[0 0 2 4 0]]
+    """
+    assert r == textwrap.dedent(expect).strip()

--- a/tests/test_staged_changes.py
+++ b/tests/test_staged_changes.py
@@ -1563,6 +1563,20 @@ def test_commit_multidim_and_edges():
     assert_array_equal(a, expect, strict=True)
 
 
+def test_commit_doesnt_write_beyond_edge():
+    """commit() trims the edge chunks, so that it never writes to disk
+    the uninitialised padding beyond the edge of a staged chunk
+    """
+    a = StagedChangesArray.full((3,), chunk_size=(2,))
+    a[2] = 5  # Partial edge chunk; a.slabs[1][1] is uninitialised
+
+    def empty(*args, **kwargs):
+        return np.full(*args, **kwargs, fill_value=1337)
+
+    a.commit(empty=empty)
+    assert_array_equal(a.slabs[1], [5, 1337])
+
+
 def test_commit_no_staged_chunks():
     """commit() on an array without staged chunks has nothing to write, so it does not
     append a new base slab."""

--- a/versioned_hdf5/staged_changes.py
+++ b/versioned_hdf5/staged_changes.py
@@ -17,6 +17,7 @@ from cython import bint, ssize_t
 from numpy.typing import ArrayLike, DTypeLike, NDArray
 
 from versioned_hdf5.cytools import ceil_a_over_b, count2stop, np_hsize_t
+from versioned_hdf5.hash import hash_slab
 from versioned_hdf5.slicetools import read_many_slices
 from versioned_hdf5.subchunk_map import (
     EntireChunksMapper,
@@ -170,6 +171,24 @@ class StagedChangesArray(MutableMapping[Any, T]):
     #: slabs[0] is never dereferenced.
     slabs: list[NDArray[T] | None]
 
+    #: List parallel to :attr:`slabs` (same length, None wherever ``slabs`` is None).
+    #: An uncomputed hash table is also set to None.
+    #:
+    #: ``hash_tables[i]`` is a C-contiguous array of dtype ``uint64`` and shape
+    #: ``(n_i, 4)``, where ``n_i`` is the number of chunks in ``slabs[i]``,
+    #: and each row holds one SHA256 digest (4 * 8 = 32 bytes).
+    #:
+    #: ``hash_tables[i][j]`` is the hash of the chunk at
+    #: ``slabs[i][j*chunk_size[0]:(j+1)*chunk_size[0]]``
+    #: ignoring slab contents beyond the edge in case of edge chunks smaller
+    #: than chunk_size.
+    #:
+    #: A row set to all-zeros means the hash is uninitialized. This happens when
+    #: a staged chunk is created and then deleted, but other chunks on the slab remain.
+    #:
+    #: base slab hashes are typically loaded from disk and passed to ``__init__``.
+    hash_tables: list[NDArray[np.uint64] | None]
+
     #: Number of base slabs in the slabs list.
     #: Staged slabs start at index n_base_slabs + 1.
     n_base_slabs: int
@@ -187,6 +206,7 @@ class StagedChangesArray(MutableMapping[Any, T]):
         slab_indices: ArrayLike,
         slab_offsets: ArrayLike,
         fill_value: Any | None = None,
+        base_hash_tables: Sequence[NDArray[np.uint64]] | None = None,
     ):
         # Sanitize input (e.g. convert np.int64 to int)
         shape = tuple(int(i) for i in shape)
@@ -231,6 +251,23 @@ class StagedChangesArray(MutableMapping[Any, T]):
         self.slabs.extend(base_slabs)
         self.n_base_slabs = len(base_slabs)
 
+        # Build the hash_tables list, parallel to slabs.
+        self.hash_tables = [None]  # Full slab
+
+        if base_hash_tables is None:
+            # This only happens in unit tests
+            self.hash_tables += [None] * len(base_slabs)
+        else:
+            for base_slab, hash_table in zip(base_slabs, base_hash_tables, strict=True):
+                n_chunks_i = int(ceil_a_over_b(base_slab.shape[0], chunk_size[0]))
+                hash_table_shape = (n_chunks_i, 4)
+                if hash_table.shape != hash_table_shape:
+                    raise ValueError(
+                        f"{hash_table.shape=}; expected {hash_table_shape}"
+                    )
+                bht = np.ascontiguousarray(np.asarray(hash_table, dtype=np.uint64))
+                self.hash_tables.append(bht)
+
         self.slab_indices = asarray(slab_indices, dtype=np_hsize_t)
         self.slab_offsets = asarray(slab_offsets, dtype=np_hsize_t)
 
@@ -243,6 +280,13 @@ class StagedChangesArray(MutableMapping[Any, T]):
     @property
     def full_slab(self) -> NDArray[T]:
         return cast(NDArray[T], self.slabs[0])
+
+    @property
+    def full_hash_table(self) -> NDArray[T] | None:
+        """The hash_table for the full slab is calculated lazily only when actually
+        needed to deduplicate the staged chunks
+        """
+        return self.hash_tables[0]
 
     @property
     def fill_value(self) -> NDArray[T]:
@@ -309,8 +353,16 @@ class StagedChangesArray(MutableMapping[Any, T]):
         return self.slabs[1 : self.staged_slabs_start]
 
     @property
+    def base_hash_tables(self) -> Sequence[NDArray[np.uint64] | None]:
+        return self.hash_tables[1 : self.staged_slabs_start]
+
+    @property
     def staged_slabs(self) -> Sequence[NDArray[T] | None]:
         return self.slabs[self.staged_slabs_start :]
+
+    @property
+    def staged_hash_tables(self) -> Sequence[NDArray[np.uint64] | None]:
+        return self.hash_tables[self.staged_slabs_start :]
 
     @property
     def has_changes(self) -> bool:
@@ -445,6 +497,66 @@ class StagedChangesArray(MutableMapping[Any, T]):
             n_base_slabs=self.n_base_slabs,
         )
 
+    def _hash_plan(self) -> HashPlan:
+        """Formulate a plan to hash all staged chunks.
+
+        This is a read-only operation.
+        """
+        # Only the full slab (index 0) and the staged slabs (index > n_base_slabs) are
+        # hashed here. Base slab hashes are loaded externally (from the on-disk hash
+        # table, or passed to __init__) and a base slab that lacks one simply doesn't
+        # contribute deduplication candidates at commit time.
+        start = self.staged_slabs_start
+        slab_idx_filter = np.asarray(
+            [
+                slab is not None and ht is None and (i == 0 or i >= start)
+                for i, (slab, ht) in enumerate(
+                    zip(self.slabs, self.hash_tables, strict=True)
+                )
+            ]
+        )
+
+        return HashPlan(
+            shape=self.shape,
+            chunk_size=self.chunk_size,
+            slab_indices=self.slab_indices,
+            slab_offsets=self.slab_offsets,
+            slab_idx_filter=slab_idx_filter,
+        )
+
+    def _commit_plan(self, copy: bool = True) -> CommitPlan:
+        """Formulate a plan to deduplicate and consolidate all staged chunks.
+
+        You must run _calc_hashes() before invoking this.
+
+        See Also
+        --------
+        _calc_hashes
+        _setitem_plan
+        """
+        copy = copy or not self.slab_indices.flags.writeable
+
+        if self.size:
+            # _calc_hashes() must have hashed the full slab and every (non-dropped)
+            # staged slab. Base slab hashes are provided externally and may be absent,
+            # in which case that slab simply contributes no deduplication candidates.
+            assert self.full_hash_table is not None, "_calc_hashes() did not run"
+            for slab, ht in zip(
+                self.staged_slabs, self.staged_hash_tables, strict=True
+            ):
+                assert (slab is None) is (ht is None), "_calc_hashes() did not run"
+
+        # Note: even if there are staged slabs, CommitPlan may resolve that all staged
+        # chunks are duplicates of the base or full chunks and thus no data transfers
+        # are needed.
+        return CommitPlan(
+            slab_indices=self.slab_indices.copy() if copy else self.slab_indices,
+            slab_offsets=self.slab_offsets.copy() if copy else self.slab_offsets,
+            hash_tables=self.hash_tables,
+            n_base_slabs=self.n_base_slabs,
+            chunk_size=self.chunk_size,
+        )
+
     def _get_slab(
         self,
         idx: int | None,
@@ -472,15 +584,12 @@ class StagedChangesArray(MutableMapping[Any, T]):
             slab = asarray(slab, dtype=self.dtype)
             self.slabs[idx] = slab
 
-        if writeable:
-            # dst_slab is either a staged slab or the return value of __getitem__
-            assert isinstance(slab, np.ndarray)
-            if not slab.flags.writeable:
-                assert idx is not None  # __getitem__ return value is always writeable
-                assert idx > self.n_base_slabs  # Only staged slabs are writeable
-                # There was a previous call to copy()
-                slab = slab.copy()
-                self.slabs[idx] = slab
+        if writeable and isinstance(slab, np.ndarray) and not slab.flags.writeable:
+            assert idx is not None  # __getitem__ return value is always writeable
+            assert idx > self.n_base_slabs  # Only staged slabs are writeable
+            # There was a previous call to copy()
+            slab = slab.copy()
+            self.slabs[idx] = slab
 
         return slab
 
@@ -543,11 +652,21 @@ class StagedChangesArray(MutableMapping[Any, T]):
         return out[()] if out.ndim == 0 else out
 
     def _apply_mutating_plan(
-        self, plan: MutatingPlan, default_slab: NDArray[T] | None = None
+        self,
+        plan: MutatingPlan,
+        default_slab: NDArray[T] | None = None,
+        empty: Callable[..., MutableArrayProtocol] = np.empty,
     ) -> None:
         """Implement common workflow of __setitem__, resize, and load."""
         for shape in plan.append_slabs:
-            self.slabs.append(np.empty(shape, dtype=self.dtype))
+            slab = empty(shape, dtype=self.dtype)
+            if isinstance(slab, np.ndarray):
+                # This is a __setitem__ / resize / load. Initialise the slab to
+                # fill_value. commit() will later write the whole thing, padding
+                # included, to hdf5 and we don't want to write uninitialised memory.
+                slab[...] = self.fill_value
+            self.slabs.append(slab)
+            self.hash_tables.append(None)
 
         for tplan in plan.transfers:
             src_slab = self._get_slab(tplan.src_slab_idx, default_slab)
@@ -561,6 +680,7 @@ class StagedChangesArray(MutableMapping[Any, T]):
         for slab_idx in plan.drop_slabs:
             assert slab_idx != 0  # Never drop the full slab
             self.slabs[slab_idx] = None
+            self.hash_tables[slab_idx] = None
 
         # Even if we pass the indices arrays by reference to the *Plan
         # constructors, they may nonetheless be copied internally.
@@ -635,6 +755,84 @@ class StagedChangesArray(MutableMapping[Any, T]):
         plan = self._load_plan(copy=False)
         self._apply_mutating_plan(plan)  # This may be a no-op
 
+    def _calc_hashes(self) -> None:
+        """Internal stage 1 of commit():
+        hash all staged chunks (and the full slab) in place.
+        """
+        hplan = self._hash_plan()
+        for slab_plan in hplan.slabs:
+            slab = self._get_slab(slab_plan.slab_idx)
+            self.hash_tables[slab_plan.slab_idx] = slab_plan.hash_slab(slab)
+
+    def commit(self, empty: Callable[..., MutableArrayProtocol] = np.empty) -> None:
+        """Consolidate all staged chunks into a single, brand new base slab.
+
+        This is the act of moving every chunk that lies on a staged slab to a new base
+        slab, deduplicating it along the way:
+
+        - against the other staged chunks (so identical staged chunks are stored once),
+        - against the existing base slabs (so a staged chunk identical to one already on
+          a base slab - e.g. the ``raw_data`` of an InMemoryDataset - becomes just a
+          reference to it and is not rewritten), and
+        - against the fill_value (so a full-sized chunk that turns out to be entirely
+          fill_value is dropped to the full slab and not written at all).
+
+        When deduplicating, the slab with the lowest index wins a tie: base slabs win
+        over staged slabs and the full slab wins over everything. *All* hashes are
+        considered, even those of base-slab chunks not currently referenced by any
+        chunk, so that a chunk committed two or more versions ago and since deleted -
+        but still present in ``raw_data`` - can be reused.
+
+        This is the inverse of :meth:`load`: where ``load`` copies the contents of the
+        base slabs into a new staged slab, ``commit`` copies the contents of the staged
+        slabs (those that survive deduplication) into a new base slab and then drops all
+        the staged slabs.
+
+        After this call there are exactly ``n_base_slabs + 2`` slabs: the full slab, the
+        original base slabs (any that are no longer referenced are replaced with None),
+        and the new base slab at index ``n_base_slabs + 1`` (the old ``n_base_slabs``).
+        There are no more staged slabs.
+
+        Parameters
+        ----------
+        empty:
+            Callable with signature compatible with :func:`numpy.empty` (``empty(shape,
+            dtype)``) that returns the writeable destination for the new base slab.
+
+            Defaults to :func:`numpy.empty` (used in unit testing). The InMemoryDataset
+            wrapper instead passes a callable that enlarges the ``raw_data`` hdf5
+            dataset and returns a view of the newly created surface, so that the chunks
+            are written straight to disk.
+        """
+        if not self.writeable:
+            raise ValueError("assignment destination is read-only")
+
+        # Stage 1 (HashPlan): hash the full slab and all staged chunks in place.
+        self._calc_hashes()
+
+        # Stage 2 (CommitPlan): deduplicate, then plan the transfer to the new slab.
+        # CommitPlan remaps every surviving staged chunk either onto a brand new base
+        # slab (appended last) or, where it was deduplicated, onto the matching
+        # base/full chunk. A new base slab is appended only if at least one staged chunk
+        # survived deduplication.
+        cplan = self._commit_plan(copy=False)
+        if cplan.mutates:
+            self._apply_mutating_plan(cplan, None, empty)
+
+        drop_start = self.n_base_slabs + 1
+        if cplan.new_hash_table is not None:
+            self.hash_tables[len(self.slabs) - 1] = cplan.new_hash_table
+            # Drop all the (now superseded) staged slabs
+            drop_stop = len(self.slabs) - 1
+            del self.slabs[drop_start:drop_stop]
+            del self.hash_tables[drop_start:drop_stop]
+            self.n_base_slabs += 1
+        else:
+            # All staged slabs were deduplicated to preexisting chunks
+            # on the base slabs or the full slab
+            del self.slabs[drop_start:]
+            del self.hash_tables[drop_start:]
+
     def copy(self) -> StagedChangesArray[T]:
         """Return a writeable Copy-on-Write (CoW) copy of self.
 
@@ -651,6 +849,7 @@ class StagedChangesArray(MutableMapping[Any, T]):
 
         out = copy.copy(self)  # Shallow object copy
         out.slabs = self.slabs.copy()  # Shallow list copy
+        out.hash_tables = self.hash_tables.copy()  # Shallow list copy
         out.writeable = True  # Coherently with np.ndarray.copy()
         return out
 
@@ -669,7 +868,7 @@ class StagedChangesArray(MutableMapping[Any, T]):
             The new dtype.
         base_slabs: optional
             If provided, the new base slabs. Must have the same shapes as the original
-            base_slabs be of the new dtype.
+            base_slabs and be of the new dtype.
             If omitted, load into memory all chunks that are not yet staged and
             dereference the previous base slabs.
         """
@@ -677,6 +876,15 @@ class StagedChangesArray(MutableMapping[Any, T]):
         dtype = np.dtype(dtype)
         if self.dtype == dtype:
             return out
+
+        # In object string<->StringDType conversion; hashes are identical
+        # and don't need to be recalculated.
+        # Note: this flag should be True only during unit testing, as it can
+        # be exceptionally expensive to recompute the hashes of a slab on disk!
+        recalc_hashes = dtype.kind not in ("O", "T") or self.dtype.kind not in (
+            "O",
+            "T",
+        )
 
         if base_slabs is None:
             # Load all base slabs, if any, into new staged slabs
@@ -699,11 +907,15 @@ class StagedChangesArray(MutableMapping[Any, T]):
                         f"base_slabs[{i}] mismatched shape: {new.shape} != {old.shape}"
                     )
                 out.slabs[i + 1] = new  # offset by the full slab at index 0
+                if recalc_hashes:
+                    out.hash_tables[i + 1] = None
 
         # Convert the full slab; this has to happen after calling out.load().
         out.slabs[0] = np.broadcast_to(
             asarray(out.fill_value, dtype=dtype), out.chunk_size
         )
+        if recalc_hashes:
+            out.hash_tables[0] = None
 
         # Leave the staged slabs as read-only views of the original slabs, with
         # original dtype. They will be converted lazily, upon first access, by
@@ -727,6 +939,7 @@ class StagedChangesArray(MutableMapping[Any, T]):
 
         out.load()
         out.slabs[0] = np.broadcast_to(fill_value, out.chunk_size)
+        out.hash_tables[0] = None
         for idx, slab in enumerate(out.staged_slabs, start=out.staged_slabs_start):
             if slab is None:
                 continue
@@ -877,6 +1090,7 @@ class StagedChangesArray(MutableMapping[Any, T]):
                     slab = np.asarray(slab)
 
             out.slabs.append(slab)
+            out.hash_tables.append(None)
 
         if as_base_slabs:
             out.n_base_slabs = out.n_slabs - 1
@@ -1118,7 +1332,7 @@ class MutatingPlan:
     slab_offsets: NDArray[np_hsize_t]
 
     #: Create new uninitialized slabs with the given shapes
-    #: and append them StagedChangesArray.slabs
+    #: and append them to StagedChangesArray.slabs
     append_slabs: list[tuple[int, ...]] = field(init=False, default_factory=list)
 
     #: data transfers between slabs or from the __setitem__ value to a slab.
@@ -1153,7 +1367,7 @@ class MutatingPlan:
             slab_start_idx = int(max_slab_idx) - len(self.append_slabs) + 1
             assert slab_start_idx > 0
             for slab_idx, shape in enumerate(self.append_slabs, slab_start_idx):
-                s += f"\n  slabs.append(np.empty({shape}))  # slabs[{slab_idx}]"
+                s += f"\n  slabs.append(empty({shape}))  # slabs[{slab_idx}]"
 
         s += "".join(str(tplan) for tplan in self.transfers)
         for slab_idx in self.drop_slabs:
@@ -1428,8 +1642,9 @@ class ChangesPlan:
         # slab slices on the other axes can be built with a ruler
         # (and they'll be all the same except for the last chunk)
         for mapper in mappers[1:]:
+            n_chunks = cython.cast(ssize_t, mapper.n_chunks)
             slab_slices.append(
-                [slice(0, mapper.chunk_size, 1)] * (mapper.n_chunks - 1)
+                [slice(0, mapper.chunk_size, 1)] * (n_chunks - 1)
                 + [slice(0, mapper.last_chunk_size, 1)]
             )
 
@@ -1732,6 +1947,317 @@ class ResizePlan(MutatingPlan):
     @property
     def head(self) -> str:
         return "ResizePlan<" + super().head
+
+
+@cython.cclass
+@dataclass(repr=False, eq=False)
+class HashSlabPlan:
+    """Container for the plan to a single call to hash_slab"""
+
+    slab_idx: hsize_t
+    src_start: hsize_t[::1]
+    count: hsize_t[:, ::1]
+    chunk_size_0: hsize_t
+
+    def hash_slab(self, slab: np.ndarray):
+        """Hash the slab and return a new hash table"""
+        cs0 = self.chunk_size_0
+        nchunks = ceil_a_over_b(slab.shape[0], cs0)
+        nrows = self.src_start.shape[0]
+
+        hash_rows: hsize_t[::1] = np.empty(nrows, dtype=np_hsize_t)
+        for i in range(nrows):
+            hash_rows[i] = self.src_start[i] // cs0
+
+        ht = np.zeros((nchunks, 4), dtype=np.uint64)
+        hash_slab(slab, ht, hash_rows, self.src_start, self.count)
+
+        # We'll never write to it again
+        ht.flags.writeable = False
+        return ht
+
+    def __repr__(self) -> str:
+        ndim = self.count.shape[1]
+        nrows = self.src_start.shape[0]
+        cs0 = self.chunk_size_0
+        s = f"\n  # hash {nrows} chunks of slabs[{self.slab_idx}]"
+        s += f"\n  hash_tables[{self.slab_idx}] = np.empty(({nrows}, sizeof(sha256)))"
+
+        for plan_row in range(nrows):
+            src_start = self.src_start[plan_row]
+            hash_table_row = src_start // cs0
+            stop = src_start + self.count[plan_row, 0]
+            s += (
+                f"\n  hash_tables[{self.slab_idx}][{hash_table_row}] "
+                f"= hash(slabs[{self.slab_idx}][{src_start}:{stop}"
+            )
+            for dim in range(1, ndim):
+                stop = self.count[plan_row, dim]
+                s += f", :{stop}"
+            s += "])"
+
+        return s
+
+
+@cython.cclass
+@dataclass(init=False, repr=False)
+class HashPlan:
+    """Instructions to hash all staged chunks of a StagedChangesArray.
+
+    Finds every chunk that lies on a staged slab and, grouped by slab, produces the
+    ``(hash_rows, src_start, count)`` parameters for
+    :func:`versioned_hdf5.hash.hash_slab`.
+    """
+
+    #: One tuple per slab in ``slab_idx_filter``:
+    #: ``(slab_idx, hash_rows, src_start, count)``,
+    #: each ready to be passed to :func:`versioned_hdf5.hash.hash_slab`.
+    slabs: list[HashSlabPlan]
+
+    def __init__(
+        self,
+        shape: tuple[int, ...],
+        chunk_size: tuple[int, ...],
+        slab_indices: np.ndarray[np_hsize_t],
+        slab_offsets: np.ndarray[np_hsize_t],
+        slab_idx_filter: np.bool_[::1],
+    ):
+        self.slabs = []
+        ndim = len(shape)
+        chunk_size_0: hsize_t = chunk_size[0]
+
+        _, mappers = index_chunk_mappers((), shape, chunk_size)
+        if not mappers:  # size-0 array: no chunks at all
+            return
+
+        if slab_idx_filter[0]:
+            # Hash full slab. Do not pass it to _chunk_in_selection below
+            # as it would return one row for each chunk where it is used.
+            slab_idx_filter[0] = False
+            self.slabs.append(
+                HashSlabPlan(
+                    slab_idx=0,
+                    chunk_size_0=chunk_size_0,
+                    src_start=np.zeros((1,), dtype=np_hsize_t),
+                    count=np.asarray([chunk_size], dtype=np_hsize_t),
+                )
+            )
+
+        query = _chunks_in_selection(
+            slab_indices,
+            slab_offsets,
+            mappers,
+            filter=lambda slab_idx: slab_idx_filter[slab_idx],
+            idxidx=False,
+            sort_by_slab=True,
+        )
+        nchunks = query.shape[0]
+        if nchunks == 0:
+            return
+
+        # Edge-trimmed shape of each chunk (chunk_size, except the last chunk along an
+        # axis, where it's the remainder). This makes an edge chunk hash like the
+        # smaller chunk it represents in the virtual array, never reading past its edge.
+        count: hsize_t[:, ::1] = np.empty((nchunks, ndim), dtype=np_hsize_t)
+        for dim in range(ndim):
+            last_chunk_idx: hsize_t = ceil_a_over_b(shape[dim], chunk_size[dim]) - 1
+            cs: hsize_t = chunk_size[dim]
+            last_cs: hsize_t = (shape[dim] % chunk_size[dim]) or chunk_size[dim]
+            for row in range(nchunks):
+                count[row, dim] = last_cs if query[row, dim] == last_chunk_idx else cs
+
+        slab_off_col: hsize_t[::1] = np.ascontiguousarray(query[:, ndim + 1])
+
+        # The query is sorted by slab index; split it into per-slab groups.
+        slab_start = 0
+        for row in range(nchunks):
+            slab_idx = query[row, ndim]
+            if row == nchunks - 1 or query[row + 1, ndim] != slab_idx:
+                slab_stop = row + 1
+                self.slabs.append(
+                    HashSlabPlan(
+                        slab_idx=slab_idx,
+                        chunk_size_0=chunk_size_0,
+                        src_start=slab_off_col[slab_start:slab_stop],
+                        count=count[slab_start:slab_stop],
+                    )
+                )
+                slab_start = slab_stop
+
+    @property
+    def head(self) -> str:
+        n_chunks = sum(slab_plan.src_start.shape[0] for slab_plan in self.slabs)
+        n_slabs = len(self.slabs)
+        return f"HashPlan<{n_chunks} chunks over {n_slabs} slabs>"
+
+    def __repr__(self) -> str:
+        s = self.head
+        for slab_plan in self.slabs:
+            s += repr(slab_plan)
+        return s
+
+
+@cython.cclass
+@dataclass(init=False, repr=False)
+class CommitPlan(MutatingPlan):
+    """Instructions to execute StagedChangesArray.commit().
+
+    Deduplicates the staged chunks against each other, the base slabs and the full slab,
+    then plans the transfer of the unique survivors into a single new base slab.
+    """
+
+    #: Hash table for the new base slab; one row per surviving unique chunk.
+    new_hash_table: NDArray[np.uint64] | None
+
+    def __init__(
+        self,
+        slab_indices: NDArray[np_hsize_t],
+        slab_offsets: NDArray[np_hsize_t],
+        hash_tables: list[np.ndarray | None],
+        n_base_slabs: hsize_t,
+        chunk_size: tuple[int, ...],
+    ):
+        super().__init__(slab_indices, slab_offsets)
+        self.transfers = []
+        np_chunk_size = np.asarray(chunk_size, dtype=np_hsize_t).reshape((1, -1))
+
+        ndim: hsize_t = len(chunk_size)
+        cs0: hsize_t = chunk_size[0]
+        new_slab_idx: hsize_t = n_base_slabs + 1
+        out_row: hsize_t = 0
+        out_offset: hsize_t = 0
+
+        n_total_transfers: hsize_t = 0
+        for ht in hash_tables[n_base_slabs + 1 :]:
+            if ht is not None:
+                n_total_transfers += ht.shape[0]
+
+        new_hash_table: cython.ulonglong[:, ::1] = np.empty(
+            (n_total_transfers, 4), dtype=np.uint64
+        )
+        src_start: hsize_t[:, ::1] = np.zeros(
+            (n_total_transfers, ndim), dtype=np_hsize_t
+        )
+        dst_start: hsize_t[:, ::1] = np.zeros(
+            (n_total_transfers, ndim), dtype=np_hsize_t
+        )
+
+        # These are std::unordered_map when staged_changes.py is compiled by Cython
+        # and Python dicts when it is not compiled.
+        hash_to_old_chunk: ChunkHashMap = ChunkHashMap()
+        old_to_new_chunk: ChunkLocMap = ChunkLocMap()
+
+        old_slab_idx: ssize_t
+        inp_row: ssize_t
+        inp_offset: hsize_t
+        h0: cython.ulonglong
+        h1: cython.ulonglong
+        h2: cython.ulonglong
+        h3: cython.ulonglong
+        is_staged_slab: cython.bint
+        n_slab_transfers: hsize_t
+        i: ssize_t
+        old_slab_offset: hsize_t
+
+        # Build {hash -> (slab_idx, hash_table row)} from ALL hash tables. Iterating
+        # slabs in ascending order makes the lowest slab win ties: the full slab (0)
+        # beats the base slabs, which beat the staged slabs. Unreferenced base-slab
+        # chunks are included too, so a chunk deleted versions ago but still present in
+        # raw_data can be reused.
+
+        for old_slab_idx in range(len(hash_tables)):
+            ht = hash_tables[old_slab_idx]
+            if ht is None:
+                continue
+
+            is_staged_slab = old_slab_idx > cython.cast(ssize_t, n_base_slabs)
+            ht_view: cython.const[cython.ulonglong][:, ::1] = ht  # type: ignore[valid-type]
+            n_slab_transfers = 0
+            for inp_row in range(ht.shape[0]):
+                inp_offset = inp_row * cs0
+                h0 = ht_view[inp_row, 0]
+                h1 = ht_view[inp_row, 1]
+                h2 = ht_view[inp_row, 2]
+                h3 = ht_view[inp_row, 3]
+
+                if h0 == 0 and h1 == 0 and h2 == 0 and h3 == 0:
+                    if is_staged_slab:
+                        n_total_transfers -= 1
+                    continue  # Deleted chunk
+
+                ch_key = ChunkHash(h0, h1, h2, h3)
+                cl_key = ChunkLoc(old_slab_idx, inp_offset)
+                if hash_to_old_chunk.count(ch_key) == 0:  # std::unordered_map syntax
+                    if is_staged_slab:
+                        # Schedule for commit
+                        n_slab_transfers += 1
+
+                        cl_val = ChunkLoc(new_slab_idx, out_offset)
+                        hash_to_old_chunk[ch_key] = cl_val
+                        old_to_new_chunk[cl_key] = cl_val
+
+                        new_hash_table[out_row, 0] = h0
+                        new_hash_table[out_row, 1] = h1
+                        new_hash_table[out_row, 2] = h2
+                        new_hash_table[out_row, 3] = h3
+                        src_start[out_row, 0] = inp_row * cs0
+                        dst_start[out_row, 0] = out_row * cs0
+                        out_row += 1
+                        out_offset += cs0
+                    else:
+                        # Save hash of base or full chunk so that it can potentially
+                        # be used to deduplicate a staged chunk
+                        hash_to_old_chunk[ch_key] = cl_key
+                elif is_staged_slab:
+                    # Schedule for deduplication
+                    n_total_transfers -= 1
+                    old_to_new_chunk[cl_key] = hash_to_old_chunk[ch_key]
+
+            if n_slab_transfers > 0:
+                tplan = TransferPlan.__new__(TransferPlan)
+                tplan.src_slab_idx = old_slab_idx
+                # slab_idx of the new base slab, before the staged slabs are removed
+                tplan.dst_slab_idx = len(hash_tables)
+                tplan.src_start = src_start[out_row - n_slab_transfers : out_row]
+                tplan.dst_start = dst_start[out_row - n_slab_transfers : out_row]
+                # Slightly inefficient: also copy uninitialised data beyond the
+                # border of edge chunks so that we don't have to bother figuring
+                # out their shape here
+                tplan.count = np.broadcast_to(
+                    np_chunk_size, (n_slab_transfers, ndim)
+                ).copy()
+                tplan.src_stride = np.ones((n_slab_transfers, ndim), dtype=np_hsize_t)
+                tplan.dst_stride = tplan.src_stride
+                self.transfers.append(tplan)
+
+        # Append a single new base slab for the surviving unique staged chunks, but only
+        # if there are any (they have not been found to be duplicates of chunks in the
+        # base slabs or the full slab).
+        if n_total_transfers > 0:
+            self.append_slabs = [(int(n_total_transfers) * cs0, *chunk_size[1:])]
+            self.new_hash_table = np.asarray(new_hash_table[:n_total_transfers])
+        else:
+            assert not self.transfers
+            self.new_hash_table = None
+
+        # Scan through slab_indices and slab_offsets and update all chunks
+        # that were on a staged slab
+        self.slab_indices = np.ascontiguousarray(self.slab_indices)
+        self.slab_offsets = np.ascontiguousarray(self.slab_offsets)
+        slab_indices_flat_view: hsize_t[::1] = self.slab_indices.reshape(-1)
+        slab_offsets_flat_view: hsize_t[::1] = self.slab_offsets.reshape(-1)
+        for i in range(slab_indices_flat_view.size):
+            old_slab_idx = slab_indices_flat_view[i]
+            old_slab_offset = slab_offsets_flat_view[i]
+            loc = ChunkLoc(old_slab_idx, old_slab_offset)
+            if old_to_new_chunk.count(loc) != 0:
+                mapped = old_to_new_chunk[loc]
+                slab_indices_flat_view[i] = mapped.slab_idx
+                slab_offsets_flat_view[i] = mapped.slab_offset
+
+    @property
+    def head(self) -> str:
+        return "CommitPlan<" + super().head
 
 
 @cython.ccall

--- a/versioned_hdf5/staged_changes.py
+++ b/versioned_hdf5/staged_changes.py
@@ -507,14 +507,12 @@ class StagedChangesArray(MutableMapping[Any, T]):
         # table, or passed to __init__) and a base slab that lacks one simply doesn't
         # contribute deduplication candidates at commit time.
         start = self.staged_slabs_start
-        slab_idx_filter = np.asarray(
-            [
-                slab is not None and ht is None and (i == 0 or i >= start)
-                for i, (slab, ht) in enumerate(
-                    zip(self.slabs, self.hash_tables, strict=True)
-                )
-            ]
-        )
+        slab_idx_filter = [
+            slab is not None and ht is None and (i == 0 or i >= start)
+            for i, (slab, ht) in enumerate(
+                zip(self.slabs, self.hash_tables, strict=True)
+            )
+        ]
 
         return HashPlan(
             shape=self.shape,
@@ -2017,7 +2015,7 @@ class HashPlan:
         chunk_size: tuple[int, ...],
         slab_indices: np.ndarray[np_hsize_t],
         slab_offsets: np.ndarray[np_hsize_t],
-        slab_idx_filter: np.bool_[::1],
+        slab_idx_filter: list[bool],
     ):
         self.slabs = []
         ndim = len(shape)
@@ -2027,10 +2025,11 @@ class HashPlan:
         if not mappers:  # size-0 array: no chunks at all
             return
 
-        if slab_idx_filter[0]:
+        slab_idx_filter_np: np.bool_[::-1] = np.asarray(slab_idx_filter)
+        if slab_idx_filter_np[0]:
             # Hash full slab. Do not pass it to _chunk_in_selection below
             # as it would return one row for each chunk where it is used.
-            slab_idx_filter[0] = False
+            slab_idx_filter_np[0] = False
             self.slabs.append(
                 HashSlabPlan(
                     slab_idx=0,
@@ -2044,7 +2043,7 @@ class HashPlan:
             slab_indices,
             slab_offsets,
             mappers,
-            filter=lambda slab_idx: slab_idx_filter[slab_idx],
+            filter=lambda slab_idx: slab_idx_filter_np[slab_idx],
             idxidx=False,
             sort_by_slab=True,
         )

--- a/versioned_hdf5/staged_changes.py
+++ b/versioned_hdf5/staged_changes.py
@@ -550,6 +550,7 @@ class StagedChangesArray(MutableMapping[Any, T]):
         # chunks are duplicates of the base or full chunks and thus no data transfers
         # are needed.
         return CommitPlan(
+            shape=self.shape,
             slab_indices=self.slab_indices.copy() if copy else self.slab_indices,
             slab_offsets=self.slab_offsets.copy() if copy else self.slab_offsets,
             hash_tables=self.hash_tables,
@@ -659,13 +660,7 @@ class StagedChangesArray(MutableMapping[Any, T]):
     ) -> None:
         """Implement common workflow of __setitem__, resize, and load."""
         for shape in plan.append_slabs:
-            slab = empty(shape, dtype=self.dtype)
-            if isinstance(slab, np.ndarray):
-                # This is a __setitem__ / resize / load. Initialise the slab to
-                # fill_value. commit() will later write the whole thing, padding
-                # included, to hdf5 and we don't want to write uninitialised memory.
-                slab[...] = self.fill_value
-            self.slabs.append(slab)
+            self.slabs.append(empty(shape, dtype=self.dtype))
             self.hash_tables.append(None)
 
         for tplan in plan.transfers:
@@ -674,6 +669,8 @@ class StagedChangesArray(MutableMapping[Any, T]):
             assert tplan.dst_slab_idx is not None
             assert tplan.dst_slab_idx > self.n_base_slabs
             dst_slab = self._get_slab(tplan.dst_slab_idx, writeable=True)
+            # Whatever hashes we knew about the destination slab are now stale
+            self.hash_tables[tplan.dst_slab_idx] = None
 
             tplan.transfer(src_slab, dst_slab)
 
@@ -2111,6 +2108,7 @@ class CommitPlan(MutatingPlan):
 
     def __init__(
         self,
+        shape: tuple[int, ...],
         slab_indices: NDArray[np_hsize_t],
         slab_offsets: NDArray[np_hsize_t],
         hash_tables: list[np.ndarray | None],
@@ -2164,6 +2162,10 @@ class CommitPlan(MutatingPlan):
         # beats the base slabs, which beat the staged slabs. Unreferenced base-slab
         # chunks are included too, so a chunk deleted versions ago but still present in
         # raw_data can be reused.
+
+        # Plan to copy full chunks, including for partial edge chunks.
+        # We'll refine the selection later in this method.
+        tplan_count = np.broadcast_to(np_chunk_size, (n_total_transfers, ndim)).copy()
 
         for old_slab_idx in range(len(hash_tables)):
             ht = hash_tables[old_slab_idx]
@@ -2220,12 +2222,9 @@ class CommitPlan(MutatingPlan):
                 tplan.dst_slab_idx = len(hash_tables)
                 tplan.src_start = src_start[out_row - n_slab_transfers : out_row]
                 tplan.dst_start = dst_start[out_row - n_slab_transfers : out_row]
-                # Slightly inefficient: also copy uninitialised data beyond the
-                # border of edge chunks so that we don't have to bother figuring
-                # out their shape here
-                tplan.count = np.broadcast_to(
-                    np_chunk_size, (n_slab_transfers, ndim)
-                ).copy()
+                # Note: this is a view; it's important since we're going to refine
+                # tplan_count values later in this method.
+                tplan.count = tplan_count[out_row - n_slab_transfers : out_row]
                 tplan.src_stride = np.ones((n_slab_transfers, ndim), dtype=np_hsize_t)
                 tplan.dst_stride = tplan.src_stride
                 self.transfers.append(tplan)
@@ -2254,6 +2253,23 @@ class CommitPlan(MutatingPlan):
                 mapped = old_to_new_chunk[loc]
                 slab_indices_flat_view[i] = mapped.slab_idx
                 slab_offsets_flat_view[i] = mapped.slab_offset
+
+        # Trim the edge chunks, so that the transfers never read the uninitialised
+        # padding beyond the edge of a staged slab (which would then be written to
+        # disk). The TransferPlans hold views of `tplan_count`, so this applies
+        # retroactively. Duplicate chunks all share the same trimmed shape, as the shape
+        # is part of the hash, so it's enough to look at one occurrence of each on the
+        # new slab.
+        for dim in range(ndim):
+            last_chunk_idx = self.slab_indices.shape[dim] - 1
+            trim = shape[dim] - last_chunk_idx * chunk_size[dim]
+            if trim == chunk_size[dim]:
+                continue  # No edge chunks along this axis
+            edge = (slice(None),) * dim + (slice(last_chunk_idx, None),)
+            edge_offsets = self.slab_offsets[edge][
+                self.slab_indices[edge] == new_slab_idx
+            ]
+            tplan_count[edge_offsets // cs0, dim] = trim
 
     @property
     def head(self) -> str:

--- a/versioned_hdf5/staged_changes.py
+++ b/versioned_hdf5/staged_changes.py
@@ -1095,7 +1095,7 @@ class StagedChangesArray(MutableMapping[Any, T]):
 
 
 @cython.cclass
-@dataclass(init=False, eq=False, repr=False)
+@dataclass(init=False, eq=False, repr=False, kw_only=True)
 class TransferPlan:
     """Instructions to transfer data:
 
@@ -1251,7 +1251,7 @@ class TransferPlan:
 
 
 @cython.cclass
-@dataclass(init=False, repr=False)
+@dataclass(init=False, repr=False, kw_only=True)
 class GetItemPlan:
     """Instructions to execute StagedChangesArray.__getitem__"""
 
@@ -1375,7 +1375,7 @@ class MutatingPlan:
 
 
 @cython.cclass
-@dataclass(init=False, repr=False)
+@dataclass(init=False, repr=False, kw_only=True)
 class SetItemPlan(MutatingPlan):
     """Instructions to execute StagedChangesArray.__setitem__"""
 
@@ -1530,7 +1530,7 @@ class SetItemPlan(MutatingPlan):
 
 
 @cython.cclass
-@dataclass(init=False, repr=False)
+@dataclass(init=False, repr=False, kw_only=True)
 class LoadPlan(MutatingPlan):
     """Load all chunks that have not been loaded yet from the base slabs."""
 
@@ -1582,7 +1582,7 @@ class LoadPlan(MutatingPlan):
 
 
 @cython.cclass
-@dataclass(init=False, repr=False)
+@dataclass(init=False, repr=False, kw_only=True)
 class ChangesPlan:
     """Instructions to execute StagedChangesArray.changes()."""
 
@@ -1687,7 +1687,7 @@ class ChangesPlan:
 
 
 @cython.cclass
-@dataclass(init=False, repr=False)
+@dataclass(init=False, repr=False, kw_only=True)
 class ResizePlan(MutatingPlan):
     """Instructions to execute StagedChangesArray.resize()"""
 
@@ -1947,7 +1947,7 @@ class ResizePlan(MutatingPlan):
 
 
 @cython.cclass
-@dataclass(repr=False, eq=False)
+@dataclass(eq=False, repr=False, kw_only=True)
 class HashSlabPlan:
     """Container for the plan to a single call to hash_slab"""
 
@@ -1997,7 +1997,7 @@ class HashSlabPlan:
 
 
 @cython.cclass
-@dataclass(init=False, repr=False)
+@dataclass(init=False, repr=False, kw_only=True)
 class HashPlan:
     """Instructions to hash all staged chunks of a StagedChangesArray.
 
@@ -2095,7 +2095,7 @@ class HashPlan:
 
 
 @cython.cclass
-@dataclass(init=False, repr=False)
+@dataclass(init=False, repr=False, kw_only=True)
 class CommitPlan(MutatingPlan):
     """Instructions to execute StagedChangesArray.commit().
 

--- a/versioned_hdf5/staged_changes.py
+++ b/versioned_hdf5/staged_changes.py
@@ -282,7 +282,7 @@ class StagedChangesArray(MutableMapping[Any, T]):
         return cast(NDArray[T], self.slabs[0])
 
     @property
-    def full_hash_table(self) -> NDArray[T] | None:
+    def full_hash_table(self) -> NDArray[np.uint64] | None:
         """The hash_table for the full slab is calculated lazily only when actually
         needed to deduplicate the staged chunks
         """


### PR DESCRIPTION
- Towards #398
- Blocked by and incorporates #525

This PR integrates the hashing system of #514 into StagedChangesArray, which exposes a new `commit(empty=np.empty)` method.

## Brief workflow summary
A less hermetic explanation is available in the documentation changes in this same PR.

The following happens when you call `StagedChangesArray.commit()`:

1. StagedChangesArray generates a `HashPlan` for all staged slabs
2. then it uses the HashPlan to call `slicetools.hash_slab` once per each slab (added in #514)
3. that in turn populates the new `StagedChangesArray.hash_tables` list that runs parallel to `StagedChangesArray.slabs`
4. back to StagedChangesArray, which generates a `CommitPlan`
5. `CommitPlan` ingests all the hashes of the base slabs (loaded from hdf5) plus the newly-generated hashes of the staged chunks
6. `CommitPlan` deduplicates the chunks (full slab wins over base slab that wins over staged slab) using a C++ `std::unordered_map`
7. `CommitPlan` generates a plan to transfer all staged chunks that survived deduplication to a new base slab and generate a new hash_table with the hashes of all the chunks it planned to copy
8. back to `StagedChangesArray`, which invokes the `empty` callback to generate the new base slab. In unit tests, this is `np.empty`. After integration, it will be a writeable view of the h5py `raw_data` dataset, which has just been enlarged to accommodate the new chunks.
9. `StagedChangesArray` invokes `slicestools.read_many_slices` from the staged slabs (np.ndarray) to the base slab, which post integration will be a HDF5 dataset (numpy->hdf5 write added in #505)
10. You now have the following:
  - a new base slab with the new chunks, which is a view to the tail of the `raw_data` HDF5 dataset on disk;
  - a new hash table, which the wrapper just needs to append to the hash table hdf5 dataset on disk;
  - the `StagedChangesArray.changes()` method that returns only slices to either the old or the new base slab; this is transitorily still needed for as long as we use the legacy pure-python function to generate the virtual dataset
  - the `StagedChangesArray.slab_offsets` and `StagedChangesArray.slab_indices` arrays are ready to be trivially iterated upon by the future, heavily cythonized, function that will generate the VDS replacement (stage 2 of #398)

## Out of scope
This PR does NOT trigger `StagedChangesArray.commit()` when a staged dataset leaves its context manager. 
User-facing performance is unaltered as none of the new functionality is actually triggered by final users yet.
Integration will be in scope for one more PR downstream of this.
