### PR TITLE
Use the HDF5 C API in read_many_slices for non-contiguous NumPy arrays

### DIFF
--- a/benchmarks/read_many_slices.py
+++ b/benchmarks/read_many_slices.py
@@ -37,7 +37,7 @@ NCOLS = 128
 def make_array(
     shape: tuple[int, int], layout: str, rng: np.random.Generator
 ) -> np.ndarray:
-    """Return a NumPy array of with the given shape and layout,
+    """Return a NumPy array with the given shape and layout,
     full of random float64 data
     """
     if layout == "contiguous":

--- a/benchmarks/read_many_slices.py
+++ b/benchmarks/read_many_slices.py
@@ -8,6 +8,58 @@ CHUNK_SIZES = [1024 // 8, 64 * 1024 // 8, 1024 * 1024 // 8]
 # Total bytes transferred per benchmark call ~16 MiB
 TOTAL_ELEMENTS = 16 * 1024 * 1024 // 8
 
+# Memory layouts of the NumPy side of the transfer
+LAYOUTS = [
+    # C-contiguous buffer
+    "contiguous",
+    # The innermost axis is C-contiguous, but the last point of a row is not adjacent in
+    # memory to the first point of the next row
+    "sliced",
+    # 1D array in memory, with replicated rows; each row is a contiguous buffer
+    "broadcast_outer",
+    # 1D array in memory, with replicated columns
+    "broadcast_inner",
+    # The innermost axis is C-contiguous, but rows are copied in reverse order
+    "reverse_outer",
+    # The innermost axis is copied in reverse order
+    "reverse_inner",
+    # Copy every other row. The innermost axis is C-contiguous.
+    "strided_outer",
+    # Copy every other column.
+    "strided_inner",
+    # Outermost NumPy axis is the innermost one in memory (Fortran order)
+    "transposed",
+]
+
+NCOLS = 128
+
+
+def make_array(
+    shape: tuple[int, int], layout: str, rng: np.random.Generator
+) -> np.ndarray:
+    """Return a NumPy array of with the given shape and layout,
+    full of random float64 data
+    """
+    if layout == "contiguous":
+        return rng.random(shape, np.float64)
+    if layout == "sliced":
+        return rng.random((shape[0], shape[1] + 8), np.float64)[:, 4:-4]
+    if layout == "broadcast_outer":
+        return np.broadcast_to(rng.random((1, shape[1]), np.float64), shape)
+    if layout == "broadcast_inner":
+        return np.broadcast_to(rng.random((shape[0], 1), np.float64), shape)
+    if layout == "reverse_outer":
+        return rng.random(shape, np.float64)[::-1, :]
+    if layout == "reverse_inner":
+        return rng.random(shape, np.float64)[:, ::-1]
+    if layout == "strided_outer":
+        return rng.random((shape[0] * 2, shape[1]), np.float64)[::2, :]
+    if layout == "strided_inner":
+        return rng.random((shape[0], shape[1] * 2), np.float64)[:, ::2]
+    if layout == "transposed":
+        return rng.random(shape[::-1], np.float64).T
+    raise AssertionError(f"unknown layout: {layout}")
+
 
 class TimeReadManySlicesNumPy:
     """Benchmark read_many_slices with NumPy src and NumPy dst."""
@@ -31,13 +83,11 @@ class TimeReadManySlicesNumPy:
         read_many_slices(self.src, self.dst, self.src_start, self.dst_start, self.count)
 
 
-class _TimeReadManySlicesH5Base(Benchmark):
-    """Common setup for h5py read/write benchmarks."""
+class TimeReadManySlices(Benchmark):
+    """Benchmark read_many_slices between h5py src and a contiguous NumPy array"""
 
     params = [CHUNK_SIZES, [True, None, False]]
     param_names = ["chunk_size", "fast"]
-
-    direction = ""  # "h5_to_np" or "np_to_h5"; overridden by subclasses
 
     def setup(self, chunk_size, fast):
         super().setup(chunk_size, fast)
@@ -58,11 +108,7 @@ class _TimeReadManySlicesH5Base(Benchmark):
         self.dst_start = starts
         self.count = np.full((n_slices, 1), chunk_size, dtype=np.uint64)
 
-
-class TimeReadManySlicesH5ToNp(_TimeReadManySlicesH5Base):
-    """Benchmark read_many_slices with h5py src and NumPy dst."""
-
-    def time_read_many_slices(self, chunk_size, fast):
+    def time_read_many_slices_h5_to_np(self, chunk_size, fast):
         read_many_slices(
             self.h5_dset,
             self.np_arr,
@@ -72,11 +118,60 @@ class TimeReadManySlicesH5ToNp(_TimeReadManySlicesH5Base):
             fast=fast,
         )
 
+    def time_read_many_slices_np_to_h5(self, chunk_size, fast):
+        read_many_slices(
+            self.np_arr,
+            self.h5_dset,
+            self.src_start,
+            self.dst_start,
+            self.count,
+            fast=fast,
+        )
 
-class TimeReadManySlicesNpToH5(_TimeReadManySlicesH5Base):
-    """Benchmark read_many_slices with numpy src and h5py dst."""
 
-    def time_read_many_slices(self, chunk_size, fast):
+class TimeReadManySlicesNonContiguous(Benchmark):
+    """Benchmark read_many_slices between h5py src and a non-contiguous NumPy array"""
+
+    params = [CHUNK_SIZES, LAYOUTS, [None, False]]
+    param_names = ["chunk_size", "layout", "fast"]
+
+    def setup(self, chunk_size, layout, fast):
+        super().setup(chunk_size, layout, fast)
+        rows_per_slice = max(1, chunk_size // NCOLS)
+        nrows = TOTAL_ELEMENTS // NCOLS
+        n_slices = nrows // rows_per_slice
+
+        self.np_arr = make_array((nrows, NCOLS), layout, self.rng)
+        self.h5_dset = self.file.create_dataset(
+            "data",
+            # Initialize with data so reads return something realistic
+            data=self.rng.random((nrows, NCOLS)),
+            chunks=(rows_per_slice, NCOLS),
+        )
+
+        # Contiguous, chunk-aligned offsets in both src and dst
+        starts = np.zeros((n_slices, 2), dtype=np.uint64)
+        starts[:, 0] = np.arange(n_slices) * rows_per_slice
+        self.src_start = starts
+        self.dst_start = starts
+        self.count = np.array([rows_per_slice, NCOLS], dtype=np.uint64)
+
+    def time_read_many_slices_h5_to_np(self, chunk_size, layout, fast):
+        if "broadcast" in layout:
+            from asv_runner.benchmarks.mark import SkipNotImplemented
+
+            raise SkipNotImplemented("read-only array")
+
+        read_many_slices(
+            self.h5_dset,
+            self.np_arr,
+            self.src_start,
+            self.dst_start,
+            self.count,
+            fast=fast,
+        )
+
+    def time_read_many_slices_np_to_h5(self, chunk_size, layout, fast):
         read_many_slices(
             self.np_arr,
             self.h5_dset,

--- a/benchmarks/read_many_slices.py
+++ b/benchmarks/read_many_slices.py
@@ -20,9 +20,9 @@ LAYOUTS = [
     # 1D array in memory, with replicated columns
     "broadcast_inner",
     # The innermost axis is C-contiguous, but rows are copied in reverse order
-    "reverse_outer",
+    "reversed_outer",
     # The innermost axis is copied in reverse order
-    "reverse_inner",
+    "reversed_inner",
     # Copy every other row. The innermost axis is C-contiguous.
     "strided_outer",
     # Copy every other column.
@@ -48,9 +48,9 @@ def make_array(
         return np.broadcast_to(rng.random((1, shape[1]), np.float64), shape)
     if layout == "broadcast_inner":
         return np.broadcast_to(rng.random((shape[0], 1), np.float64), shape)
-    if layout == "reverse_outer":
+    if layout == "reversed_outer":
         return rng.random(shape, np.float64)[::-1, :]
-    if layout == "reverse_inner":
+    if layout == "reversed_inner":
         return rng.random(shape, np.float64)[:, ::-1]
     if layout == "strided_outer":
         return rng.random((shape[0] * 2, shape[1]), np.float64)[::2, :]

--- a/tests/test_slicetools.py
+++ b/tests/test_slicetools.py
@@ -36,8 +36,8 @@ class NumPyLayout(enum.Enum):
     # becoming aliases of each other and get silently skipped when enumerating.
     contiguous = NumPyLayoutElem("contiguous", 1, True, True)
     sliced = NumPyLayoutElem("sliced", 1, True, True)
-    step_outer = NumPyLayoutElem("step_outer", 2, True, True)
-    step_inner = NumPyLayoutElem("step_inner", 1, True, False)
+    strided_outer = NumPyLayoutElem("strided_outer", 2, True, True)
+    strided_inner = NumPyLayoutElem("strided_inner", 1, True, False)
     transposed = NumPyLayoutElem("transposed", 2, True, False)
     reversed_inner = NumPyLayoutElem("reversed_inner", 1, True, False)
     reversed_outer = NumPyLayoutElem("reversed_outer", 2, True, False)
@@ -64,9 +64,9 @@ def make_array(
         out = np.empty(shape, dtype)
     elif layout is L.sliced:
         out = np.empty(tuple(s + 3 for s in shape), dtype)[every_axis(slice(1, -2))]
-    elif layout is L.step_inner:
+    elif layout is L.strided_inner:
         out = np.empty((*shape[:-1], shape[-1] * 3), dtype)[..., ::3]
-    elif layout is L.step_outer:
+    elif layout is L.strided_outer:
         assert ndim > 1
         base = np.empty((*(s * 3 for s in shape[:-1]), shape[-1]), dtype)
         out = base[every_axis(slice(None, None, 3))[:-1]]

--- a/tests/test_slicetools.py
+++ b/tests/test_slicetools.py
@@ -1,3 +1,6 @@
+import enum
+from typing import Literal, NamedTuple
+
 import hypothesis
 import numpy as np
 import pytest
@@ -5,6 +8,7 @@ from h5py._hl.selections import Selection
 from hypothesis import given
 from hypothesis import strategies as st
 from numpy.testing import assert_equal
+from numpy.typing import DTypeLike
 from versioned_hdf5.slicetools import (
     RawDataView,
     build_slab_indices_and_offsets,
@@ -18,6 +22,86 @@ from versioned_hdf5.cytools import count2stop
 from .test_typing import MinimalArray
 
 max_examples = 10_000
+
+
+class NumPyLayoutElem(NamedTuple):
+    name: str
+    min_ndim: int
+    writeable: bool
+    fast: bool
+
+
+class NumPyLayout(enum.Enum):
+    # Note: repeating the name prevents elements with identical capabilities from
+    # becoming aliases of each other and get silently skipped when enumerating.
+    contiguous = NumPyLayoutElem("contiguous", 1, True, True)
+    sliced = NumPyLayoutElem("sliced", 1, True, True)
+    step_outer = NumPyLayoutElem("step_outer", 2, True, True)
+    step_inner = NumPyLayoutElem("step_inner", 1, True, False)
+    transposed = NumPyLayoutElem("transposed", 2, True, False)
+    reversed_inner = NumPyLayoutElem("reversed_inner", 1, True, False)
+    reversed_outer = NumPyLayoutElem("reversed_outer", 2, True, False)
+    broadcast_outer = NumPyLayoutElem("broadcast_outer", 2, False, False)
+    broadcast_inner = NumPyLayoutElem("broadcast_inner", 2, False, False)
+
+
+def make_array(
+    shape: tuple[int, ...],
+    dtype: DTypeLike,
+    layout: NumPyLayout,
+    values: Literal["zeros", "range"],
+) -> np.ndarray:
+    """Return a NumPy array of the given shape, dtype, memory layout, and sample
+    values.
+    """
+    ndim = len(shape)
+    L = NumPyLayout
+
+    def every_axis(s: slice) -> tuple[slice, ...]:
+        return (s,) * ndim
+
+    if layout is L.contiguous:
+        out = np.empty(shape, dtype)
+    elif layout is L.sliced:
+        out = np.empty(tuple(s + 3 for s in shape), dtype)[every_axis(slice(1, -2))]
+    elif layout is L.step_inner:
+        out = np.empty((*shape[:-1], shape[-1] * 3), dtype)[..., ::3]
+    elif layout is L.step_outer:
+        assert ndim > 1
+        base = np.empty((*(s * 3 for s in shape[:-1]), shape[-1]), dtype)
+        out = base[every_axis(slice(None, None, 3))[:-1]]
+    elif layout is L.transposed:
+        assert ndim > 1
+        out = np.empty(shape[::-1], dtype).T
+    elif layout is L.reversed_inner:
+        # Negative strides on the innermost axis
+        out = np.empty(shape, dtype)[..., ::-1]
+    elif layout is L.reversed_outer:
+        assert ndim > 1
+        # Negative stride but not on the innermost axis
+        out = np.empty(shape, dtype)[::-1]
+
+    # Broadcast arrays must be filled *before* we create the view
+    elif layout is L.broadcast_inner:
+        assert ndim > 1
+        base = make_array(shape[:-1], dtype, L.contiguous, values)
+        return np.broadcast_to(base[..., None], shape)
+    elif layout is L.broadcast_outer:
+        assert ndim > 1
+        base = make_array(shape[1:], dtype, L.contiguous, values)
+        return np.broadcast_to(base[None, ...], shape)
+
+    else:
+        raise AssertionError("unreachable")  # pragma: nocover
+
+    if values == "zeros":
+        out[:] = 0
+    elif values == "range":
+        out[:] = np.arange(1, out.size + 1, dtype=dtype).reshape(out.shape)
+    else:
+        raise AssertionError("unreachable")  # pragma: nocover
+
+    return out
 
 
 def test_spaceid_to_slice(h5file):
@@ -193,6 +277,10 @@ def many_slices_st(
     list[tuple[slice, ...]],
     # matching list of indices to slice dst array with
     list[tuple[slice, ...]],
+    # memory layout of the src array, when it's a numpy array
+    NumPyLayout,
+    # memory layout of the dst array, when it's a numpy array
+    NumPyLayout,
 ]:
     src_shape_st = st.lists(st.integers(1, max_size), min_size=1, max_size=max_ndim)
     src_shape = tuple(draw(src_shape_st))
@@ -213,7 +301,22 @@ def many_slices_st(
         src_indices.append(tuple(src_idx))
         dst_indices.append(tuple(dst_idx))
 
-    return src_shape, dst_shape, src_indices, dst_indices
+    src_layout = draw(
+        st.sampled_from(
+            [layout for layout in NumPyLayout if layout.value.min_ndim <= ndim]
+        )
+    )
+    dst_layout = draw(
+        st.sampled_from(
+            [
+                layout
+                for layout in NumPyLayout
+                if layout.value.min_ndim <= ndim and layout.value.writeable
+            ]
+        )
+    )
+
+    return src_shape, dst_shape, src_indices, dst_indices, src_layout, dst_layout
 
 
 @pytest.mark.slow
@@ -225,9 +328,9 @@ def many_slices_st(
     suppress_health_check=[hypothesis.HealthCheck.function_scoped_fixture],
 )
 def test_read_many_slices(h5file, args):
-    shape_from, shape_to, indices_from, indices_to = args
+    shape_from, shape_to, indices_from, indices_to, src_layout, dst_layout = args
 
-    src = np.arange(1, np.prod(shape_from) + 1, dtype=np.int32).reshape(shape_from)
+    src = make_array(shape_from, np.int32, src_layout, "range")
 
     expect = np.zeros(shape_to, dtype=src.dtype)
     src_start = []
@@ -245,7 +348,7 @@ def test_read_many_slices(h5file, args):
         count.append([len(range(s.start, s.stop, s.step)) for s in idx_from])
 
     # Test numpy->numpy
-    dst = np.zeros(shape_to, dtype=src.dtype)
+    dst = make_array(shape_to, src.dtype, dst_layout, "zeros")
     read_many_slices(src, dst, src_start, dst_start, count, src_step, dst_step)
     np.testing.assert_array_equal(dst, expect, strict=True)
 
@@ -258,15 +361,21 @@ def test_read_many_slices(h5file, args):
     dst_dset = h5file.create_dataset("b", shape=shape_to, dtype=src.dtype, fillvalue=0)
 
     # Test h5py->NumPy
-    for kwargs in ({}, {"fast": True}, {"fast": False}):
-        dst = np.zeros(shape_to, dtype=src.dtype)
+    kwargss = [{}, {"fast": False}]
+    if dst_layout.value.fast:
+        kwargss.append({"fast": True})
+    for kwargs in kwargss:
+        dst = make_array(shape_to, src.dtype, dst_layout, "zeros")
         read_many_slices(
             src_dset, dst, src_start, dst_start, count, src_step, dst_step, **kwargs
         )
         np.testing.assert_array_equal(dst, expect, strict=True)
 
     # Test NumPy->h5py
-    for kwargs in ({}, {"fast": True}, {"fast": False}):
+    kwargss = [{}, {"fast": False}]
+    if src_layout.value.fast:
+        kwargss.append({"fast": True})
+    for kwargs in kwargss:
         dst_dset[:] = 0
         read_many_slices(
             src, dst_dset, src_start, dst_start, count, src_step, dst_step, **kwargs
@@ -426,30 +535,56 @@ def test_read_many_slices_dst_size_zero(h5file, use_h5):
     read_many_slices(src, dst, [(0, 0)], [(0, 0)], [(3, 3)])
 
 
-def test_read_many_slices_noncontiguous_dst(h5file):
-    """dst is a numpy array that's not C-contiguous.
-    It is supported, but only with fast=False.
+@pytest.mark.parametrize("shape", [(6,), (5, 4), (3, 4, 5), (3, 1, 4)], ids=str)
+@pytest.mark.parametrize("layout", NumPyLayout)
+@pytest.mark.parametrize("side", ["src", "dst"])
+def test_read_many_slices_layouts(h5file, side, layout, shape):
+    """read_many_slices uses the hdf5 C API for the memory layouts H5Sselect_hyperslab
+    can describe and falls back to the pure-python transfer for the rest, with the same
+    outcome either way.
     """
