### PR TITLE
Redesign the commit stage: Do not drop base slabs

### DIFF
--- a/docs/staged_changes.rst
+++ b/docs/staged_changes.rst
@@ -329,8 +329,9 @@ be physically filled with the fill_value:
 --------------------
 
 ``LoadPlan`` ensures that all chunks are either on the full slab or on a staged slab. It
-selects all chunks in that lie on a base slab and transfers them to a brand new staged
-slab.
+selects all chunks that lie on a base slab and transfers them to a brand new staged
+slab. The base slabs themselves remain in the ``slabs`` list; they're simply no longer
+referenced by ``slab_indices``.
 
 
 .. _staged_changes_commit:
@@ -432,17 +433,14 @@ updates a chunk with ``__setitem__`` and later drops that very same chunk with
 ``resize()`` - which is obviously wasteful so it should not be part of a typical
 workflow. Additionally, slabs are cleaned up as soon as the staged version is committed.
 
-If a slab is completely empty, however - in other words, it no longer appears in
-``slab_indices`` - it *may* be dropped. This is guaranteed to happen for staged slabs
-and *may* happen for base slabs too (if computationally cheap to determine). Note that
-nothing particular happens today when the ``raw_data`` base slab, which is a hdf5
-dataset,is deferenced by the ``StagedChangesArray``.
-
-When a slab is dropped, it is replaced by None in the ``slabs`` list, which dereferences
-it. This allows not to change all the following slab indices after the operation.
-The full slab is never dropped, as it may be needed later by ``resize()`` to create new
-chunks or partially fill existing edge chunks.
-
+When ``ResizePlan`` shrinks the array, it may cause a slab to no longer be referenced by
+``slab_indices``. When this happens to a *staged* slab, it is dereferenced from the
+``slabs`` list and replaced by None. This avoids having to renumber all the following
+slab indices. **The full slab and the base slabs are never dropped**, even when no
+chunks reference them anymore. The full slab may be needed later by ``resize()`` to
+create new chunks or partially fill existing edge chunks. ``commit()`` needs the hash
+tables of the base slabs to deduplicate staged chunks. As base slabs are disk-backed, it
+is cheap to leave them referenced.
 
 Copy-on-Write (CoW) mechanics
 -----------------------------
@@ -459,13 +457,15 @@ the new dtype, not just the selection requested.
 
 Hot-swapping the base slabs
 ---------------------------
-When calling ``astype()``, base slabs are normally fully loaded into memory and then
-converted with NumPy to the new dtype. This may not be desirable:
-`h5py.Dataset.astype()`_ returns a lazy ``AsTypeView`` object, which directly performs
-dtype conversions in libhdf5, only on the areas selected with ``__getitem__``. To
-leverage this, ``StagedChangesArray.astype()`` has the option of hot-swapping the base
-slabs with any other array-like objects with the new dtype and the same shapes as the
-original slabs.
+When calling ``astype()``, each base slab is fully loaded into memory, converted with
+NumPy to the new dtype, and then dropped. Note that this is different from ``resize()``,
+which instead never drops a base slab as it may be useful later during ``commit()``.
+
+This load and drop may not be desirable: `h5py.Dataset.astype()`_ returns a lazy
+``AsTypeView`` object, which directly performs dtype conversions in libhdf5, only on the
+areas selected with ``__getitem__``. To leverage this, ``StagedChangesArray.astype()``
+accepts a ``base_slabs`` parameter to hot-swap the base slabs with any other array-like
+objects with the new dtype and the same shapes as the original slabs.
 
 
 API interaction

--- a/tests/test_staged_changes.py
+++ b/tests/test_staged_changes.py
@@ -261,7 +261,10 @@ def test_array_protocol_from_slabs():
     arr3 = arr.astype("i4")
     arr.load()
 
-    assert arr.slabs[1] is None
+    # load() does not drop base slabs: it leaves them in the slabs list, unreferenced by
+    # slab_indices. astype(), on the other hand, drops the base slabs, as they don't
+    # contain compatible data anymore.
+    assert arr.slabs[1] is base_slab
     assert arr2.slabs[1] is base_slab
     assert arr3.slabs[1] is None
 
@@ -290,6 +293,8 @@ def test_load():
     arr = StagedChangesArray.from_array(
         np.arange(4).reshape(2, 2), chunk_size=(2, 1), fill_value=42
     )
+    orig_slabs = arr.slabs.copy()
+
     arr.resize((3, 2))
     assert len(arr.slabs) == 3
     assert_array_equal(arr.slab_indices, [[1, 2], [0, 0]])
@@ -300,10 +305,10 @@ def test_load():
     assert_array_equal(arr.slab_indices, [[3, 3], [0, 0]])
     assert_array_equal(arr, np.array([[0, 1], [2, 3], [42, 42]]))
 
