### PR TITLE
[SECURITY] Fix: delete_versions leaks data when writing corner chunks

### DIFF
--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -9,7 +9,6 @@ from hypothesis import given
 from hypothesis import strategies as st
 from ndindex import Slice
 from numpy.testing import assert_array_equal
-from versioned_hdf5.slicetools import spaceid_to_slice
 
 from versioned_hdf5 import VersionedHDF5File
 from versioned_hdf5.backend import DEFAULT_CHUNK_SIZE
@@ -920,23 +919,66 @@ def test_recreate_virtual_dataset(vfile):
     np.testing.assert_equal(orig_virtual_dataset, new_virtual_dataset)
 
 
-def test_delete_versions_invalidates_cache(vfile):
-    """delete_versions() shuffles the chunks of raw_data around. A version that was read
-    through the same VersionedHDF5File handle beforehand must not keep reading from the
-    stale chunk offsets afterwards.
+def setup_two_versions(vfile):
+    """Create two versions of a 3x3 dataset, the second of which alters a single chunk.
+
+    Return the expected contents of the second version.
     """
     with vfile.stage_version("r0") as sv:
         sv.create_dataset("values", data=np.arange(1, 10).reshape(3, 3), chunks=(2, 2))
     with vfile.stage_version("r1") as sv:
         sv["values"][0, 0] = 100
+    return [[100, 2, 3], [4, 5, 6], [7, 8, 9]]
 
-    expect = np.arange(1, 10).reshape(3, 3)
-    expect[0, 0] = 100
-    assert_array_equal(vfile["r1"]["values"][:], expect)  # Populate the caches
 
-    delete_versions(vfile, ["r0"])
-
+@pytest.mark.parametrize("raw_h5py_file", [False, True])
+def test_delete_versions_invalidates_cache(vfile, raw_h5py_file):
+    """delete_versions() shuffles the chunks of raw_data around. A version that was read
+    through the same VersionedHDF5File handle beforehand must not keep reading from the
+    stale chunk offsets afterwards.
+    """
+    expect = setup_two_versions(vfile)
+    assert_array_equal(vfile["r1"]["values"][:], expect)  # Populate cache
+    delete_versions(vfile.f if raw_h5py_file else vfile, ["r0"])
     assert_array_equal(vfile["r1"]["values"][:], expect)
+
+
+def test_delete_versions_invalidates_other_handle(vfile):
+    """All VersionedHDF5File handles on a file must be invalidated by delete_versions(),
+    not just the one it was called on.
+    """
+    other = VersionedHDF5File(vfile.f)
+    expect = setup_two_versions(vfile)
+    assert_array_equal(other["r1"]["values"][:], expect)  # Populate cache
+    delete_versions(vfile, ["r0"])
+    assert_array_equal(other["r1"]["values"][:], expect)
+
+
+def test_delete_versions_invalidates_held_group(vfile):
+    """A version group obtained before delete_versions() must not keep reading from the
+    stale chunk offsets afterwards.
+    """
+    expect = setup_two_versions(vfile)
+    r1 = vfile["r1"]
+    assert_array_equal(r1["values"][:], expect)  # Populate cache
+    delete_versions(vfile, ["r0"])
+    assert_array_equal(r1["values"][:], expect)
+
+
+@pytest.mark.xfail(
+    reason="A dataset that was already handed out to the user is bound to a virtual "
+    "dataset which delete_versions() deletes and recreates from scratch; it can't be "
+    "repointed to the new one."
+)
+def test_delete_versions_invalidates_held_dataset(vfile):
+    """Same as test_delete_versions_invalidates_held_group, for a dataset that was
+    obtained directly.
+    """
+    expect = setup_two_versions(vfile)
+    values = vfile["r1"]["values"]
+    assert_array_equal(values[:], expect)  # Populate cache
+    delete_versions(vfile, ["r0"])
+    assert_array_equal(values[:], expect)
 
 
 def test_delete_versions_resets_edge_chunk_padding(vfile):

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -9,6 +9,7 @@ from hypothesis import given
 from hypothesis import strategies as st
 from ndindex import Slice
 from numpy.testing import assert_array_equal
+from versioned_hdf5.slicetools import spaceid_to_slice
 
 from versioned_hdf5 import VersionedHDF5File
 from versioned_hdf5.backend import DEFAULT_CHUNK_SIZE
@@ -917,6 +918,67 @@ def test_recreate_virtual_dataset(vfile):
     new_virtual_dataset = vfile.f["_version_data/versions/version2/_tmp_test_data"][:]
 
     np.testing.assert_equal(orig_virtual_dataset, new_virtual_dataset)
+
+
+def test_delete_versions_invalidates_cache(vfile):
+    """delete_versions() shuffles the chunks of raw_data around. A version that was read
+    through the same VersionedHDF5File handle beforehand must not keep reading from the
+    stale chunk offsets afterwards.
+    """
+    with vfile.stage_version("r0") as sv:
+        sv.create_dataset("values", data=np.arange(1, 10).reshape(3, 3), chunks=(2, 2))
+    with vfile.stage_version("r1") as sv:
+        sv["values"][0, 0] = 100
+
+    expect = np.arange(1, 10).reshape(3, 3)
+    expect[0, 0] = 100
+    assert_array_equal(vfile["r1"]["values"][:], expect)  # Populate the caches
+
+    delete_versions(vfile, ["r0"])
+
+    assert_array_equal(vfile["r1"]["values"][:], expect)
+
+
+def test_delete_versions_resets_edge_chunk_padding(vfile):
+    """raw_data must not retain any data from the deleted versions in the padding around
+    the chunks that lie on the edge of the virtual dataset. This includes the corner of
+    a chunk that is truncated along two or more axes at once.
+    """
+    with vfile.stage_version("r0") as sv:
+        sv.create_dataset("values", data=[[1, 2], [3, 4]], chunks=(2, 2))
+    with vfile.stage_version("r1") as sv:
+        sv["values"].resize((3, 3))
+        sv["values"][2, 2] = 5
+    with vfile.stage_version("r2") as sv:
+        sv["values"][:2, :2] = [[6, 7], [8, 9]]
+
+    expect_vds = [
+        [6, 7, 0],
+        [8, 9, 0],
+        [0, 0, 5],
+    ]
+    expect_raw_data = [
+        [1, 2],  # r0 (0, 0)
+        [3, 4],
+        [5, 0],  # r1 (1, 1) (corner)
+        [0, 0],
+        [6, 7],  # r2 (0, 0)
+        [8, 9],
+    ]
+
+    assert_array_equal(vfile["r2"]["values"][:], expect_vds)
+    assert_array_equal(vfile.f["_version_data/values/raw_data"], expect_raw_data)
+
+    delete_versions(vfile, ["r0", "r1"])
+    expect_raw_data2 = [
+        [5, 0],  # r1 (1, 1) (corner)
+        [0, 0],
+        [6, 7],  # r2 (0, 0)
+        [8, 9],
+    ]
+
+    assert_array_equal(vfile["r2"]["values"][:], expect_vds)
+    assert_array_equal(vfile.f["_version_data/values/raw_data"], expect_raw_data2)
 
 
 def test_delete_versions2(vfile):

--- a/versioned_hdf5/api.py
+++ b/versioned_hdf5/api.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import datetime
 import logging
 from contextlib import contextmanager
+from typing import ClassVar
+from weakref import WeakSet
 
 import h5py
 import ndindex
@@ -79,6 +81,8 @@ class VersionedHDF5File:
     should be closed separately.)
     """
 
