### PR TITLE
Speed up fast get/set actions on StagedChangesArray

### DIFF
--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -7,9 +7,7 @@ from versioned_hdf5.slicetools import RawDataView
 
 from versioned_hdf5.h5py_compat import h5py_astype
 from versioned_hdf5.staged_changes import StagedChangesArray
-from versioned_hdf5.typing_ import (
-    is_array_protocol,
-)
+from versioned_hdf5.typing_ import is_array_protocol
 
 
 class MinimalArray:

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -7,7 +7,9 @@ from versioned_hdf5.slicetools import RawDataView
 
 from versioned_hdf5.h5py_compat import h5py_astype
 from versioned_hdf5.staged_changes import StagedChangesArray
-from versioned_hdf5.typing_ import ArrayProtocol, MutableArrayProtocol
+from versioned_hdf5.typing_ import (
+    is_array_protocol,
+)
 
 
 class MinimalArray:
@@ -55,28 +57,28 @@ class MinimalMutableArray(MinimalArray):
 
 
 def test_array_protocol():
-    assert isinstance(MinimalArray(1), ArrayProtocol)
-    assert not isinstance(MinimalArray(1), MutableArrayProtocol)
-    assert isinstance(MinimalMutableArray(1), ArrayProtocol)
-    assert isinstance(MinimalMutableArray(1), MutableArrayProtocol)
-    assert isinstance(np.array(1), ArrayProtocol)
-    assert isinstance(np.array(1), MutableArrayProtocol)
-    assert isinstance(np.int64(1), ArrayProtocol)
-    assert not isinstance(np.int64(1), MutableArrayProtocol)
-    assert not isinstance(1, ArrayProtocol)
-    assert not isinstance([1], ArrayProtocol)
+    assert is_array_protocol(MinimalArray(1))
+    assert not is_array_protocol(MinimalArray(1), mutable=True)
+    assert is_array_protocol(MinimalMutableArray(1))
+    assert is_array_protocol(MinimalMutableArray(1), mutable=True)
+    assert is_array_protocol(np.array(1))
+    assert is_array_protocol(np.array(1), mutable=True)
+    assert is_array_protocol(np.int64(1))
+    assert not is_array_protocol(np.int64(1), mutable=True)
+    assert not is_array_protocol(1)
+    assert not is_array_protocol([1])
 
     # numpy subclasses implement ArrayProtocol
     x = ma.masked_array([1, -1], mask=[0, 1], dtype="i2")
-    assert isinstance(x, ArrayProtocol)
-    assert isinstance(x, MutableArrayProtocol)
+    assert is_array_protocol(x)
+    assert is_array_protocol(x, mutable=True)
 
 
 def test_array_protocol_h5_dataset(h5file):
     """Test that h5py.Dataset is a ArrayProtocol"""
     dset = h5file.create_dataset("x", shape=(10,), dtype="i2")
-    assert isinstance(dset, ArrayProtocol)
-    assert isinstance(dset, MutableArrayProtocol)
+    assert is_array_protocol(dset)
+    assert is_array_protocol(dset, mutable=True)
 
 
 @pytest.mark.skipif(Version(h5py.__version__) < Version("3.13"), reason="h5py#2550")
@@ -84,8 +86,9 @@ def test_array_protocol_h5_astypeview(h5file):
     """Test that h5py AsTypeView is an ArrayProtocol"""
     dset = h5file.create_dataset("x", shape=(10,), dtype="i2")
     view = dset.astype("i4")
-    assert isinstance(view, ArrayProtocol)
-    assert not isinstance(view, MutableArrayProtocol)
+    assert is_array_protocol(view)
+    assert not is_array_protocol(view, mutable=True)
+    assert is_array_protocol(view)
 
 
 def test_array_protocol_h5_astypeview_compat(h5file):
@@ -94,14 +97,15 @@ def test_array_protocol_h5_astypeview_compat(h5file):
     """
     dset = h5file.create_dataset("x", shape=(10,), dtype="i2")
     view = h5py_astype(dset, "i4")
-    assert isinstance(view, ArrayProtocol)
-    assert not isinstance(view, MutableArrayProtocol)
+    assert is_array_protocol(view)
+    assert not is_array_protocol(view, mutable=True)
+    assert is_array_protocol(view)
 
 
 def array_protocol_staged_changes():
     arr = StagedChangesArray.full((3, 3), chunk_size=(3, 1), dtype="f4")
-    assert isinstance(arr, ArrayProtocol)
-    assert isinstance(arr, MutableArrayProtocol)
+    assert is_array_protocol(arr)
+    assert is_array_protocol(arr, mutable=True)
 
 
 def test_array_protocol_rawdataview():
@@ -110,5 +114,5 @@ def test_array_protocol_rawdataview():
     __getitem__/__setitem__/__array__ raise (it must only be used via read_many_slices).
     """
     view = RawDataView(np.zeros((4, 3)), offset=1, dtype=np.dtype("i8"))
-    assert isinstance(view, ArrayProtocol)
-    assert isinstance(view, MutableArrayProtocol)
+    assert is_array_protocol(view)
+    assert is_array_protocol(view, mutable=True)

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -6,7 +6,7 @@ import pytest
 from numpy.testing import assert_array_equal, assert_equal
 
 from versioned_hdf5 import VersionedHDF5File