-    # Base slabs were dereferenced; full slab was not
-    assert_array_equal(arr.slabs[0], [[42], [42]])
-    assert arr.slabs[1] is None
-    assert arr.slabs[2] is None
+    # Base slabs are no longer referenced by any chunk,
+    # but are still in the slabs list.
+    for lhs, rhs in zip(arr.slabs[: arr.n_base_slabs + 1], orig_slabs, strict=True):
+        assert lhs is rhs
 
     # No-op
     arr.load()
@@ -311,9 +316,8 @@ def test_load():
     assert_array_equal(arr.slab_indices, [[3, 3], [0, 0]])
     assert_array_equal(arr, np.array([[0, 1], [2, 3], [42, 42]]))
 
-    # Edge case where __setitem__ stops using a base slab but doesn't dereference it for
-    # performance reasons, so there are no transfers to do but you still should drop
-    # the base slab
+    # Edge case where __setitem__ stopped using a base slab:
+    # there are no transfers to do, so load() is a no-op.
     arr = StagedChangesArray.from_array(np.arange(2), chunk_size=(2,))
     arr[0] = 2
     assert_array_equal(arr.slab_indices, [2])
@@ -321,7 +325,7 @@ def test_load():
     arr.load()
     assert_array_equal(arr.slab_indices, [2])
     assert len(arr.slabs) == 3  # Didn't append a new slab with size 0
-    assert arr.slabs[1] is None
+    assert arr.slabs[1] is not None
 
 
 def test_load_plan_without_base_slabs():
@@ -361,8 +365,12 @@ def test_resize_through_size_zero():
     size 0, so that no chunks are actually transferred.
     """
     a = StagedChangesArray.from_array(np.arange(12).reshape(2, 6), chunk_size=(2, 3))
+    orig_slabs = a.slabs.copy()
     a.resize((0, 5))  # Shrink to size 0, leaving a partial edge chunk
-    assert a.slabs[1:] == [None, None]
+    # Base slabs are never dropped, even when the array shrinks to size 0
+    assert a.n_base_slabs == 2
+    for lhs, rhs in zip(orig_slabs, a.slabs[:3], strict=True):
+        assert lhs is rhs
     a.resize((0, 8))  # Enlarge the edge chunk and add a new chunk while size stays 0
     a.resize((2, 8))
     assert_array_equal(a, np.zeros((2, 8)))
@@ -384,27 +392,34 @@ def test_size_zero_with_base_slabs():
 
 
 def test_shrinking_dereferences_slabs():
-    """Test that shrinking a StagedChangesArray dereferences the slabs that are no
-    longer referenced by any chunks.
+    """Test that shrinking a StagedChangesArray dereferences the *staged* slabs that are
+    no longer referenced by any chunks. The full slab and the base slabs are never
+    dereferenced.
     """
     arr = StagedChangesArray.from_array(
         [[1, 2, 3, 4, 5, 6, 7]], chunk_size=(1, 2), fill_value=42
     )
-    arr[0, -1] = 8
+    assert arr.n_base_slabs == 4  # slabs 1..4
+    arr[0, -1] = 8  # partial chunk on base slab 4 -> staged slab 5
     arr.resize((1, 10))
     assert_array_equal(arr.slab_indices, [[1, 2, 3, 5, 0]])
     assert_array_equal(arr, [[1, 2, 3, 4, 5, 6, 8, 42, 42, 42]])
 
     arr.resize((1, 4))
     assert_array_equal(arr.slab_indices, [[1, 2]])
-    assert arr.slabs[3:] == [None, None, None]
+    # Base slabs 3 and 4 are no longer referenced, but they are kept; only the staged
+    # slab 5 is dropped.
+    assert arr.slabs[3] is not None
+    assert arr.slabs[4] is not None
+    assert arr.slabs[5] is None
     assert_array_equal(arr, [[1, 2, 3, 4]])
 
     arr.resize((0, 0))
     assert_array_equal(arr.slab_indices, np.empty((0, 0)))
-    # The base slab is never dereferenced
+    # The full slab and all the base slabs are kept; only the staged slab was dropped.
     assert_array_equal(arr.slabs[0], [[42, 42]])
-    assert arr.slabs[1:] == [None, None, None, None, None]
+    assert all(slab is not None for slab in arr.slabs[:5])
+    assert arr.slabs[5:] == [None]
 
 
 @pytest.mark.parametrize("starting_size", [6, 5])
@@ -477,7 +492,7 @@ def test_astype():
     a = StagedChangesArray.from_array(
         np.asarray([[1, 2, 3]], dtype="f4"), chunk_size=(1, 1)
     )
