### PR TITLE
Redesign the commit stage: RawDataView

### DIFF
--- a/tests/test_slicetools.py
+++ b/tests/test_slicetools.py
@@ -6,6 +6,7 @@ from hypothesis import given
 from hypothesis import strategies as st
 from numpy.testing import assert_equal
 from versioned_hdf5.slicetools import (
+    RawDataView,
     build_slab_indices_and_offsets,
     read_many_slices,
     spaceid_to_slice,
@@ -481,6 +482,26 @@ def test_read_many_slices_array_protocol():
     expect = np.asarray([0, 2, 3, 0])
     read_many_slices(src, dst, src_start=[(2,)], dst_start=[(1,)], count=[(2,)])
     np.testing.assert_equal(dst, expect)
+
+
+@pytest.mark.parametrize("fast", [True, None, False])
+def test_read_many_slices_rawdataview(h5file, fast):
+    src = np.array([[1, 2, 3], [4, 5, 6]])
+    nrows = 3
+    raw = h5file.create_dataset("raw", shape=(nrows, 3), dtype=src.dtype)
+    view = RawDataView(raw, 1, raw.dtype)
+    assert view.shape == (2, 3)
+    assert view.ndim == 2
+    assert view.size == 6
+    assert view.dtype == raw.dtype
+
+    src_start = [[0, 0]]
+    dst_start = [[1, 1]]
+    count = [[1, 2]]
+
+    read_many_slices(src, view, src_start, dst_start, count, fast=fast)
+    expect = [[0, 0, 0], [0, 0, 0], [0, 1, 2]]
+    np.testing.assert_array_equal(raw[:], expect)
 
 
 def test_read_many_slices_fail():

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -3,6 +3,7 @@ import numpy as np
 import numpy.ma as ma
 import pytest
 from packaging.version import Version
+from versioned_hdf5.slicetools import RawDataView
 
 from versioned_hdf5.h5py_compat import h5py_astype
 from versioned_hdf5.staged_changes import StagedChangesArray
@@ -101,3 +102,13 @@ def array_protocol_staged_changes():
     arr = StagedChangesArray.full((3, 3), chunk_size=(3, 1), dtype="f4")
     assert isinstance(arr, ArrayProtocol)
     assert isinstance(arr, MutableArrayProtocol)
+
+
+def test_array_protocol_rawdataview():
+    """RawDataView conforms to the writeable MutableArrayProtocol, so that it satisfies
+    the return type of StagedChangesArray.commit()'s ``empty`` callback, even though its
+    __getitem__/__setitem__/__array__ raise (it must only be used via read_many_slices).
+    """
+    view = RawDataView(np.zeros((4, 3)), offset=1, dtype=np.dtype("i8"))
+    assert isinstance(view, ArrayProtocol)
+    assert isinstance(view, MutableArrayProtocol)

--- a/versioned_hdf5/slicetools.pyx
+++ b/versioned_hdf5/slicetools.pyx
@@ -294,6 +294,44 @@ cdef Exception HDF5Error():
     return RuntimeError(msg)
 
 
+class RawDataView:
+    """A writeable view onto raw_data[offset:], to be used with read_many_slices.
+    """
+    raw_data: Dataset
+    offset: int
+    dtype: np.dtype
+
+    def __init__(self, raw_data: Dataset, offset: int, dtype: np.dtype):
+        self.raw_data = raw_data
+        self.offset = offset
+        # Outwards dtype. This may differ from raw_data.dtype for variable-width strings
+        # (e.g. StringDType staged slabs vs an object-dtype raw_data).
+        self.dtype = dtype
+
+    @property
+    def ndim(self):
+        return self.raw_data.ndim
+
+    @property
+    def shape(self):
+        s = self.raw_data.shape
+        return (s[0] - self.offset, *s[1:])
+
+    @property
+    def size(self):
+        return int(np.prod(self.shape))
+
+    # This class must be exclusively accessed with read_many_slices
+    def __getitem__(self, idx):
+        raise NotImplementedError()
+
+    def __setitem__(self, idx, value):
+        raise NotImplementedError()
+
+    def __array__(self, dtype=None, copy=None):
+        raise NotImplementedError()
+
+
 cpdef void read_many_slices(
     src: ArrayProtocol,
     dst: ArrayProtocol,
@@ -433,6 +471,11 @@ cpdef void read_many_slices(
     if dst.size == 0 or src.size == 0:
         return
 
+    cdef hsize_t dst_axis0_offset = 0
+    if isinstance(dst, RawDataView):
+        dst_axis0_offset = dst.offset
+        dst = dst.raw_data
+
     cdef bint fast_h5_to_np = False
     cdef bint fast_np_to_h5 = False
     if fast is not False:
@@ -446,6 +489,10 @@ cpdef void read_many_slices(
     src_start = _preproc_many_slices_idx(src_start, ndim, bfast)
     dst_start = _preproc_many_slices_idx(dst_start, ndim, bfast)
     count = _preproc_many_slices_idx(count, ndim, bfast)
+
+    if dst_axis0_offset:
+        dst_start = dst_start.copy()
+        dst_start[..., 0] += dst_axis0_offset
 
     if src_stride is None:
         src_stride = np.ones(ndim, dtype=np_hsize_t)


### PR DESCRIPTION
Towards #398

Add a array-like writeable view to raw_data, which will after #521 will be returned by the `empty` callback from the backend to `StagedChangesArray.commit(empty=empty)`