-from versioned_hdf5.typing_ import ArrayProtocol
+from versioned_hdf5.typing_ import is_array_protocol
 from versioned_hdf5.wrappers import (
     DatasetWrapper,
     InMemoryArrayDataset,
@@ -270,7 +270,7 @@ def test_astype_dense(vfile, dtype):
         assert isinstance(dset.dataset, InMemoryArrayDataset)
 
         a = dset.astype(dtype)
-        assert isinstance(a, ArrayProtocol)
+        assert is_array_protocol(a)
         assert a.dtype == dtype
         assert dset.dtype == "i1"
         with pytest.raises(ValueError, match="read-only"):
@@ -286,7 +286,7 @@ def test_astype_dense(vfile, dtype):
         assert dset.dtype == "i1"
 
         a = dset.astype(dtype)
-        assert isinstance(a, ArrayProtocol)
+        assert is_array_protocol(a)
         assert a.dtype == dtype
         assert dset.dtype == "i1"
         with pytest.raises(ValueError, match="read-only"):
@@ -307,7 +307,7 @@ def test_astype_sparse(vfile, dtype):
         dset[0] = 1
 
         a = dset.astype(dtype)
-        assert isinstance(a, ArrayProtocol)
+        assert is_array_protocol(a)
         assert a.dtype == dtype
         assert dset.dtype == "i1"
         with pytest.raises(ValueError, match="read-only"):

--- a/versioned_hdf5/tools.py
+++ b/versioned_hdf5/tools.py
@@ -6,7 +6,7 @@ import ndindex
 import numpy as np
 from numpy.typing import ArrayLike, DTypeLike
 
-from versioned_hdf5.typing_ import ArrayProtocol
+from versioned_hdf5.typing_ import is_array_protocol
 
 _NP_VERSION = np.lib.NumpyVersion(np.__version__)
 NP_VERSION = (_NP_VERSION.major, _NP_VERSION.minor, _NP_VERSION.bugfix)
@@ -25,7 +25,7 @@ def asarray(a: ArrayLike, /, *, dtype: DTypeLike | None = None):
        on NumPy >=2.0.0,<2.2.3 when converting from arrays of object strings to
        NpyStrings
     """
-    if not isinstance(a, ArrayProtocol) or np.isscalar(a):
+    if not is_array_protocol(a) or np.isscalar(a):
         return np.asarray(a, dtype=dtype)
 
     if dtype is None:

--- a/versioned_hdf5/typing_.py
+++ b/versioned_hdf5/typing_.py
@@ -8,13 +8,12 @@ collision in Cython with the standard library 'typing' and 'types' modules.
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, Protocol
 
 import numpy as np
 from numpy.typing import ArrayLike, DTypeLike, NDArray
 
 
-@runtime_checkable
 class ArrayProtocol(Protocol):
     """Minimal read-only NumPy array-like interface.
 
@@ -46,7 +45,7 @@ class ArrayProtocol(Protocol):
     ) -> NDArray: ...
 
 
-@runtime_checkable  # Does not support inheritance
+# Protocol does not support inheritance
 class MutableArrayProtocol(Protocol):
     @property
     def shape(self) -> tuple[int, ...]: ...
@@ -62,11 +61,23 @@ class MutableArrayProtocol(Protocol):
 
     def __getitem__(self, index: Any) -> MutableArrayProtocol: ...
 
-    def __array__(
-        self, dtype: DTypeLike | None = None, copy: bool | None = None
-    ) -> NDArray: ...
-
     def __setitem__(self, index: Any, value: ArrayLike) -> None: ...
+
+
+def is_array_protocol(a: Any, *, mutable: bool = False) -> bool:
+    """Equivalent of ``isinstance(a, ArrayProtocol)`` or
+    ``isinstance(a, MutableArrayProtocol)`` should these classes have
+    the @runtime_checkable decorator, but up to 35x faster (5.5us -> 0.15us).
+    """
+    out = isinstance(a, np.ndarray) or (
+        hasattr(a, "shape")
+        and hasattr(a, "size")
+        and hasattr(a, "ndim")
+        and hasattr(a, "dtype")
+        and hasattr(a, "__getitem__")
+        and hasattr(a, "__array__")
+    )
+    return out and (not mutable or hasattr(a, "__setitem__"))
 
 
 class Default(Enum):


### PR DESCRIPTION
Speed up use case where the user performs many small `__getitem__` or `__setitem__` calls on a InMemoryDataset or InMemorySparseDataset.

```
| Change   | Before [bc80e415] <master>   | After [67781086] <is_array_protocol>   | Ratio   | Benchmark (Parameter)                                          |
|----------|------------------------------|----------------------------------------|---------|----------------------------------------------------------------|
| -        | 493±60ms                     | 268±7ms                                | 0.54    | staged_changes.TimeGetItem.time_getitem('all_fragmented')      |
| -        | 560±100ms                    | 272±3ms                                | 0.49    | staged_changes.TimeSetItem.time_setitem('all_fragmented')      |
```