### PR TITLE
Improve hash performance for non-contiguous slabs

### DIFF
--- a/benchmarks/hash.py
+++ b/benchmarks/hash.py
@@ -37,6 +37,7 @@ class TimeHashSlab:
         self.count = np.empty((n_chunks, 2), dtype=np.uint64)
         self.count[:, 0] = chunk_size[0]
         self.count[:, 1] = chunk_size[1] - 1 if edge else chunk_size[1]
+        self.chunk_size = chunk_size
 
     def time_hash_slab(self, chunk_size, edge):
         hash_slab(
@@ -45,7 +46,10 @@ class TimeHashSlab:
             self.hash_rows,
             self.src_start,
             self.count,
+            self.chunk_size,
         )
+
+    peakmem_hash_slab = time_hash_slab
 
     def time_hash_slab_naive(self, chunk_size, edge):
         """Naive Python hashlib reimplementation of hash_slab."""
@@ -61,6 +65,64 @@ class TimeHashSlab:
             h.update(np.ascontiguousarray(chunk))
             h.update(str(chunk.shape).encode("ascii"))
             self.hash_table[hash_row, :] = np.frombuffer(h.digest(), dtype=np.uint64)
+
+
+class TimeHashSlabNonContig:
+    """Benchmark hash_slab with non-C-contiguous slabs.
+
+    **layout**
+
+    step_outer
+        strided along axis 0, contiguous along the innermost axis (hashed as one
+        EVP_DigestUpdate per row, without any copy)
+    transpose
+        transposed slab (chunk-sized scratch buffer path)
+    step_inner
+        strided along the innermost axis (chunk-sized scratch buffer path)
+    broadcast
+        read-only broadcasted slab, e.g. the full slab of a StagedChangesArray
+        (chunk-sized scratch buffer path)
+    """
+
+    params = [["step_outer", "transpose", "step_inner", "broadcast"], CHUNK_SIZES]
+    param_names = ["layout", "chunk_size"]
+
+    def setup(self, layout, chunk_size):
+        rng = np.random.default_rng(42)
+        n_chunks = TOTAL_BYTES // np.prod(chunk_size)
+        n_rows = n_chunks * chunk_size[0]
+        cs1 = chunk_size[1]
+        if layout == "step_outer":
+            self.src = rng.random((2 * n_rows, cs1), dtype=np.float64)[::2]
+        elif layout == "transpose":
+            self.src = rng.random((cs1, n_rows), dtype=np.float64).T
+        elif layout == "step_inner":
+            self.src = rng.random((n_rows, 2 * cs1), dtype=np.float64)[:, ::2]
+        elif layout == "broadcast":
+            self.src = np.broadcast_to(1.5, (n_rows, cs1))
+        else:
+            raise AssertionError("unreachable")  # pragma: nocover
+        assert self.src.shape == (n_rows, cs1)
+
+        self.hash_table = np.zeros((n_chunks, 4), dtype=np.uint64)
+        self.hash_rows = np.arange(n_chunks, dtype=np.uint64)
+        self.src_start = np.arange(0, n_rows, chunk_size[0], dtype=np.uint64)
+        self.count = np.empty((n_chunks, 2), dtype=np.uint64)
+        self.count[:, 0] = chunk_size[0]
+        self.count[:, 1] = cs1
+        self.chunk_size = chunk_size
+
+    def time_hash_slab(self, layout, chunk_size):
+        hash_slab(
+            self.src,
+            self.hash_table,
+            self.hash_rows,
+            self.src_start,
+            self.count,
+            self.chunk_size,
+        )
+
+    peakmem_hash_slab = time_hash_slab
 
 
 class TimeHashSlabStrings:
@@ -103,6 +165,7 @@ class TimeHashSlabStrings:
         self.count = np.empty((n_chunks, 2), dtype=np.uint64)
         self.count[:, 0] = chunk_size[0]
         self.count[:, 1] = chunk_size[1]
+        self.chunk_size = chunk_size
 
     def time_hash_slab(self, dtype, max_nchars, chunk_size):
         hash_slab(
@@ -111,6 +174,7 @@ class TimeHashSlabStrings:
             self.hash_rows,
             self.src_start,
             self.count,
+            self.chunk_size,
         )
 
     def time_hash_slab_naive(self, dtype, max_nchars, chunk_size):

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -396,15 +396,6 @@ def test_step_inner_axis_3d():
     assert hash_single_chunk(slab) == reference(slab)
 
 
-def test_single_chunk_larger_than_lot():
-    """Test when a single non-C-contiguous chunk is larger than the ~2 MiB lot size"""
-    base = np.arange(5 * 1000002, dtype="u1").reshape(5, 1000002)
-    slab = base[:, ::2]  # shape (5, 500001): 2.5 MB > 2 MiB, strided innermost axis
-    assert slab.nbytes > 2 * 1024 * 1024
-    assert slab.strides[-1] != slab.dtype.itemsize
-    assert hash_single_chunk(slab) == reference(slab)
-
-
 def test_step_outer_axis():
     # Contiguous along the innermost axis only; rows are contiguous runs
     slab = np.arange(60, dtype="i8").reshape(6, 10)[::2]

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -58,13 +58,13 @@ def test_multiple_chunks_route_to_rows():
     """
     slab = np.arange(16, dtype="i4")  # 4 chunks
     ht = np.zeros((4, 4), dtype=np.uint64)
-    # Hash chunks 0 and 3 only, and (to prove hash_rows is honoured)
-    # deliberately route chunk at offset 8 to row 2.
+    # Hash chunks 0, 2 and 3 (skipping chunk 1), and (to prove hash_rows is honoured)
+    # deliberately route chunk at offset 8 to row 2 and the one at offset 12 to row 3.
     hash_slab(
         slab,
         ht,
-        np.array([0, 3, 2], dtype=np_hsize_t),
-        np.array([0, 12, 8], dtype=np_hsize_t),
+        np.array([0, 2, 3], dtype=np_hsize_t),
+        np.array([0, 8, 12], dtype=np_hsize_t),
         np.array([[4], [4], [4]], dtype=np_hsize_t),
         (4,),
     )
@@ -396,6 +396,15 @@ def test_step_inner_axis_3d():
     assert hash_single_chunk(slab) == reference(slab)
 
 
+def test_single_chunk_larger_than_lot():
+    """Test when a single non-C-contiguous chunk is larger than the ~2 MiB lot size"""
+    base = np.arange(5 * 1000002, dtype="u1").reshape(5, 1000002)
+    slab = base[:, ::2]  # shape (5, 500001): 2.5 MB > 2 MiB, strided innermost axis
+    assert slab.nbytes > 2 * 1024 * 1024
+    assert slab.strides[-1] != slab.dtype.itemsize
+    assert hash_single_chunk(slab) == reference(slab)
+
+
 def test_step_outer_axis():
     # Contiguous along the innermost axis only; rows are contiguous runs
     slab = np.arange(60, dtype="i8").reshape(6, 10)[::2]
@@ -558,17 +567,20 @@ def test_hypothesis_single_chunk(slab_and_name):
 
 @given(_slabs(), st.data())
 def test_hypothesis_multichunk(slab_and_name, data):
-    """Random chunks carved out of a randomly strided slab."""
+    """Random tiled chunks carved out of a randomly strided slab."""
     _, slab = slab_and_name
     ndim = slab.ndim
-    if slab.shape[0] < 2:
-        return  # need room for at least an offset chunk
-    nchunks = data.draw(st.integers(1, min(3, slab.shape[0])))
+    # Chunks partition the slab's rows: draw the physical chunk width and how
+    # many chunks fit, then trim the counts along the other axes randomly.
+    chunk_size_0 = data.draw(st.integers(1, slab.shape[0]))
+    nchunks = data.draw(
+        st.integers(1, (slab.shape[0] + chunk_size_0 - 1) // chunk_size_0)
+    )
     src_start = []
     counts = []
-    for _ in range(nchunks):
-        start = data.draw(st.integers(0, slab.shape[0] - 1))
-        c0 = data.draw(st.integers(1, slab.shape[0] - start))
+    for i in range(nchunks):
+        start = i * chunk_size_0
+        c0 = min(chunk_size_0, slab.shape[0] - start)
         count = [c0]
         for j in range(1, ndim):
             count.append(data.draw(st.integers(1, slab.shape[j])))
@@ -668,8 +680,8 @@ def test_no_collision_multichunk_geometry():
     each other; the shape suffix of one chunk must not leak into the next.
     """
     slab = np.zeros((6, 4), dtype="i8")
