### PR TITLE
Fix default fillvalue for object strings

### DIFF
--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -441,3 +441,36 @@ def test_string_dtype(vfile):
         f"fails for r1: {cv['strs'].dtype.metadata=} "
         f"vs. {cv['strs'][:].dtype.metadata=}"
     )
+
+
+def test_object_strings_default_fillvalue(vfile):
+    with vfile.stage_version("v1") as v:
+        # InMemorySparseDataset
+        ds = v.create_dataset("x", shape=(4,), chunks=(2,), dtype=h5py.string_dtype())
+        assert isinstance(ds, InMemorySparseDataset)
+        ds[0] = b"abc"
+        assert ds.fillvalue == b""
+        assert_equal(ds[:], np.array([b"abc", b"", b"", b""], dtype=object))
+
+    v = vfile.get_version_by_name(vfile.current_version)
+    assert_equal(v["x"][:], np.array([b"abc", b"", b"", b""], dtype=object))
+
+    with vfile.stage_version("v2") as v:
+        # InMemoryDataset
+        ds = v["x"]
+        assert isinstance(ds.dataset, InMemoryDataset)
+        assert ds.fillvalue == b""
+        assert_equal(ds[:], np.array([b"abc", b"", b"", b""], dtype=object))
+
+        # InMemoryArrayDataset
+        ds2 = v.create_dataset(
+            "x", data=[b"abc"], chunks=(2,), dtype=h5py.string_dtype()
+        )
+        assert isinstance(ds2.dataset, InMemoryArrayDataset)
+        assert ds2.fillvalue == b""
+
+        # InMemoryArrayDataset -> InMemorySparseDataset
+        ds2.resize((4,))
+        assert isinstance(ds2.dataset, InMemorySparseDataset)
+        assert ds2.fillvalue == b""
+        assert_equal(ds2[:], np.array([b"abc", b"", b"", b""], dtype=object))

--- a/versioned_hdf5/wrappers.py
+++ b/versioned_hdf5/wrappers.py
@@ -1044,7 +1044,9 @@ class InMemorySparseDataset(BufferMixin, FiltersMixin, DatasetLike):
         self._fillvalue = fillvalue
 
         # BufferMixin can later change self.staged_changes.dtype
-        if dtype is not None and not isinstance(dtype, np.dtype):
+        if dtype is None:
+            dtype = np.array([]).dtype
+        elif not isinstance(dtype, np.dtype):
             dtype = np.dtype(dtype)
         self.dtype = dtype
 

--- a/versioned_hdf5/wrappers.py
+++ b/versioned_hdf5/wrappers.py
@@ -1039,17 +1039,22 @@ class InMemorySparseDataset(BufferMixin, FiltersMixin, DatasetLike):
     ):
         self.name = name
         self.attrs = attrs or {}
-        self._fillvalue = fillvalue
         assert isinstance(chunks, tuple)
         self.parent = parent
+        self._fillvalue = fillvalue
+
+        # BufferMixin can later change self.staged_changes.dtype
+        if dtype is not None and not isinstance(dtype, np.dtype):
+            dtype = np.dtype(dtype)
+        self.dtype = dtype
+
         self.staged_changes = StagedChangesArray.full(
             shape=shape,
             chunk_size=chunks,
             dtype=dtype,
-            fill_value=fillvalue,
+            # DatasetLike.fillvalue property sanitizes the value
+            fill_value=self.fillvalue,
         )
-        # BufferMixin can later change self.staged_changes.dtype
-        self.dtype = self.staged_changes.dtype
 
     @property
     def data_dict(self) -> dict[Tuple, Slice | np.ndarray]:


### PR DESCRIPTION
Fix crash in `create_dataset` when creating sparse arrays with object string dtype and omitting the fillvalue.
This PR fixes it to be '' like in all other use cases, coherently with h5py.