+    _instances: ClassVar[WeakSet[VersionedHDF5File]] = WeakSet()
+
     def __init__(self, f):
         self.f = f
         if "_version_data" not in f:
@@ -130,6 +134,7 @@ class VersionedHDF5File:
 
         self._closed = False
         self._version_cache = {}
+        VersionedHDF5File._instances.add(self)
 
     @property
     def _versions(self):

--- a/versioned_hdf5/replay.py
+++ b/versioned_hdf5/replay.py
@@ -518,10 +518,7 @@ def delete_versions(
     the version.
     """
     if isinstance(f, VersionedHDF5File):
-        vfile = f
         f = f.f
-    else:
-        vfile = None
 
     version_data = f["_version_data"]
     if isinstance(versions_to_delete, str):
@@ -543,11 +540,6 @@ def delete_versions(
     for name in _walk(version_data):
         _delete_dataset(f, name, versions_to_delete)
 
-    # Invalidate any cached InMemoryGroup's and their contents
-    InMemoryGroup._instances.clear()
-    if vfile is not None:
-        vfile._version_cache.clear()
-
     # find new prev_version which was not deleted
     versions_to_delete_set = set(versions_to_delete)
     for version_name in versions:
@@ -566,6 +558,13 @@ def delete_versions(
         del versions[version_name]
 
     versions.attrs["current_version"] = current_version
+
+    # Invalidate the caches of all live wrappers of this file, as they point to the
+    # chunks of raw_data that we just moved around. Note that this indiscriminately hits
+    # the wrappers of other files too, which is harmless.
+    InMemoryGroup._invalidate_all()
+    for vfile in VersionedHDF5File._instances:
+        vfile._version_cache.clear()
 
     # Collect garbage here to handle intermittent slicing
     # issue; see https://github.com/deshaw/versioned-hdf5/pull/277

--- a/versioned_hdf5/replay.py
+++ b/versioned_hdf5/replay.py
@@ -229,34 +229,23 @@ def _recreate_raw_data(
         chunks.indices(new_shape), sorted_chunks_to_keep, strict=False
     ):
         # Truncate the new slice if it isn't a full chunk
-        to_set_fillvalue = []
+        truncated = False
         new_truncated = []
         for i in range(len(new_chunk.args)):
             end = new_chunk.args[i].start + len(chunk.args[i])
             new_truncated.append(Slice(new_chunk.args[i].start, end))
-
-            # If one dimension is truncated, create slices into
-            # all other dimensions to be set to the fillvalue
             if len(new_chunk.args[i]) != len(chunk.args[i]):
-                to_fill = []
-                for j in range(len(new_chunk.args)):
-                    if j == i:
-                        to_fill.append(Slice(end, new_chunk.args[i].stop))
-                    else:
-                        to_fill.append(
-                            Slice(
-                                new_chunk.args[j].start,
-                                new_chunk.args[j].start + len(chunk.args[j]),
-                            )
-                        )
-                to_set_fillvalue.append(Tuple(*to_fill))
+                truncated = True
 
         new_truncated = Tuple(*new_truncated)
-        raw_data[new_truncated.raw] = raw_data[chunk.raw]
-
-        # Set the fillvalue of any slices which were truncated.
-        for tup in to_set_fillvalue:
-            raw_data[tup.raw] = fillvalue
+        # Read before writing; the destination may be the source itself
+        chunk_data = raw_data[chunk.raw]
+        if truncated:
+            # The chunk lies on the edge of the virtual dataset, so it doesn't cover the
+            # whole raw_data chunk. Reset the padding around it to the fillvalue, so
+            # that no data from the deleted versions lingers in raw_data.
+            raw_data[new_chunk.raw] = fillvalue
+        raw_data[new_truncated.raw] = chunk_data
         raw_data_chunks_map[chunk] = new_truncated
 
     raw_data.resize(new_shape)
@@ -529,7 +518,10 @@ def delete_versions(
     the version.
     """
     if isinstance(f, VersionedHDF5File):
+        vfile = f
         f = f.f
+    else:
+        vfile = None
 
     version_data = f["_version_data"]
     if isinstance(versions_to_delete, str):
@@ -550,6 +542,11 @@ def delete_versions(
 
     for name in _walk(version_data):
         _delete_dataset(f, name, versions_to_delete)
+
+    # Invalidate any cached InMemoryGroup's and their contents
+    InMemoryGroup._instances.clear()
+    if vfile is not None:
+        vfile._version_cache.clear()
 
     # find new prev_version which was not deleted
     versions_to_delete_set = set(versions_to_delete)

--- a/versioned_hdf5/wrappers.py
+++ b/versioned_hdf5/wrappers.py
@@ -99,6 +99,23 @@ class InMemoryGroup(Group):
             if isinstance(obj, InMemoryGroup):
                 obj.close()
 
+    @classmethod
+    def _invalidate_all(cls):
+        """Forget everything that was read from the file, both in the live instances and
+        in the instances registry, so that it is read again on next access.
+
+        This must be called by :func:`~versioned_hdf5.replay.delete_versions`, which
+        moves the chunks of ``raw_data`` around and recreates all virtual datasets
+        pointing to them.
+        """
+        for group in list(cls._instances.values()):
+            # Uncommitted groups hold data that only exists in memory; dropping it
+            # would silently discard the user's staged changes.
+            if group._committed:
+                group._data.clear()
+                group._subgroups.clear()
+        cls._instances.clear()
+
     # Based on Group.__repr__
     def __repr__(self):
         namestr = f'"{self.name}"' if self.name is not None else "(anonymous)"


### PR DESCRIPTION
**Severity: LOW**

A user could
1. write sensitive data to version r1,
2. thoroughly overwrite the contents of the dataset on version r2,
3. call `delete_version(["r1"])`
4. compact database
5. ship the file to a third party that was not meant to see the contents of r1, or store it on low-security storage.

This PR fixes a bug where, when `delete_versions` overwrites a full chunk from r1 with a corner chunk (last chunk along 2+ axes) from r2 that doesn't align exactly with chunk_size, the partial contents of the chunk from r1 that exceed the valid surface of the corner chunk of r2 remain stored in raw_data.