-    a.resize((1, 2))  # dereference a slab
+    a.resize((1, 2))  # leave a base slab unreferenced (but not dropped)
     a.resize((1, 3))
     a[0, 1] = 4
     assert a.n_base_slabs == 3
@@ -523,11 +538,11 @@ def test_astype_base_slabs():
         slab_offsets=[0, 1, 0],
     )
     a[1] = 4  # base slab -> staged slab; chunks remain on the base slab
-    a.resize((2,))  # drop base_slabs[1]
+    a.resize((2,))
     assert a.slab_indices.tolist() == [1, 3]
     assert a.slab_offsets.tolist() == [0, 0]
-    assert a.base_slabs[1] is None
-    base_slabs = [np.array([6, 7], dtype="i2"), None]
+    assert a.base_slabs[1] is not None
+    base_slabs = [np.array([6, 7], dtype="i2"), np.array([0, 0], dtype="i2")]
     b = a.astype("i2", base_slabs=base_slabs)
     assert b.base_slabs[0] is base_slabs[0]
     assert_array_equal(a, np.array([1, 4], dtype="i1"), strict=True)
@@ -538,7 +553,7 @@ def test_astype_base_slabs():
     base_slabs = [np.array([6, 7], dtype="i2"), np.array([8, 9], dtype="i2")]
     b = a.astype("i2", base_slabs=base_slabs)
     assert b.base_slabs[0] is base_slabs[0]
-    assert b.base_slabs[1] is None
+    assert b.base_slabs[1] is base_slabs[1]
     assert_array_equal(b, np.array([6, 4], dtype="i2"), strict=True)
 
     with pytest.raises(TypeError, match=r"base_slabs\[0\] is None"):
@@ -948,16 +963,18 @@ def test_repr():
     )
     r = repr(a._resize_plan((1, 5)))
     assert "2 slice transfers among 2 slab pairs" in r, r
-    assert "drop 1 slabs" in r, r
+    # The base slab becomes unreferenced but is never dropped
+    assert "drop 0 slabs" in r, r
     assert "slabs[2][0:1, 0:2] = slabs[1][0:1, 0:2]" in r, r
 
     r = repr(a._load_plan())
     assert "append 1 empty slab" in r, r
     assert "2 slice transfers among 1 slab pair" in r, r
-    assert "drop 1 slab" in r, r
+    # load() moves the chunks off the base slab, but the base slab is never dropped
+    assert "drop 0 slabs" in r, r
     assert "slabs.append(empty((2, 4)))  # slabs[2]" in r, r
     assert "slabs[2][0:1, 0:2] = slabs[1][0:1, 0:2]" in r, r
-    assert "slabs[1] = None" in r, r
+    assert "slabs[1] = None" not in r, r
 
     a[0, 0] = 5
     r = repr(a._changes_plan())
@@ -966,9 +983,10 @@ def test_repr():
     assert "base[1:2, 0:2] = slabs[1][1:2, 0:2]" in r, r
 
     # MutatingPlan.__repr__ with no appended slabs
-    r = repr(a._resize_plan((1, 2)))
+    r = repr(a._resize_plan((0, 2)))
     assert "append 0 empty slabs" in r, r
-    assert "slabs[1] = None" in r, r
+    assert "slabs[1] = None" not in r, r
+    assert "slabs[2] = None" in r, r
 
 
 def test_invalid_parameters():

--- a/versioned_hdf5/staged_changes.py
+++ b/versioned_hdf5/staged_changes.py
@@ -163,12 +163,10 @@ class StagedChangesArray(MutableMapping[Any, T]):
     #: cells; the shape of each staged slab is always
     #: (n*chunk_size[0], *chunk_size[1:]).
     #:
-    #: When a slab no longer holds any current chunk, it is dereferenced and replaced
-    #: with None in this list. This happens:
-    #: 1. after modifying every chunk of a base slab, so that they now live entirely
-    #:    in the staged slabs, and/or
-    #: 2. when shrinking the array with resize().
-    #: slabs[0] is never dereferenced.
+    #: When resize() shrinks the array, causing a *staged* slab to no longer hold
+    #: any chunk, the slab is dereferenced and
+    #: replaced with None in this list. astype() can instead dereference the base slabs.
+    #: The full slab (index 0) is never dereferenced.
     slabs: list[NDArray[T] | None]
 
     #: List parallel to :attr:`slabs` (same length, None wherever ``slabs`` is None).
@@ -720,9 +718,9 @@ class StagedChangesArray(MutableMapping[Any, T]):
         transfers from a base slab to the new slab, and finally transfers from slabs[0]
         to the new slab.
 