-    src = np.arange(1, 17).reshape(4, 4)
-    expect = np.zeros((8, 12), dtype=src.dtype)
-    expect[::2, ::3] = src[()]
+    if layout.value.min_ndim > len(shape):
+        pytest.skip(f"{layout.name} requires at least {layout.value.min_ndim} axes")
 
-    dst = np.zeros_like(expect)
-    read_many_slices(src, dst[::2, ::3], [(0, 0), (2, 0)], [(0, 0), (2, 0)], (2, 4))
-    np.testing.assert_equal(dst, expect)
+    dtype = np.dtype(np.int32)
+    data = np.arange(1, np.prod(shape) + 1, dtype=dtype).reshape(shape)
+    params = {
+        "src_start": [[i % s for s in shape] for i in range(3)],
+        "dst_start": [[(i + 1) % s for s in shape] for i in range(3)],
+        "count": [list(shape) for _ in range(3)],
+        "src_stride": [[i + 1] * len(shape) for i in range(3)],
+        "dst_stride": [[3 - i] * len(shape) for i in range(3)],
+    }
 
-    src = h5file.create_dataset("a", data=src)
-    dst = np.zeros_like(expect)
-    read_many_slices(
-        src, dst[::2, ::3], [(0, 0), (2, 0)], [(0, 0), (2, 0)], (2, 4), fast=False
-    )
-    np.testing.assert_equal(dst, expect)
+    if side == "dst":
+        ref_src = data
+    else:
+        ref_src = make_array(shape, dtype, layout, "range")
 