-    starts = [0, 1, 3, 2]
-    counts = [(1, 4), (2, 2), (3, 1), (4, 4)]
+    starts = [0, 1, 2, 3]
+    counts = [(1, 4), (1, 2), (1, 1), (3, 4)]
     ht = np.zeros((4, 4), dtype=np.uint64)
     hash_slab(
         slab,

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -8,6 +8,8 @@ import struct
 
 import numpy as np
 import pytest
+from hypothesis import given
+from hypothesis import strategies as st
 from versioned_hdf5.hash import hash_slab
 
 from versioned_hdf5.cytools import np_hsize_t
@@ -45,6 +47,7 @@ def test_single_chunk():
         np.array([0], dtype=np_hsize_t),
         np.array([0], dtype=np_hsize_t),
         np.array([[10]], dtype=np_hsize_t),
+        (10,),
     )
     assert rows_as_digests(ht)[0] == reference(slab)
 
@@ -63,6 +66,7 @@ def test_multiple_chunks_route_to_rows():
         np.array([0, 3, 2], dtype=np_hsize_t),
         np.array([0, 12, 8], dtype=np_hsize_t),
         np.array([[4], [4], [4]], dtype=np_hsize_t),
+        (4,),
     )
     digests = rows_as_digests(ht)
     assert digests[0] == reference(slab[0:4])
@@ -84,7 +88,7 @@ def test_edge_chunk_ignores_uninitialised_memory():
     rows = np.array([0, 1], dtype=np_hsize_t)
 
     ht = np.zeros((2, 4), dtype=np.uint64)
-    hash_slab(slab, ht, rows, src_start, count)
+    hash_slab(slab, ht, rows, src_start, count, (3, 5))
     h0, h1 = rows_as_digests(ht)
     assert h0 == reference(slab[0:3, :])
     assert h1 == reference(slab[3:5, :])
@@ -92,7 +96,7 @@ def test_edge_chunk_ignores_uninitialised_memory():
     # Poison the uninitialised row and re-hash: the digests must be unchanged.
     slab[5] = 999
     ht2 = np.zeros((2, 4), dtype=np.uint64)
-    hash_slab(slab, ht2, rows, src_start, count)
+    hash_slab(slab, ht2, rows, src_start, count, (3, 5))
     assert rows_as_digests(ht2) == [h0, h1]
 
 
@@ -109,6 +113,7 @@ def test_column_edge_is_made_contiguous():
         np.array([0], dtype=np_hsize_t),
         np.array([0], dtype=np_hsize_t),
         np.array([[4, 3]], dtype=np_hsize_t),
+        (4, 5),
     )
     sub = slab[0:4, 0:3]
     assert not sub.flags.c_contiguous
@@ -128,6 +133,7 @@ def test_full_slab_broadcast():
         np.array([0], dtype=np_hsize_t),
         np.array([0], dtype=np_hsize_t),
         np.array([[3, 4]], dtype=np_hsize_t),
+        (3, 4),
     )
     assert rows_as_digests(ht)[0] == reference(np.full((3, 4), 42, dtype="u2"))
 
@@ -142,6 +148,7 @@ def test_empty_chunk():
         np.array([0], dtype=np_hsize_t),
         np.array([0], dtype=np_hsize_t),
         np.array([[0, 3]], dtype=np_hsize_t),
+        (1, 3),
     )
     (h,) = rows_as_digests(ht)
     assert h == hashlib.sha256(b"(0, 3)").digest()
@@ -157,6 +164,7 @@ def test_no_chunks_is_noop():
         np.zeros(0, dtype=np_hsize_t),
         np.zeros(0, dtype=np_hsize_t),
         np.zeros((0, 1), dtype=np_hsize_t),
+        (1,),
     )
     assert rows_as_digests(ht) == [b"\x00" * 32]  # Never written
 
@@ -176,6 +184,7 @@ def test_pod_dtypes_multichunk(dtype):
         np.array([0, 1, 2], dtype=np_hsize_t),
         np.array([0, 2, 4], dtype=np_hsize_t),
         np.array([[2], [2], [2]], dtype=np_hsize_t),
+        (2,),
     )
     digests = rows_as_digests(ht)
     for j, start in ((0, 0), (1, 2), (2, 4)):
@@ -191,6 +200,7 @@ def test_object_slab():
         np.array([0, 1, 2], dtype=np_hsize_t),
         np.array([0, 2, 4], dtype=np_hsize_t),
         np.array([[2], [2], [2]], dtype=np_hsize_t),
+        (2,),
     )
     digests = rows_as_digests(ht)
     for j, start in enumerate([0, 2, 4]):
@@ -203,7 +213,7 @@ def test_object_edge_chunk_ignores_uninitialised():
     count = np.array([[1]], dtype=np_hsize_t)  # only "ccc"
     rows = np.array([0], dtype=np_hsize_t)
     ht = np.zeros((1, 4), dtype=np.uint64)
-    hash_slab(slab, ht, rows, src_start, count)
+    hash_slab(slab, ht, rows, src_start, count, (1,))
     assert rows_as_digests(ht)[0] == reference(slab[2:3])
 
 
@@ -217,6 +227,7 @@ def test_npystrings_slab():
         np.array([0, 1], dtype=np_hsize_t),
         np.array([0, 2], dtype=np_hsize_t),
         np.array([[2], [2]], dtype=np_hsize_t),
+        (2,),
     )
     digests = rows_as_digests(ht)
     assert digests[0] == reference(slab[0:2])
@@ -232,6 +243,7 @@ def test_identical_chunks_same_hash():
         np.array([0, 1], dtype=np_hsize_t),
         np.array([0, 2], dtype=np_hsize_t),
         np.array([[2], [2]], dtype=np_hsize_t),
+        (2,),
     )
     assert rows_as_digests(ht)[0] == rows_as_digests(ht)[1]
 
@@ -265,6 +277,7 @@ def hash_chunk(
         np.array([0], dtype=np_hsize_t),
         np.array([src_start], dtype=np_hsize_t),
         np.array([count], dtype=np_hsize_t),
+        count,
     )
     digest = rows_as_digests(ht)[0]
     idx = (slice(src_start, src_start + count[0]), *(slice(c) for c in count[1:]))
@@ -320,6 +333,264 @@ def test_no_collision_vlen_empty_and_nul():
     ]
     digests = {hash_chunk(case, dtype=object) for case in cases}
     assert len(digests) == len(cases)