-        Slabs that are no longer needed are dereferenced; their location in the slabs
-        list is replaced with None.
-        This may cause base slabs to be dereferenced, but never the full slab.
+        Staged slabs that are no longer needed are dereferenced; their location in the
+        slabs list is replaced with None.
+        This never causes base slabs or the full slab to be dereferenced.
         """
         if not self.writeable:
             raise ValueError("assignment destination is read-only")
@@ -784,9 +782,7 @@ class StagedChangesArray(MutableMapping[Any, T]):
         the staged slabs.
 
         After this call there are exactly ``n_base_slabs + 2`` slabs: the full slab, the
-        original base slabs (any that are no longer referenced are replaced with None),
-        and the new base slab at index ``n_base_slabs + 1`` (the old ``n_base_slabs``).
-        There are no more staged slabs.
+        original base slabs, and a single new base slab. There are no more staged slabs.
 
         Parameters
         ----------
@@ -885,6 +881,9 @@ class StagedChangesArray(MutableMapping[Any, T]):
             # Load all base slabs, if any, into new staged slabs
             # and set all the base slabs to None
             out.load()
+            for i in range(1, out.n_base_slabs + 1):
+                out.slabs[i] = None
+                out.hash_tables[i] = None
         else:
             # Hot-swap the base slabs
             for i, old in enumerate(out.base_slabs):
@@ -1412,19 +1411,21 @@ class SetItemPlan(MutatingPlan):
            a. create a new empty slab;
            b. transfer the chunk from the base or full slab to the new slab;
            c. update slab_indices and slab_offsets to reflect the transfer;
-           d. potentially dereference the base slab if it contains no other chunks;
-           e. update the new slab with the __setitem__ value.
+           d. update the new slab with the __setitem__ value.
 
         2. A chunk is full of fill_value or lies on a base slab,
            and is wholly covered by the selection:
            a. create a new empty slab;
            b. update the new slab with the __setitem__ value;
            c. update slab_indices and slab_offsets to reflect that the chunk is no
-              longer on the base or full slab;
-           d. potentially dereference the base slab if it contains no other chunks.
+              longer on the base or full slab.
 
         3. A chunk is on a staged slab:
            a. update the staged slab with the __setitem__ value.
+
+        Note that this may leave a base slab without any references to it in
+        ``slab_indices``. The base slab must remain in memory, as it may be used later
+        by ``commit()`` to deduplicate staged chunks.
         """
         super().__init__(slab_indices, slab_offsets)
 
@@ -1515,10 +1516,6 @@ class SetItemPlan(MutatingPlan):
                 )
             )
 
-        # DO NOT perform a full scan of self.slab_indices in order to populate
-        # self.drop_slabs. Everything so far has been O(selected chunks), do not
-        # introduce an operation that is O(all chunks)!
-
     @property
     def head(self) -> str:
         return (
@@ -1569,10 +1566,6 @@ class LoadPlan(MutatingPlan):
                     slab_offsets=slab_offsets,  # Modified in place
                 )
             )
-
-        # Also drop slabs that were previously loaded by SetItemPlan or ResizePlan, but
-        # which were not in SetItemPlan.drop_slabs because of performance reasons.
-        self.drop_slabs.extend(range(1, n_base_slabs + 1))
 
     @property
     def head(self) -> str:
@@ -1789,17 +1782,12 @@ class ResizePlan(MutatingPlan):
                         )
                         prev_shape = next_shape
 
-        # Shrinking may drop any slab. Crucially, they may be staged slabs, and
-        # dereferencing them means releasing memory.
-        # Enlarging may only drop base slabs. Let's not do that, for the same
-        # reason we don't do it in __setitem__: an all-too-common pattern is to
-        # enlarge over and over again by one or a few points.
-        if chunks_dropped:
-            # This may set to None again slabs that were already None. That's fine.
-            # On the upside, it also cleans up slabs dereferenced by __setitem__
-            # or by enlarge operations.
+        # Shrinking may leave staged slabs unreferenced; dereferencing them releases
+        # memory. Do not drop the full slab or base slabs.
+        if chunks_dropped and n_slabs > n_base_slabs + 1:
             self.drop_slabs = np.setdiff1d(
-                np.arange(1, n_slabs, dtype=np_hsize_t),  # Never drop the full slab
+                # Never drop the full slab (0) or the base slabs (1 .. n_base_slabs)
+                np.arange(n_base_slabs + 1, n_slabs, dtype=np_hsize_t),
                 np.unique(self.slab_indices),  # fairly expensive
                 assume_unique=True,
             ).tolist()


### PR DESCRIPTION
- Towards #398
- Blocked by and incorporates #525
- Blocked by and incorporates #521

Revert the policy in StagedChangesArray to dereference base slabs when no longer needed.
This was never useful in practice - a base slab is a h5py array and you won't save any resources by dereferencing it aggressively.

With #398 it becomes beneficial to retain deleted chunks on the base slab, as they can be resuscitated by the deduplication phase of commit().