-    # h5py src only works in slow mode
-    with pytest.raises(ValueError, match="fast transfer is not possible"):
-        read_many_slices(
-            src, dst[::2, ::3], [(0, 0), (2, 0)], [(0, 0), (2, 0)], (2, 4), fast=True
-        )
+    # numpy->numpy always goes through the pure-python transfer
+    expect = np.zeros(shape, dtype)
+    read_many_slices(ref_src, expect, **params)
+
+    dset = h5file.create_dataset("a", shape=shape, dtype=dtype)
+
+    for fast in (None, False, True):
+        if side == "dst":
+            if not layout.value.writeable:
+                continue
+
+            dset[...] = data
+            np_arr = make_array(shape, dtype, layout, "zeros")
+            src, dst = dset, np_arr
+        else:
+            dset[...] = 0
+            src, dst = ref_src, dset
+
+        if fast and not layout.value.fast:
+            with pytest.raises(ValueError, match="fast transfer is not possible"):
+                read_many_slices(src, dst, **params, fast=True)
+        else:
+            read_many_slices(src, dst, **params, fast=fast)
+            np.testing.assert_array_equal(dst[...], expect, strict=True)
 
 
 def test_read_many_slices_not_fast_read_ok(h5file):

--- a/versioned_hdf5/slicetools.pyx
+++ b/versioned_hdf5/slicetools.pyx
@@ -99,6 +99,8 @@ cdef extern from "hdf5.h":
     ) except H5S_sel_type.H5S_SEL_ERROR nogil
     cdef herr_t H5Sclose(hid_t space_id) nogil
     cdef int H5Sget_simple_extent_ndims(hid_t space_id) nogil