+
+
+# ------------------------------------------------------------------------------
+# Non-contiguous input geometries
+#
+# hash_slab may be handed any NumPy view as a slab: transposed, stepped along any
+# axis, broadcast, reversed, or combinations thereof. In all cases the digest must
+# match the C-contiguous materialization of the chunk.
+# ------------------------------------------------------------------------------
+
+
+def make_ht(n):
+    return np.zeros((n, 4), dtype=np.uint64)
+
+
+def hash_single_chunk(slab, count=None):
+    """Hash the whole of ``slab`` (or its ``count``-trimmed prefix) as one chunk."""
+    count = slab.shape if count is None else count
+    ht = make_ht(1)
+    hash_slab(
+        slab,
+        ht,
+        np.array([0], dtype=np_hsize_t),
+        np.array([0], dtype=np_hsize_t),
+        np.array([count], dtype=np_hsize_t),
+        count,
+    )
+    return rows_as_digests(ht)[0]
+
+
+def test_transposed_2d():
+    slab = np.arange(30, dtype="i8").reshape(5, 6).T  # F-contiguous
+    assert not slab.flags.c_contiguous
+    assert hash_single_chunk(slab) == reference(slab)
+
+
+def test_transposed_3d():
+    a = np.arange(60, dtype="f4").reshape(3, 4, 5)
+    for perm in [(1, 0, 2), (2, 1, 0), (0, 2, 1), (2, 0, 1)]:
+        slab = a.transpose(perm)
+        assert hash_single_chunk(slab) == reference(slab)
+
+
+def test_fortran_order():
+    slab = np.asfortranarray(np.arange(24, dtype="i2").reshape(4, 6))
+    assert slab.flags.f_contiguous
+    assert not slab.flags.c_contiguous
+    assert hash_single_chunk(slab) == reference(slab)
+
+
+def test_step_inner_axis():
+    # Non-contiguous along the innermost axis
+    slab = np.arange(40, dtype="i8").reshape(4, 10)[:, ::2]
+    assert slab.strides[-1] != slab.dtype.itemsize
+    assert hash_single_chunk(slab) == reference(slab)
+
+
+def test_step_inner_axis_3d():
+    slab = np.arange(120, dtype="i8").reshape(4, 5, 6)[:, ::3, ::2]
+    assert slab.strides[-1] != slab.dtype.itemsize
+    assert hash_single_chunk(slab) == reference(slab)
+
+
+def test_step_outer_axis():
+    # Contiguous along the innermost axis only; rows are contiguous runs
+    slab = np.arange(60, dtype="i8").reshape(6, 10)[::2]
+    assert slab.strides[-1] == slab.dtype.itemsize
+    assert not slab.flags.c_contiguous
+    assert hash_single_chunk(slab) == reference(slab)
+
+
+def test_step_middle_axis():
+    slab = np.arange(120, dtype="i8").reshape(4, 5, 6)[:, ::2]
+    assert slab.strides[-1] == slab.dtype.itemsize
+    assert not slab.flags.c_contiguous
+    assert hash_single_chunk(slab) == reference(slab)
+
+
+def test_trailing_axes_contiguous_3d():
+    # Contiguous along axes 1 and 2, but not along axis 0
+    slab = np.arange(180, dtype="i8").reshape(6, 5, 6)[::2]
+    assert slab.strides == (60 * 8, 6 * 8, 8)
+    assert hash_single_chunk(slab) == reference(slab)
+
+
+def test_reversed_axis_0():
+    slab = np.arange(30, dtype="i8").reshape(5, 6)[::-1]
+    assert slab.strides[0] < 0
+    assert hash_single_chunk(slab) == reference(slab)
+
+
+def test_reversed_all_axes():
+    slab = np.arange(60, dtype="i8").reshape(3, 4, 5)[::-1, ::-1, ::-1]
+    assert all(s < 0 for s in slab.strides)
+    assert hash_single_chunk(slab) == reference(slab)
+
+
+def test_broadcast_inner_axis():
+    # Zero stride on axis 0, contiguous innermost axis
+    slab = np.broadcast_to(np.arange(1, 5, dtype="i8"), (3, 4))
+    assert slab.strides == (0, 8)
+    assert hash_single_chunk(slab) == reference(slab)
+
+
+def test_broadcast_full_2d():
+    slab = np.broadcast_to(np.array(7, dtype="i4"), (3, 5))
+    assert slab.strides == (0, 0)
+    assert hash_single_chunk(slab) == reference(slab)
+
+
+def test_broadcast_full_3d():
+    slab = np.broadcast_to(1.5, (2, 3, 4))
+    assert hash_single_chunk(slab) == reference(slab)
+
+
+def test_broadcast_1d():
+    slab = np.broadcast_to(np.uint8(3), (7,))
+    assert slab.strides == (0,)
+    assert hash_single_chunk(slab) == reference(slab)
+
+
+def test_expand_dims():
+    slab = np.arange(12, dtype="i8").reshape(4, 3)[:, np.newaxis, :]
+    assert hash_single_chunk(slab) == reference(slab)
+
+
+def test_transposed_then_stepped():
+    slab = np.arange(60, dtype="i8").reshape(5, 12).T[::3]
+    assert slab.strides[-1] != slab.dtype.itemsize
+    assert hash_single_chunk(slab) == reference(slab)
+
+
+def test_strided_slab_multichunk():
+    """Multiple chunks, with edge trimming and hash row permutation, carved out of a
+    stepped (outer axis) slab: the chunk axis-0 offset must use the real stride.
+    """
+    slab = np.arange(80, dtype="i8").reshape(8, 10)[::2]  # shape (4, 10)
+    # 2 chunks of 2 rows each, second one edge-trimmed to 1 row and 7 columns
+    src_start = [0, 2]
+    counts = [(2, 10), (1, 7)]
+    ht = make_ht(2)
+    hash_slab(
+        slab,
+        ht,
+        np.array([1, 0], dtype=np_hsize_t),
+        np.array(src_start, dtype=np_hsize_t),
+        np.array(counts, dtype=np_hsize_t),
+        (2, 10),
+    )
+    digests = rows_as_digests(ht)
+    assert digests[1] == reference(slab[0:2, :10])
+    assert digests[0] == reference(slab[2:3, :7])
+
+
+def test_transposed_slab_multichunk():
+    slab = np.arange(40, dtype="i4").reshape(4, 10).T  # shape (10, 4)
+    ht = make_ht(2)
+    hash_slab(
+        slab,
+        ht,
+        np.array([0, 1], dtype=np_hsize_t),
+        np.array([0, 5], dtype=np_hsize_t),
+        np.array([(5, 4), (5, 3)], dtype=np_hsize_t),
+        (5, 4),
+    )
+    digests = rows_as_digests(ht)
+    assert digests[0] == reference(slab[0:5, :4])
+    assert digests[1] == reference(slab[5:10, :3])
+
+
+def test_object_strided_slab():
+    slab = np.array([b"a", "bb", b"ccc", "dddd", "e", "ff"], dtype=object)[::2]
+    assert hash_single_chunk(slab) == reference(slab)
+
+
+# ------------------------------------------------------------------------------
+# Hypothesis: randomized slab geometries
+# ------------------------------------------------------------------------------
+
+
+def _transformations(a: np.ndarray, rng):
+    """Yield a handful of strided/broadcast views of ``a``."""
+    yield "identity", a
+    if a.ndim >= 2:
+        yield "transpose", a.T
+        yield "fortran", np.asfortranarray(a)
+    yield "step0", a[:: 1 + rng.integers(1, 3)]
+    if a.ndim >= 2:
+        yield "step_inner", a[..., :: 1 + rng.integers(1, 3)]
+        yield "step0_step_inner", a[::2, ..., ::2]
+    if a.ndim >= 3:
+        yield "step1", a[:, :: 1 + rng.integers(1, 3)]
+    yield "reverse0", a[::-1]
+    if a.ndim >= 2:
+        yield "reverse_all", a[::-1, ..., ::-1]
+    yield "expand0", a[np.newaxis]
+    yield "expand_inner", a[..., np.newaxis]
+
+
+@st.composite
+def _slabs(draw):
+    ndim = draw(st.integers(1, 3))
+    shape = tuple(draw(st.integers(1, 5)) for _ in range(ndim))
+    dtype = draw(st.sampled_from(["i8", "i4", "u1", "f8"]))
+    a = np.arange(int(np.prod(shape)), dtype=dtype).reshape(shape)
+    rng = np.random.default_rng(draw(st.integers(0, 2**32 - 1)))
+    name, slab = draw(st.sampled_from(list(_transformations(a, rng))))
+    return name, slab
+
+
+@pytest.mark.parametrize("dtype", VLEN_DTYPES)
+def test_strided_single_chunk_object(dtype):
+    slab = np.array(["a", "bb", "", "ccc", "dddd", "e"], dtype=dtype)[::2]
+    assert hash_single_chunk(slab) == reference(slab)
+
+
+@given(_slabs())
+def test_hypothesis_single_chunk(slab_and_name):
+    _, slab = slab_and_name
+    digest = hash_single_chunk(slab)
+    assert digest == reference(slab)
+
+
+@given(_slabs(), st.data())
+def test_hypothesis_multichunk(slab_and_name, data):
+    """Random chunks carved out of a randomly strided slab."""
+    _, slab = slab_and_name
+    ndim = slab.ndim
+    if slab.shape[0] < 2:
+        return  # need room for at least an offset chunk
+    nchunks = data.draw(st.integers(1, min(3, slab.shape[0])))
+    src_start = []
+    counts = []
+    for _ in range(nchunks):
+        start = data.draw(st.integers(0, slab.shape[0] - 1))
+        c0 = data.draw(st.integers(1, slab.shape[0] - start))
+        count = [c0]
+        for j in range(1, ndim):
+            count.append(data.draw(st.integers(1, slab.shape[j])))
+        src_start.append(start)
+        counts.append(count)
+    # hash_rows may repeat/permute freely
+    hash_rows = np.arange(nchunks, dtype=np_hsize_t)[::-1].copy()
+    ht = make_ht(nchunks)
+    counts_arr = np.array(counts, dtype=np_hsize_t)
+    hash_slab(
+        slab,
+        ht,
+        hash_rows,
+        np.array(src_start, dtype=np_hsize_t),
+        counts_arr,
+        tuple(counts_arr.max(axis=0)),
+    )
+    digests = rows_as_digests(ht)
+    for i in range(nchunks):
+        idx = (slice(src_start[i], src_start[i] + counts[i][0]),)
+        idx += tuple(slice(c) for c in counts[i][1:])
+        assert digests[hash_rows[i]] == reference(slab[idx])
 
 
 GEOMETRIES = [(6,), (1, 6), (6, 1), (2, 3), (3, 2), (1, 1, 6), (1, 6, 1), (6, 1, 1)]
@@ -406,6 +677,7 @@ def test_no_collision_multichunk_geometry():
         np.array([0, 1, 2, 3], dtype=np_hsize_t),
         np.array(starts, dtype=np_hsize_t),
         np.array(counts, dtype=np_hsize_t),
+        (4, 4),
     )
     digests = rows_as_digests(ht)
     assert digests == [

--- a/tests/test_hash_legacy_compat.py
+++ b/tests/test_hash_legacy_compat.py
@@ -34,6 +34,7 @@ def hash_one(chunk: np.ndarray) -> bytes:
         np.zeros(1, dtype=np_hsize_t),  # hash_rows
         np.zeros(1, dtype=np_hsize_t),  # src_start
         np.asarray([chunk.shape], dtype=np_hsize_t),  # count
+        chunk.shape,
     )
     return hash_table[0].view(np.uint8).tobytes()
 

--- a/versioned_hdf5/hash.pxd
+++ b/versioned_hdf5/hash.pxd
@@ -12,4 +12,5 @@ cpdef void hash_slab(
     hsize_t[::1] hash_rows,
     hsize_t[::1] src_start,
     hsize_t[:, ::1] count,
+    chunk_size,  # tuple[int, ...]
 ) except *

--- a/versioned_hdf5/hash.pyx
+++ b/versioned_hdf5/hash.pyx
@@ -15,6 +15,7 @@ from numpy cimport npy_intp, NPY_MAXDIMS
 from libc.stddef cimport size_t
 from libc.stdint cimport uint64_t
 from libc.stdio cimport snprintf
+from libc.string cimport memcpy
 
 from versioned_hdf5.cytools cimport hsize_t
 
@@ -77,7 +78,8 @@ cpdef void hash_slab(
     ----------
     src:
         The slab to read from; always a NumPy array (a staged slab, or the broadcasted
-        full slab).
+        full slab). Slabs that are not C-contiguous along the innermost axis are
+        hashed through a chunk-sized scratch buffer; other axes may be strided.
         Note that non-NumPy base slabs (e.g. backed by h5py) are never hashed here;
         their hashes are loaded from disk.
     hash_table:
@@ -88,10 +90,7 @@ cpdef void hash_slab(
         the digest of that chunk to.
     src_start:
         1D array with one element per chunk. ``src_start[i]`` is the offset along
-        axis 0 of chunk i within its slab, strictly monotonic increasing. Chunks must
-        occupy disjoint row ranges (two chunks never share a slab row); gaps
-        between chunks are allowed (e.g. caused by edge chunks). Offsets on all
-        other axes are always 0.
+        axis 0 of chunk i within its slab. Offsets on all other axes are always 0.
     count:
         2D array of shape ``(nchunks, ndim)`` with the edge-trimmed shape of each chunk,
         i.e. the actual number of valid points along each axis.
@@ -107,14 +106,6 @@ cpdef void hash_slab(
     cdef hsize_t stride0
     cdef hsize_t offset
     cdef hsize_t n_contig
-    cdef hsize_t bytes_per_chunk
-    cdef hsize_t chunks_per_lot
-    cdef hsize_t lot_begin
-    cdef hsize_t lot_end
-    cdef hsize_t lot_start
-    cdef hsize_t lot_stop
-    cdef hsize_t lot_stride0
-    cdef hsize_t chunk_size0
     cdef np.ndarray scratch
 
     assert src.ndim == ndim
@@ -150,7 +141,6 @@ cpdef void hash_slab(
         # Special case: an empty slab also has all-zero strides, but a None base;
         # fall through to Case 3 instead.
         scratch = np.full(chunk_size, fill_value=src.flat[0], dtype=src.dtype)
-
         with nogil:
             for i in range(nchunks):
                 _hash_chunk_from_ptr(
@@ -164,50 +154,28 @@ cpdef void hash_slab(
                 )
 
     elif src.strides[ndim - 1] != itemsize:
-        # Case 3: the innermost axis is strided. Copy chunks in lots of up to ~2 MiB to
-        # a C-contiguous buffer, then hash each chunk in the lot.
-        chunk_size0 = <hsize_t>chunk_size[0]
-        bytes_per_chunk = itemsize * chunk_size0
-        for j in range(1, ndim):
-            bytes_per_chunk *= src.shape[j]
-        if bytes_per_chunk == 0:
-            chunks_per_lot = nchunks
-        else:
-            chunks_per_lot = max(1, (2 * 1024 * 1024) // bytes_per_chunk)
-
-        for lot_begin in range(0, nchunks, chunks_per_lot):
-            lot_end = min(lot_begin + chunks_per_lot, nchunks)
-            # Copy the row span covering every chunk of the lot. Chunks never
-            # overlap, so this (clamped at the slab edge) contains each chunk in
-            # full; gaps between chunks are copied along but never hashed.
-            lot_start = src_start[lot_begin]
-            lot_stop = src_start[lot_end] if lot_end < nchunks else src.shape[0]
-            scratch = np.ascontiguousarray(src[lot_start:lot_stop])
-
-            with nogil:
-                lot_stride0 = scratch.strides[0]
-                for i in range(lot_begin, lot_end):
-                    # Byte offset of chunk i within the lot: the lot copy starts at row
-                    # lot_start, and every chunk lies fully inside it.
-                    offset = (src_start[i] - lot_start) * lot_stride0
-                    # The lot is fully C-contiguous, but an edge chunk may be trimmed
-                    # along some axis: count the trailing axes that form one contiguous
-                    # run, as in Case 4.
-                    n_contig = 1
-                    for j in range(ndim - 2, -1, -1):
-                        if scratch.strides[j] != scratch.strides[j + 1] * count[i, j + 1]:
-                            break
-                        n_contig += 1
-
-                    _hash_chunk_from_ptr(
-                        <const unsigned char*>scratch.data + offset,
-                        &hash_table[hash_rows[i], 0],
-                        count[i],
-                        ndim,
-                        n_contig,
-                        itemsize,
-                        scratch.strides,
-                    )
+        # Case 3: the innermost axis is strided. Deep-copy each chunk into a chunk-sized
+        # scratch buffer and hash it as a contiguous blob.
+        scratch = np.empty(chunk_size, dtype=src.dtype)
+        with nogil:
+            for i in range(nchunks):
+                _copy_chunk(
+                    <const unsigned char*>src.data + src.strides[0] * src_start[i],
+                    <unsigned char*>scratch.data,
+                    count[i],
+                    ndim,
+                    itemsize,
+                    src.strides,
+                )
+                _hash_chunk_from_ptr(
+                    <const unsigned char*>scratch.data,
+                    &hash_table[hash_rows[i], 0],
+                    count[i],
+                    ndim,
+                    ndim,
+                    itemsize,
+                    scratch.strides,
+                )
 
     else:
         # Case 4 (general, most common case): Non-object slab, at least C-contiguous
@@ -271,6 +239,47 @@ cdef void _hash_shape(EVP_MD_CTX* ctx, hsize_t* shape, int ndim) noexcept nogil:
         )
 
     EVP_DigestUpdate(ctx, shape_buf, nchars)
+
+
+cdef void _copy_chunk(
+    const unsigned char* src_ptr,
+    unsigned char* dst,
+    hsize_t[::1] shape,
+    hsize_t ndim,
+    hsize_t itemsize,
+    npy_intp* strides,
+) noexcept nogil:
+    """Deep-copy an edge-trimmed chunk into a C-contiguous scratch buffer.
+
+    nogil, C-friendly equivalent of np.ascontiguousarray().
+    """
+    cdef hsize_t[NPY_MAXDIMS] outer_idx
+    cdef hsize_t outer_total = 1
+    cdef hsize_t inner = shape[ndim - 1]
+    cdef hsize_t outer, k
+    cdef npy_intp offset
+    cdef const unsigned char* src_row
+
+    for k in range(ndim - 1):
+        outer_idx[k] = 0
+        outer_total *= shape[k]
+
+    for outer in range(outer_total):
+        offset = 0
+        for k in range(ndim - 1):
+            offset += outer_idx[k] * strides[k]
+        src_row = src_ptr + offset
+
+        for k in range(inner):
+            memcpy(dst, src_row + k * strides[ndim - 1], itemsize)
+            dst += itemsize
+
+        # Advance the indices of the leading axes
+        for k in range(ndim - 2, -1, -1):
+            outer_idx[k] += 1
+            if outer_idx[k] < shape[k]:
+                break
+            outer_idx[k] = 0
 
 
 cdef int _hash_chunk_from_ptr(

--- a/versioned_hdf5/hash.pyx
+++ b/versioned_hdf5/hash.pyx
@@ -15,7 +15,6 @@ from numpy cimport npy_intp, NPY_MAXDIMS
 from libc.stddef cimport size_t
 from libc.stdint cimport uint64_t
 from libc.stdio cimport snprintf
-from libc.string cimport memcpy
 
 from versioned_hdf5.cytools cimport hsize_t
 
@@ -79,7 +78,7 @@ cpdef void hash_slab(
     src:
         The slab to read from; always a NumPy array (a staged slab, or the broadcasted
         full slab). Slabs that are not C-contiguous along the innermost axis are
-        hashed through a chunk-sized scratch buffer; other axes may be strided.
+        hashed through a per-chunk C-contiguous copy; other axes may be strided.
         Note that non-NumPy base slabs (e.g. backed by h5py) are never hashed here;
         their hashes are loaded from disk.
     hash_table:
@@ -154,28 +153,23 @@ cpdef void hash_slab(
                 )
 
     elif src.strides[ndim - 1] != itemsize:
-        # Case 3: the innermost axis is strided. Deep-copy each chunk into a chunk-sized
-        # scratch buffer and hash it as a contiguous blob.
-        scratch = np.empty(chunk_size, dtype=src.dtype)
-        with nogil:
-            for i in range(nchunks):
-                _copy_chunk(
-                    <const unsigned char*>src.data + src.strides[0] * src_start[i],
-                    <unsigned char*>scratch.data,
-                    count[i],
-                    ndim,
-                    itemsize,
-                    src.strides,
-                )
-                _hash_chunk_from_ptr(
-                    <const unsigned char*>scratch.data,
-                    &hash_table[hash_rows[i], 0],
-                    count[i],
-                    ndim,
-                    ndim,
-                    itemsize,
-                    scratch.strides,
-                )
+        # Case 3: the innermost axis is strided. Copy each chunk to a C-contiguous
+        # buffer (via numpy, GIL held) and hash it as a contiguous blob.
+        for i in range(nchunks):
+            offset = src_start[i]
+            idx = [slice(offset, offset + count[i, 0])]
+            for j in range(1, ndim):
+                idx.append(slice(count[i, j]))
+            scratch = np.ascontiguousarray(src[tuple(idx)])
+            _hash_chunk_from_ptr(
+                <const unsigned char*>scratch.data,
+                &hash_table[hash_rows[i], 0],
+                count[i],
+                ndim,
+                ndim,
+                itemsize,
+                scratch.strides,
+            )
 
     else:
         # Case 4 (general, most common case): Non-object slab, at least C-contiguous
@@ -239,47 +233,6 @@ cdef void _hash_shape(EVP_MD_CTX* ctx, hsize_t* shape, int ndim) noexcept nogil:
         )
 
     EVP_DigestUpdate(ctx, shape_buf, nchars)
-
-
-cdef void _copy_chunk(
-    const unsigned char* src_ptr,
-    unsigned char* dst,
-    hsize_t[::1] shape,
-    hsize_t ndim,
-    hsize_t itemsize,
-    npy_intp* strides,
-) noexcept nogil:
-    """Deep-copy an edge-trimmed chunk into a C-contiguous scratch buffer.
-
-    nogil, C-friendly equivalent of np.ascontiguousarray().
-    """
-    cdef hsize_t[NPY_MAXDIMS] outer_idx
-    cdef hsize_t outer_total = 1
-    cdef hsize_t inner = shape[ndim - 1]
-    cdef hsize_t outer, k
-    cdef npy_intp offset
-    cdef const unsigned char* src_row
-
-    for k in range(ndim - 1):
-        outer_idx[k] = 0
-        outer_total *= shape[k]
-
-    for outer in range(outer_total):
-        offset = 0
-        for k in range(ndim - 1):
-            offset += outer_idx[k] * strides[k]
-        src_row = src_ptr + offset
-
-        for k in range(inner):
-            memcpy(dst, src_row + k * strides[ndim - 1], itemsize)
-            dst += itemsize
-
-        # Advance the indices of the leading axes
-        for k in range(ndim - 2, -1, -1):
-            outer_idx[k] += 1
-            if outer_idx[k] < shape[k]:
-                break
-            outer_idx[k] = 0
 
 
 cdef int _hash_chunk_from_ptr(

--- a/versioned_hdf5/hash.pyx
+++ b/versioned_hdf5/hash.pyx
@@ -15,6 +15,7 @@ from numpy cimport npy_intp, NPY_MAXDIMS
 from libc.stddef cimport size_t
 from libc.stdint cimport uint64_t
 from libc.stdio cimport snprintf
+from libc.string cimport memcpy
 
 from versioned_hdf5.cytools cimport hsize_t
 
@@ -54,6 +55,7 @@ cpdef void hash_slab(
     hsize_t[::1] hash_rows,
     hsize_t[::1] src_start,
     hsize_t[:, ::1] count,
+    chunk_size,  # tuple[int, ...]
 ) except *:
     """Compute the SHA256 of one or more chunks of a slab and write them to a hash table.
 
@@ -76,8 +78,10 @@ cpdef void hash_slab(
     ----------
     src:
         The slab to read from; always a NumPy array (a staged slab, or the broadcasted
-        full slab). Note that non-NumPy base slabs (e.g. backed by h5py) are never
-        hashed here; their hashes are loaded from disk.
+        full slab). Slabs that are not C-contiguous along the innermost axis are
+        hashed through a chunk-sized scratch buffer; other axes may be strided.
+        Note that non-NumPy base slabs (e.g. backed by h5py) are never hashed here;
+        their hashes are loaded from disk.
     hash_table:
         2D C-contiguous array of uint64 and shape ``(n, 4)``, modified in place.
         ``n`` is the number of chunks in the slab.
@@ -90,6 +94,9 @@ cpdef void hash_slab(
     count:
         2D array of shape ``(nchunks, ndim)`` with the edge-trimmed shape of each chunk,
         i.e. the actual number of valid points along each axis.
+    chunk_size:
+        The physical (untrimmed) chunk shape, e.g. the maximum that can be contained on
+        any one row of ``count``.
     """
     cdef hsize_t nchunks = count.shape[0]
     cdef hsize_t ndim = count.shape[1]
@@ -98,15 +105,18 @@ cpdef void hash_slab(
     cdef hsize_t itemsize = src.dtype.itemsize
     cdef hsize_t stride0
     cdef hsize_t offset
-    cdef hsize_t total_bytes
+    cdef hsize_t n_contig
+    cdef np.ndarray scratch
 
     assert src.ndim == ndim
     assert hash_table.shape[1] == 4
     assert hash_rows.shape[0] == nchunks
     assert src_start.shape[0] == nchunks
+    assert isinstance(chunk_size, tuple)
+    assert len(chunk_size) == ndim
 
-    # Case 1: Object/StringDType — GIL always held (Python object iteration).
     if src.dtype.kind in ("O", "T"):
+        # Case 1: Object/StringDType — GIL always held (Python object iteration).
         for i in range(nchunks):
             offset = src_start[i]
             idx = [slice(offset, offset + count[i, 0])]
@@ -118,31 +128,84 @@ cpdef void hash_slab(
             )
         return
 
-    # Case 2: full slab. This is a single chunk; it's ok to be suboptimal.
-    if not src.flags.c_contiguous:
-        src = np.ascontiguousarray(src)
+    cdef bint is_broadcasted_scalar = True
+    for j in range(ndim):
+        if src.strides[j] != 0:
+            is_broadcasted_scalar = False
+            break
 
-    # Case 3: Non-object slab, at least C-contiguous along the innermost axis
-    # (edge chunks may not be C-contiguous on axes[:-1])
-    # release GIL for the loop.
-    # Each chunk is a slice along axis 0; byte offset = start * stride0.
-    with nogil:
-        stride0 = itemsize
-        for j in range(1, ndim):
-            stride0 *= src.shape[j]
+    if is_broadcasted_scalar and src.size > 0:
+        # Case 2: the full slab is broadcasted from scalar. However, this could also be
+        # a much larger user-provided broadcasted array, which we don't want to
+        # materialize as contiguous all at once.
+        # Special case: an empty slab also has all-zero strides, but a None base;
+        # fall through to Case 3 instead.
+        scratch = np.full(chunk_size, fill_value=src.flat[0], dtype=src.dtype)
+        with nogil:
+            for i in range(nchunks):
+                _hash_chunk_from_ptr(
+                    <const unsigned char*>scratch.data,
+                    &hash_table[hash_rows[i], 0],
+                    count[i],
+                    ndim,
+                    ndim,
+                    itemsize,
+                    scratch.strides,
+                )
 
-        for i in range(nchunks):
-            offset = stride0 * src_start[i]
-            total_bytes = stride0 * count[i, 0]
-            _hash_chunk_from_ptr(
-                <const unsigned char*>src.data + offset,
-                &hash_table[hash_rows[i], 0],
-                count[i],
-                ndim,
-                itemsize,
-                src.strides,
-                total_bytes,
-            )
+    elif src.strides[ndim - 1] != itemsize:
+        # Case 3: the innermost axis is strided. Deep-copy each chunk into a chunk-sized
+        # scratch buffer and hash it as a contiguous blob.
+        scratch = np.empty(chunk_size, dtype=src.dtype)
+        with nogil:
+            for i in range(nchunks):
+                _copy_chunk(
+                    <const unsigned char*>src.data + src.strides[0] * src_start[i],
+                    <unsigned char*>scratch.data,
+                    count[i],
+                    ndim,
+                    itemsize,
+                    src.strides,
+                )
+                _hash_chunk_from_ptr(
+                    <const unsigned char*>scratch.data,
+                    &hash_table[hash_rows[i], 0],
+                    count[i],
+                    ndim,
+                    ndim,
+                    itemsize,
+                    scratch.strides,
+                )
+
+    else:
+        # Case 4 (general, most common case): Non-object slab, at least C-contiguous
+        # along the innermost axis. The other axes may be strided (e.g. stepped or
+        # transposed slabs): chunks are then hashed one trailing-contiguous hyperplane
+        # at a time. release GIL for the loop. Each chunk is a slice along axis 0; byte
+        # offset = start * stride0.
+        with nogil:
+            stride0 = src.strides[0]
+
+            for i in range(nchunks):
+                offset = stride0 * src_start[i]
+                # Count the trailing axes -1..-n that form one C-contiguous run. This must
+                # be tested per chunk: edge chunks with trimmed counts may be non-contiguous
+                # even on a C-contiguous slab.
+                n_contig = 1
+                for j in range(ndim - 2, -1, -1):
+                    if src.strides[j] != src.strides[j + 1] * count[i, j + 1]:
+                        break
+                    n_contig += 1
+
+                _hash_chunk_from_ptr(
+                    <const unsigned char*>src.data + offset,
+                    &hash_table[hash_rows[i], 0],
+                    count[i],
+                    ndim,
+                    n_contig,
+                    itemsize,
+                    src.strides,
+                )
 
 
 cdef void _hash_shape(EVP_MD_CTX* ctx, hsize_t* shape, int ndim) noexcept nogil:
@@ -178,14 +241,55 @@ cdef void _hash_shape(EVP_MD_CTX* ctx, hsize_t* shape, int ndim) noexcept nogil:
     EVP_DigestUpdate(ctx, shape_buf, nchars)
 
 
+cdef void _copy_chunk(
+    const unsigned char* src_ptr,
+    unsigned char* dst,
+    hsize_t[::1] shape,
+    hsize_t ndim,
+    hsize_t itemsize,
+    npy_intp* strides,
+) noexcept nogil:
+    """Deep-copy an edge-trimmed chunk into a C-contiguous scratch buffer.
+
+    nogil, C-friendly equivalent of np.ascontiguousarray().
+    """
+    cdef hsize_t[NPY_MAXDIMS] outer_idx
+    cdef hsize_t outer_total = 1
+    cdef hsize_t inner = shape[ndim - 1]
+    cdef hsize_t outer, k
+    cdef npy_intp offset
+    cdef const unsigned char* src_row
+
+    for k in range(ndim - 1):
+        outer_idx[k] = 0
+        outer_total *= shape[k]
+
+    for outer in range(outer_total):
+        offset = 0
+        for k in range(ndim - 1):
+            offset += outer_idx[k] * strides[k]
+        src_row = src_ptr + offset
+
+        for k in range(inner):
+            memcpy(dst, src_row + k * strides[ndim - 1], itemsize)
+            dst += itemsize
+
+        # Advance the indices of the leading axes
+        for k in range(ndim - 2, -1, -1):
+            outer_idx[k] += 1
+            if outer_idx[k] < shape[k]:
+                break
+            outer_idx[k] = 0
+
+
 cdef int _hash_chunk_from_ptr(
     const unsigned char* data_ptr,
     uint64_t* out,
     hsize_t[::1] shape,
     hsize_t ndim,
+    hsize_t n_contig,
     hsize_t itemsize,
     npy_intp* strides,
-    size_t total_bytes,
 ) except -1 nogil:
     """Hash a single chunk given a raw pointer and strides.
     The chunk must be not object dtype, not StringDType, not broadcasted, and
@@ -194,17 +298,10 @@ cdef int _hash_chunk_from_ptr(
     cdef EVP_MD_CTX* ctx
     cdef hsize_t[NPY_MAXDIMS] outer_idx
     cdef hsize_t outer_total
-    cdef hsize_t inner_size
+    cdef hsize_t n_outer
+    cdef hsize_t block_size = itemsize
     cdef hsize_t offset
     cdef hsize_t j
-    cdef bint is_contiguous
-
-    # Check C-contiguous: strides[j] == strides[j+1] * shape[j+1]
-    is_contiguous = True
-    for j in range(ndim - 1):
-        if strides[j] != strides[j + 1] * shape[j + 1]:
-            is_contiguous = False
-            break
 
     ctx = EVP_MD_CTX_new()
     if ctx == NULL:
@@ -213,34 +310,35 @@ cdef int _hash_chunk_from_ptr(
         if EVP_DigestInit_ex(ctx, EVP_sha256(), NULL) != 1:
             return -1
 
-        if is_contiguous:
+        if n_contig == ndim:
             # Single contiguous blob
-            if total_bytes and EVP_DigestUpdate(ctx, data_ptr, total_bytes) != 1:
+            for j in range(ndim):
+                block_size *= shape[j]
+            if block_size and EVP_DigestUpdate(ctx, data_ptr, block_size) != 1:
                 return -1
         else:
-            # Non-contiguous: walk in C-order, hash each row (innermost axis).
-            # The innermost axis is contiguous for C-order arrays,
-            # so each "row" (fixed indices on axes 0..ndim-2, all indices on
-            # axis ndim-1) is a single contiguous run.
-            inner_size = itemsize * shape[ndim - 1]
-
-            # Iterate over outer dimensions (axes 0 .. ndim-2)
+            # The trailing n_contig axes are one contiguous run; hash the chunk as
+            # prod(shape[:n_outer]) contiguous blocks of block_size bytes each,
+            # walking the leading axes in C-order.
+            n_outer = ndim - n_contig
             outer_total = 1
-            for j in range(ndim - 1):
+            for j in range(ndim - 1, n_outer - 1, -1):
+                block_size *= shape[j]
+            for j in range(n_outer):
                 outer_idx[j] = 0
                 outer_total *= shape[j]
 
             for outer in range(outer_total):
-                # Compute byte offset for current outer position
+                # Compute byte offset for current block
                 offset = 0
-                for j in range(ndim - 1):
+                for j in range(n_outer):
                     offset += outer_idx[j] * strides[j]
 
-                if EVP_DigestUpdate(ctx, data_ptr + offset, inner_size) != 1:
+                if EVP_DigestUpdate(ctx, data_ptr + offset, block_size) != 1:
                     return -1
 
-                # Advance outer indices
-                for j in range(ndim - 2, -1, -1):
+                # Advance the indices of the leading axes
+                for j in range(n_outer - 1, -1, -1):
                     outer_idx[j] += 1
                     if outer_idx[j] < shape[j]:
                         break

--- a/versioned_hdf5/hash.pyx
+++ b/versioned_hdf5/hash.pyx
@@ -77,8 +77,7 @@ cpdef void hash_slab(
     ----------
     src:
         The slab to read from; always a NumPy array (a staged slab, or the broadcasted
-        full slab). Slabs that are not C-contiguous along the innermost axis are
-        hashed through a per-chunk C-contiguous copy; other axes may be strided.
+        full slab).
         Note that non-NumPy base slabs (e.g. backed by h5py) are never hashed here;
         their hashes are loaded from disk.
     hash_table:
@@ -89,7 +88,10 @@ cpdef void hash_slab(
         the digest of that chunk to.
     src_start:
         1D array with one element per chunk. ``src_start[i]`` is the offset along
-        axis 0 of chunk i within its slab. Offsets on all other axes are always 0.
+        axis 0 of chunk i within its slab, strictly monotonic increasing. Chunks must
+        occupy disjoint row ranges (two chunks never share a slab row); gaps
+        between chunks are allowed (e.g. caused by edge chunks). Offsets on all
+        other axes are always 0.
     count:
         2D array of shape ``(nchunks, ndim)`` with the edge-trimmed shape of each chunk,
         i.e. the actual number of valid points along each axis.
@@ -105,6 +107,14 @@ cpdef void hash_slab(
     cdef hsize_t stride0
     cdef hsize_t offset
     cdef hsize_t n_contig
+    cdef hsize_t bytes_per_chunk
+    cdef hsize_t chunks_per_lot
+    cdef hsize_t lot_begin
+    cdef hsize_t lot_end
+    cdef hsize_t lot_start
+    cdef hsize_t lot_stop
+    cdef hsize_t lot_stride0
+    cdef hsize_t chunk_size0
     cdef np.ndarray scratch
 
     assert src.ndim == ndim
@@ -140,6 +150,7 @@ cpdef void hash_slab(
         # Special case: an empty slab also has all-zero strides, but a None base;
         # fall through to Case 3 instead.
         scratch = np.full(chunk_size, fill_value=src.flat[0], dtype=src.dtype)
+
         with nogil:
             for i in range(nchunks):
                 _hash_chunk_from_ptr(
@@ -153,23 +164,50 @@ cpdef void hash_slab(
                 )
 
     elif src.strides[ndim - 1] != itemsize:
-        # Case 3: the innermost axis is strided. Copy each chunk to a C-contiguous
-        # buffer (via numpy, GIL held) and hash it as a contiguous blob.
-        for i in range(nchunks):
-            offset = src_start[i]
-            idx = [slice(offset, offset + count[i, 0])]
-            for j in range(1, ndim):
-                idx.append(slice(count[i, j]))
-            scratch = np.ascontiguousarray(src[tuple(idx)])
-            _hash_chunk_from_ptr(
-                <const unsigned char*>scratch.data,
-                &hash_table[hash_rows[i], 0],
-                count[i],
-                ndim,
-                ndim,
-                itemsize,
-                scratch.strides,
-            )
+        # Case 3: the innermost axis is strided. Copy chunks in lots of up to ~2 MiB to
+        # a C-contiguous buffer, then hash each chunk in the lot.
+        chunk_size0 = <hsize_t>chunk_size[0]
+        bytes_per_chunk = itemsize * chunk_size0
+        for j in range(1, ndim):
+            bytes_per_chunk *= src.shape[j]
+        if bytes_per_chunk == 0:
+            chunks_per_lot = nchunks
+        else:
+            chunks_per_lot = max(1, (2 * 1024 * 1024) // bytes_per_chunk)
+
+        for lot_begin in range(0, nchunks, chunks_per_lot):
+            lot_end = min(lot_begin + chunks_per_lot, nchunks)
+            # Copy the row span covering every chunk of the lot. Chunks never
+            # overlap, so this (clamped at the slab edge) contains each chunk in
+            # full; gaps between chunks are copied along but never hashed.
+            lot_start = src_start[lot_begin]
+            lot_stop = src_start[lot_end] if lot_end < nchunks else src.shape[0]
+            scratch = np.ascontiguousarray(src[lot_start:lot_stop])
+
+            with nogil:
+                lot_stride0 = scratch.strides[0]
+                for i in range(lot_begin, lot_end):
+                    # Byte offset of chunk i within the lot: the lot copy starts at row
+                    # lot_start, and every chunk lies fully inside it.
+                    offset = (src_start[i] - lot_start) * lot_stride0
+                    # The lot is fully C-contiguous, but an edge chunk may be trimmed
+                    # along some axis: count the trailing axes that form one contiguous
+                    # run, as in Case 4.
+                    n_contig = 1
+                    for j in range(ndim - 2, -1, -1):
+                        if scratch.strides[j] != scratch.strides[j + 1] * count[i, j + 1]:
+                            break
+                        n_contig += 1
+
+                    _hash_chunk_from_ptr(
+                        <const unsigned char*>scratch.data + offset,
+                        &hash_table[hash_rows[i], 0],
+                        count[i],
+                        ndim,
+                        n_contig,
+                        itemsize,
+                        scratch.strides,
+                    )
 
     else:
         # Case 4 (general, most common case): Non-object slab, at least C-contiguous

--- a/versioned_hdf5/staged_changes.py
+++ b/versioned_hdf5/staged_changes.py
@@ -1941,6 +1941,7 @@ class HashSlabPlan:
     src_start: hsize_t[::1]
     count: hsize_t[:, ::1]
     chunk_size_0: hsize_t
+    chunk_size: tuple[int, ...]
 
     def hash_slab(self, slab: np.ndarray):
         """Hash the slab and return a new hash table"""
@@ -1953,7 +1954,7 @@ class HashSlabPlan:
             hash_rows[i] = self.src_start[i] // cs0
 
         ht = np.zeros((nchunks, 4), dtype=np.uint64)
-        hash_slab(slab, ht, hash_rows, self.src_start, self.count)
+        hash_slab(slab, ht, hash_rows, self.src_start, self.count, self.chunk_size)
 
         # We'll never write to it again
         ht.flags.writeable = False
@@ -2024,6 +2025,7 @@ class HashPlan:
                     chunk_size_0=chunk_size_0,
                     src_start=np.zeros((1,), dtype=np_hsize_t),
                     count=np.asarray([chunk_size], dtype=np_hsize_t),
+                    chunk_size=chunk_size,
                 )
             )
 
@@ -2064,6 +2066,7 @@ class HashPlan:
                         chunk_size_0=chunk_size_0,
                         src_start=slab_off_col[slab_start:slab_stop],
                         count=count[slab_start:slab_stop],
+                        chunk_size=chunk_size,
                     )
                 )
                 slab_start = slab_stop


### PR DESCRIPTION
Towards #398

#547 uses `StagedChangesArray.from_array` to load a InMemoryArrayDataset during commit. This introduces a wealth of new use cases for `hash_slab`, which were previously unoptimized.

Do not deep-copy the whole slab at once when it is not C-contiguous, preventing a memory spike and potentially a OOM crash. This naive approach was devised when the only non-C-contiguous slab was the full slab, a single chunk broadcasted from scalar which is inconsequential from a performance point of view.

When the slab is not fully C-contiguous, identify the longest C-contiguous number of axes and reduce the number of calls to the digest function. This should speed up the use case of strided user-provided arrays with 3+ dimensions.

This PR also speeds up the pre-existing use case where a InMemoryArrayDataset is enlarged with `resize()`, which converts it to a InMemorySparseDataset through  `StagedChangesArray.from_array`.

## Benchmarks

| Change   | master   | noncontig-hash   | Ratio   | Benchmark (Parameter)                                                    |
|----------|------------------------------|-------------------------------------|---------|--------------------------------------------------------------------------|
| -        | 75.2M                        | 67.3M                               | 0.90    | hash.TimeHashSlabNonContig.peakmem_hash_slab('broadcast', (1024, 1024))  |
| -        | 75.4M                        | 58.7M                               | 0.78    | hash.TimeHashSlabNonContig.peakmem_hash_slab('broadcast', (64, 128))     |
| -        | 75.8M                        | 59.1M                               | 0.78    | hash.TimeHashSlabNonContig.peakmem_hash_slab('broadcast', (8, 16))       |
|          | 109M                         | 101M                                | 0.92    | hash.TimeHashSlabNonContig.peakmem_hash_slab('step_inner', (1024, 1024)) |
| -        | 109M                         | 92.6M                               | 0.85    | hash.TimeHashSlabNonContig.peakmem_hash_slab('step_inner', (64, 128))    |
| -        | 110M                         | 93M                                 | 0.85    | hash.TimeHashSlabNonContig.peakmem_hash_slab('step_inner', (8, 16))      |
| -        | 109M                         | 92.2M                               | 0.85    | hash.TimeHashSlabNonContig.peakmem_hash_slab('step_outer', (1024, 1024)) |
| -        | 109M                         | 92.4M                               | 0.85    | hash.TimeHashSlabNonContig.peakmem_hash_slab('step_outer', (64, 128))    |
| -        | 110M                         | 92.9M                               | 0.85    | hash.TimeHashSlabNonContig.peakmem_hash_slab('step_outer', (8, 16))      |
|          | 91.7M                        | 83.8M                               | 0.91    | hash.TimeHashSlabNonContig.peakmem_hash_slab('transpose', (1024, 1024))  |
| -        | 92.5M                        | 75.4M                               | 0.82    | hash.TimeHashSlabNonContig.peakmem_hash_slab('transpose', (64, 128))     |
| -        | 93.1M                        | 76.5M                               | 0.82    | hash.TimeHashSlabNonContig.peakmem_hash_slab('transpose', (8, 16))       |
|          | 10.0±0.7ms                   | 9.30±0.7ms                          | 0.93    | hash.TimeHashSlabNonContig.time_hash_slab('broadcast', (1024, 1024))     |
| -        | 10.4±0.9ms                   | 8.15±0.1ms                          | 0.78    | hash.TimeHashSlabNonContig.time_hash_slab('broadcast', (64, 128))        |
|          | 18.4±0.7ms                   | 16.7±0.2ms                          | 0.91    | hash.TimeHashSlabNonContig.time_hash_slab('broadcast', (8, 16))          |
|          | 12.4±0.6ms                   | 14.8±0.7ms                          | ~1.20   | hash.TimeHashSlabNonContig.time_hash_slab('step_inner', (1024, 1024))    |
| +        | 12.5±0.6ms                   | 13.8±0.04ms                         | 1.10    | hash.TimeHashSlabNonContig.time_hash_slab('step_inner', (64, 128))       |
| +        | 20.9±0.6ms                   | 23.4±0.3ms                          | 1.12    | hash.TimeHashSlabNonContig.time_hash_slab('step_inner', (8, 16))         |
| -        | 11.7±0.7ms                   | 8.52±0.02ms                         | 0.73    | hash.TimeHashSlabNonContig.time_hash_slab('step_outer', (1024, 1024))    |
| -        | 12.2±0.5ms                   | 9.60±0.03ms                         | 0.79    | hash.TimeHashSlabNonContig.time_hash_slab('step_outer', (64, 128))       |
| -        | 21.1±0.7ms                   | 17.8±0.2ms                          | 0.84    | hash.TimeHashSlabNonContig.time_hash_slab('step_outer', (8, 16))         |
| -        | 104±2ms                      | 17.7±0.4ms                          | 0.17    | hash.TimeHashSlabNonContig.time_hash_slab('transpose', (1024, 1024))     |
| -        | 205±5ms                      | 24.7±0.3ms                          | 0.12    | hash.TimeHashSlabNonContig.time_hash_slab('transpose', (64, 128))        |
| -        | 63.7±1ms                     | 32.1±0.2ms                          | 0.50    | hash.TimeHashSlabNonContig.time_hash_slab('transpose', (8, 16))          |