+    cdef enum:
+        H5S_MAX_RANK
     cdef hid_t H5Screate_simple	(
         int rank,
         const hsize_t* dims,
@@ -354,13 +356,15 @@ cpdef void read_many_slices(
     ----------
     src: np.ndarray | h5py.Dataset | other array-like object
         The source data to read from
-    dst: np.ndarray | h5py.Dataset | other numpy-like object
+    dst: np.ndarray | h5py.Dataset | other array-like object
         The destination array to write to.
 
         The following combinations of src and dst are optimized:
 
-        - src is a h5py.Dataset with simple extents; dst is a C-contiguous numpy array
-        - dst is a h5py.Dataset with simple extents; src is a C-contiguous numpy array
+        - src is a h5py.Dataset with simple extents; dst is a NumPy array whose
+          strides suit H5Sselect_hyperslab
+        - dst is a h5py.Dataset with simple extents; src is a NumPy array whose strides
+          suit H5Sselect_hyperslab
 
         All other combinations are supported but fall back to a generic, pure-python
         transfer.
@@ -385,10 +389,10 @@ cpdef void read_many_slices(
     fast: bool, optional
         If True, use the hdf5 C API directly to transfer the data. This is possible when
         src is a h5py dataset with a simple data type (see h5py.Dataset._fast_read_ok)
-        and dst is a C-contiguous numpy array, or the other way around.
-        Raise if fast transfer is not possible.
+        and dst is a NumPy array whose strides suit H5Sselect_hyperslab, or the other
+        way around. Raise if fast transfer is not possible.
 
-        If False, always use pure Python numpy syntax to slice src and dst.
+        If False, always use pure Python NumPy syntax to slice src and dst.
 
         If omitted, determine automatically. It's recommended to omit this flag unless
         you're running a unit test or benchmark.
@@ -438,7 +442,7 @@ cpdef void read_many_slices(
 
     Performance notes
     -----------------
-    When reading/writing between h5py and a C-contiguous numpy array, this function
+    When reading/writing between h5py and a suitable NumPy array, this function
     calls::
 
         H5Sselect_hyperslab(file_id, H5S_SELECT_SET, ...)
@@ -476,12 +480,17 @@ cpdef void read_many_slices(
         dst_axis0_offset = dst.offset
         dst = dst.raw_data
 
+    cdef hsize_t[NPY_MAXDIMS] mem_dims
+
     cdef bint fast_h5_to_np = False
     cdef bint fast_np_to_h5 = False
     if fast is not False:
         with phil:
-            fast_h5_to_np = _supports_fast_h5_np(src, dst)
-            fast_np_to_h5 = _supports_fast_h5_np(dst, src)
+            # Only one of the two directions can ever be viable
+            if _supports_fast_h5_np(src, dst):
+                fast_h5_to_np = _np_hyperslab_dims(dst, mem_dims)
+            elif _supports_fast_h5_np(dst, src):
+                fast_np_to_h5 = _np_hyperslab_dims(src, mem_dims)
         if fast is True and not fast_h5_to_np and not fast_np_to_h5:
             raise ValueError("fast transfer is not possible with given src/dst arrays")
     cdef bint bfast = fast_h5_to_np or fast_np_to_h5
@@ -521,9 +530,6 @@ cpdef void read_many_slices(
 
     cdef np.ndarray src_shape = np.array(src.shape, dtype=np_hsize_t)
     cdef np.ndarray dst_shape = np.array(dst.shape, dtype=np_hsize_t)
-    # On 32-bit platforms, sizeof(hsize_t) == 8; sizeof(npy_intp) == 4
-    # On 64-bit platforms, don't copy unnecessarily
-    dst_shape = asarray(dst_shape, dtype=np_hsize_t)
 
     clipped_count = _clip_count(
         src_shape,
@@ -542,7 +548,7 @@ cpdef void read_many_slices(
             src,
             dst,
             False,
-            <hsize_t*>dst_shape.data,
+            mem_dims,
             src_start,
             dst_start,
             clipped_count,
@@ -554,7 +560,7 @@ cpdef void read_many_slices(
             dst,
             src,
             True,
-            <hsize_t*>src_shape.data,
+            mem_dims,
             src_start,
             dst_start,
             clipped_count,
@@ -574,13 +580,13 @@ cpdef void read_many_slices(
 
 
 cdef np.ndarray _preproc_many_slices_idx(obj: ArrayLike, hsize_t ndim, bint fast):
-    """Helper of read_many_slices. Ensure that obj is a numpy array of hsize_t with
+    """Helper of read_many_slices. Ensure that obj is a NumPy array of hsize_t with
     either 1 or 2 dimensions, and that it's C-contiguous at least along the
     innermost dimension.
     """
-    # np.asarray with unsigned dtype raises in numpy>=2 if presented with a Python list
+    # np.asarray with unsigned dtype raises in NumPy>=2 if presented with a Python list
     # containing negative numbers, but can quietly cause an integer underflow if arr is
-    # already a numpy array with signed dtype and negative numbers in it.
+    # already a NumPy array with signed dtype and negative numbers in it.
     # TODO https://github.com/numpy/numpy/issues/25396
     if not NP_GE_200:
         obj = np.asarray(obj)
@@ -640,13 +646,85 @@ cdef hsize_t[:, :] _clip_count(
 
 
 cdef bint _supports_fast_h5_np(maybe_h5_dset, maybe_np_arr):
-    """Return True if we can use _read_many_slices_h5_np; False otherwise."""
+    """Return True if the types of the two arrays allow _read_many_slices_h5_np;
+    False otherwise.
+    Note: the NumPy strides must also pass _np_hyperslab_dims (see below).
+    """
     return (
         isinstance(maybe_h5_dset, h5py.Dataset)
         and isinstance(maybe_np_arr, np.ndarray)
         and maybe_h5_dset._fast_read_ok
-        and maybe_np_arr.flags.c_contiguous
     )
+
+
+cdef bint _np_hyperslab_dims(np.ndarray arr, hsize_t* mem_dims):
+    """Fill `mem_dims` with the extents of a simple dataspace laid out over arr's
+    buffer, for use as the mem_space in H5Dread/H5Dwrite.
+
+    A hyperslab (start, stride, count) on that dataspace is meant to land exactly
+    on arr's memory, so the dataspace's row-major strides must equal arr's element
+    strides. This works for C-contiguous arrays and views that slice or step any
+    axis as long as the innermost axis's elements stay adjacent in memory:
+    a[1:4], a[:, 2:5], a[::2, :], a[:, None].
+
+    Return False for these use cases, which are not supported by HDF5:
+    - a.T or Fortran order
+    - negative strides, e.g. a[::-1]
+    - overlapping views, e.g. like np.broadcast_to or sliding_window_view.
+
+    Also return False for arrays whose innermost axis is a stepped view,
+    e.g. a[:, ::2], which are functionally supported by libhdf5 but, as of
+    version 2.1, they perform 15x to 40x slower than NumPy's own strided copy.
+    """
+    cdef int ndim = np.PyArray_NDIM(arr)
+    cdef np.npy_intp* shape = np.PyArray_DIMS(arr)
+    cdef np.npy_intp* strides = np.PyArray_STRIDES(arr)
+    cdef np.npy_intp itemsize = np.PyArray_ITEMSIZE(arr)
+    cdef hsize_t[NPY_MAXDIMS] np_strides  # arr's element strides; 0 = don't care
+    cdef hsize_t[NPY_MAXDIMS] c_strides  # dataspace strides, in points
+    cdef hsize_t reach  # points to fit along the next dataspace axis outwards
+    cdef hsize_t min_stride, stride_j
+    cdef int j
+
+    assert itemsize >= 1
+    if ndim > H5S_MAX_RANK:
+        # Unreachable: as of libhdf5 2.1 and NumPy 2.5, H5S_MAX_RANK == NPY_MAXDIMS
+        return False
+
+    # NumPy sets the stride of a length-1 axis arbitrarily and never applies it. Copy
+    # the stride of the axis outside it: that imposes the same constraints as if the
+    # axis weren't there, which is always the least restrictive choice. 0 = nothing
+    # outside it; pick the tightest stride below instead.
+    for j in range(ndim):
+        if shape[j] > 1:
+            if strides[j] <= 0 or strides[j] % itemsize != 0:
+                return False
+            np_strides[j] = <hsize_t>strides[j] // <hsize_t>itemsize
+        elif j > 0:
+            np_strides[j] = np_strides[j - 1]
+        else:
+            np_strides[j] = 0
+
+    if shape[ndim - 1] > 1 and np_strides[ndim - 1] != 1:
+        return False
+    c_strides[ndim - 1] = 1
+    reach = <hsize_t>shape[ndim - 1]
+
+    for j in range(ndim - 2, -1, -1):
+        # Tightest stride that doesn't overlap the axes inside this one. Can't overflow:
+        # it's bounded by arr's buffer size unless we already returned False.
+        min_stride = c_strides[j + 1] * reach
+        stride_j = np_strides[j]
+        if stride_j == 0:
+            stride_j = min_stride
+        elif stride_j < min_stride or stride_j % c_strides[j + 1] != 0:
+            return False
+        c_strides[j] = stride_j
+        mem_dims[j + 1] = stride_j // c_strides[j + 1]
+        reach = <hsize_t>shape[j]
+
+    mem_dims[0] = reach
+    return True
 
 
 @cython.wraparound(False)
@@ -656,7 +734,7 @@ cdef void _read_many_slices_h5_np (
     h5_dset: h5py.Dataset,
     np.ndarray np_arr,
     bint write,
-    const hsize_t* np_arr_shape,
+    const hsize_t* mem_dims,
     const hsize_t[:, :] src_start,
     const hsize_t[:, :] dst_start,
     const hsize_t[:, :] count,
@@ -664,7 +742,8 @@ cdef void _read_many_slices_h5_np (
     const hsize_t[:, :] dst_stride,
 ):
     """Implements read_many_slices data transfer between an h5py.Dataset with simple
-    extents (h5py.Dataset._fast_read_ok) and a C-contiguous numpy array.
+    extents (h5py.Dataset._fast_read_ok) and a NumPy array, with ``mem_dims`` from
+    _np_hyperslab_dims.
 
     Performance notes
     -----------------
@@ -686,7 +765,7 @@ cdef void _read_many_slices_h5_np (
         with nogil:
             nslices, ndim = src_start.shape[:2]
 
-            mem_space_id = H5Screate_simple(ndim, np_arr_shape, NULL)
+            mem_space_id = H5Screate_simple(ndim, mem_dims, NULL)
             if mem_space_id == H5I_INVALID_HID:
                 raise HDF5Error()
 
@@ -764,7 +843,8 @@ cdef void _read_many_slices_slow (
     - src or dst is a h5py.Dataset but h5py.Dataset._fast_read_ok returns False.
       This is to avoid replicating the complex machinery found in
       h5py.Dataset.__getitem__/__setitem__;
-    - src or dst are non-contiguous NumPy arrays;
+    - src or dst is a NumPy array whose strides don't suit H5Sselect_hyperslab, e.g. a
+      transposed one (see _np_hyperslab_dims);
     - both src and dst are NumPy arrays;
     - either src and dst are arbitrary NumPy-like objects (neither NumPy nor h5py).
 


### PR DESCRIPTION
Change `read_many_slices` to use native HDF5 hyperslab selection instead of falling back to the slow pure-Python path for these use cases:

- the NumPy array is a slice of a larger array;
- the NumPy array is stepped along an axis other than the innermost one.

This change matters for the final user when:
- the user calls `resize()` to enlarge an `InMemoryArrayDataset`, which causes `DatasetWrapper` to hot-swap it for a `InMemorySparseDataset` by calling `StagedChangesArray.from_array()`;
- after #547, where every time you commit an `InMemoryArrayDataset` it is transformed with `StagedChangesArray.from_array()`.

This is becauses `StagedChangesArray.from_array` creates staged slabs by vertically slicing the input NumPy Array, obtaining columns that are one chunk wide.

### Benchmarks

The speed-up is up to 11x for very small chunks and +33~50% for 64 kiB chunks (8192 points).
Delta from master:
```
| Change   | Before [bc80e415] <master>   | After [0d2e5a1c] <noncontig-readmanyslices>   | Ratio   | Benchmark (Parameter)                                                                                             |
|----------|------------------------------|-----------------------------------------------|---------|-------------------------------------------------------------------------------------------------------------------|
| -        | 449±10ms                     | 75.3±0.3ms                                    | 0.17    | read_many_slices.TimeReadManySlicesNonContiguous.time_read_many_slices_h5_to_np(128, 'sliced', None)              |
| -        | 437±10ms                     | 74.8±0.4ms                                    | 0.17    | read_many_slices.TimeReadManySlicesNonContiguous.time_read_many_slices_h5_to_np(128, 'strided_outer', None)       |
|          | 12.1±0.3ms                   | 10.9±0.3ms                                    | ~0.90   | read_many_slices.TimeReadManySlicesNonContiguous.time_read_many_slices_h5_to_np(131072, 'sliced', None)           |
|          | 12.4±0.2ms                   | 11.5±0.5ms                                    | 0.93    | read_many_slices.TimeReadManySlicesNonContiguous.time_read_many_slices_h5_to_np(131072, 'strided_outer', None)    |
| -        | 18.0±0.2ms                   | 12.1±0.08ms                                   | 0.67    | read_many_slices.TimeReadManySlicesNonContiguous.time_read_many_slices_h5_to_np(8192, 'sliced', None)             |
| -        | 18.8±0.6ms                   | 12.3±0.2ms                                    | 0.65    | read_many_slices.TimeReadManySlicesNonContiguous.time_read_many_slices_h5_to_np(8192, 'strided_outer', None)      |
| -        | 810±20ms                     | 70.0±1ms                                      | 0.09    | read_many_slices.TimeReadManySlicesNonContiguous.time_read_many_slices_np_to_h5(128, 'sliced', None)              |
| -        | 798±6ms                      | 70.7±0.8ms                                    | 0.09    | read_many_slices.TimeReadManySlicesNonContiguous.time_read_many_slices_np_to_h5(128, 'strided_outer', None)       |
| -        | 12.6±0.4ms                   | 11.4±0.02ms                                   | 0.90    | read_many_slices.TimeReadManySlicesNonContiguous.time_read_many_slices_np_to_h5(131072, 'sliced', None)           |
|          | 13.2±0.2ms                   | 11.9±0.09ms                                   | ~0.91   | read_many_slices.TimeReadManySlicesNonContiguous.time_read_many_slices_np_to_h5(131072, 'strided_outer', None)    |
| -        | 25.1±0.1ms                   | 12.3±0.07ms                                   | 0.49    | read_many_slices.TimeReadManySlicesNonContiguous.time_read_many_slices_np_to_h5(8192, 'sliced', None)             |
| -        | 25.3±0.2ms                   | 12.4±0.08ms                                   | 0.49    | read_many_slices.TimeReadManySlicesNonContiguous.time_read_many_slices_np_to_h5(8192, 'strided_outer', None)      |
```

Full benchmark output as of this PR:
```
[25.00%] ··· read_many_slices.TimeReadManySlicesNonContiguous.time_read_many_slices_h5_to_np                                                                      ok
[25.00%] ··· ============ ================= ========== ==========
             --                                      fast        
             ------------------------------ ---------------------
              chunk_size        layout         None      False   
             ============ ================= ========== ==========
                 128          contiguous     74.4±0ms   435±0ms  
                 128            sliced       73.6±0ms   431±0ms  
                 128        reverse_outer    474±0ms    436±0ms  
                 128        reverse_inner    437±0ms    433±0ms  
                 128        strided_outer    74.3±0ms   439±0ms  
                 128        strided_inner    428±0ms    426±0ms  
                 128          transposed     561±0ms    553±0ms  
                 8192         contiguous     11.6±0ms   18.9±0ms 
                 8192           sliced       11.6±0ms   17.9±0ms 
                 8192       reverse_outer    18.8±0ms   18.0±0ms 
                 8192       reverse_inner    18.4±0ms   18.6±0ms 
                 8192       strided_outer    12.4±0ms   19.2±0ms 
                 8192       strided_inner    19.0±0ms   19.1±0ms 
                 8192         transposed     20.2±0ms   20.4±0ms 
                131072        contiguous     11.0±0ms   12.2±0ms 
                131072          sliced       11.7±0ms   12.5±0ms 
                131072      reverse_outer    12.1±0ms   12.5±0ms 
                131072      reverse_inner    12.5±0ms   12.2±0ms 
                131072      strided_outer    11.4±0ms   13.2±0ms 
                131072      strided_inner    14.4±0ms   15.5±0ms 
                131072        transposed     14.5±0ms   14.7±0ms 
             ============ ================= ========== ==========

[50.00%] ··· read_many_slices.TimeReadManySlicesNonContiguous.time_read_many_slices_np_to_h5                                                                      ok
[50.00%] ··· ============ ================= ========== ==========
             --                                      fast        
             ------------------------------ ---------------------
              chunk_size        layout         None      False   
             ============ ================= ========== ==========
                 128          contiguous     73.3±0ms   848±0ms  
                 128            sliced       68.7±0ms   798±0ms  
                 128       broadcast_outer   836±0ms    810±0ms  
                 128       broadcast_inner   854±0ms    852±0ms  
                 128        reverse_outer    786±0ms    864±0ms  
                 128        reverse_inner    912±0ms    854±0ms  
                 128        strided_outer    72.1±0ms   822±0ms  
                 128        strided_inner    930±0ms    850±0ms  
                 128          transposed     1.07±0s    1.01±0s  
                 8192         contiguous     11.8±0ms   24.4±0ms 
                 8192           sliced       12.1±0ms   25.0±0ms 
                 8192      broadcast_outer   25.0±0ms   24.6±0ms 
                 8192      broadcast_inner   24.7±0ms   24.8±0ms 
                 8192       reverse_outer    26.0±0ms   26.0±0ms 
                 8192       reverse_inner    27.1±0ms   26.6±0ms 
                 8192       strided_outer    12.5±0ms   26.2±0ms 
                 8192       strided_inner    26.2±0ms   26.1±0ms 
                 8192         transposed     217±0ms    228±0ms  
                131072        contiguous     11.2±0ms   12.2±0ms 
                131072          sliced       11.5±0ms   13.3±0ms 
                131072     broadcast_outer   12.6±0ms   12.3±0ms 
                131072     broadcast_inner   12.1±0ms   12.2±0ms 
                131072      reverse_outer    13.5±0ms   13.7±0ms 
                131072      reverse_inner    15.3±0ms   15.5±0ms 
                131072      strided_outer    12.1±0ms   13.9±0ms 
                131072      strided_inner    14.3±0ms   14.2±0ms 
                131072        transposed     214±0ms    213±0ms  
             ============ ================= ========== ==========
```

## Out of scope
### Deep-copy small chunks
The benchmark highlights how we could implement heuristics, that kick in only for small chunk sizes, which deep-copy segments of the numpy array when there is a stride that HDF5 does not support (`reverse_outer`, `reverse_inner`, `strided_inner`).
Note that the legacy path (as of release v2.4.0) is to blindly call `np.ascontiguousarray` on _all_ chunks, individually, before writing them to disk.

### Transposed arrays
The benchmark also highlights how `np.ascontiguousarray` is very slow when the input is transposed (eg Fortran order) and  larger than the CPU cache, because it iterates on the input column-wise, trashing the cache. I vibe-coded a fix where the copy is chunked to stay within the CPU cache; this however is both very complex and would need to be implemented in NumPy: https://github.com/numpy/numpy/issues/32453

Note that in the above issue you can see how the cliff edge is 8 MiB, whereas in the benchmarks here you observe severe degradation already when writing 64 kiB chunks. chunk size is irrelevant: with NCOLS=128 float64, nrows=16384 ⇒ the transposed view has strides (8, 131072); 131072 = 2¹⁷ which causes entire rows of the input array to enter the cache during the conversion to C order, well beyond the target chunk. The correct approach here would be to perform a first copy to a contiguous array with the same order, and then order conversion (blocked, if the chunk size is larger than L3/2).

This does not cause a regression in #547; transposed numpy arrays already go through the same line in h5py's `_hl/dataset.py:1030-1034`:
```python
else:
    # If the input data is already an array, let HDF5 do the conversion.
    dt = None if isinstance(val, numpy.ndarray) else self.dtype.base
    val = numpy.asarray(val, order='C', dtype=dt)
```
that numpy.asarray is where the commit of a transposed InMemoryArrayDataset spends 99% of its time, before and after #547.