### PR TITLE
StagedChangesArray.from_array: keep trimmed edges

### DIFF
--- a/benchmarks/staged_changes.py
+++ b/benchmarks/staged_changes.py
@@ -40,6 +40,9 @@ STATES = [
     # writes to the chunks one by one. Worst case for the plans, which must
     # partition their transfers by slab.
     "fragmented",
+    # No base slabs; every chunk lies on a staged slab that is a view of the original
+    # dataset. Edge slabs may be smaller than the chunk size.
+    "from_array",
 ]
 
 #: (index, initial state) pairs for __getitem__ and __setitem__.
@@ -101,6 +104,9 @@ COMMIT_SCENARIOS = [
     # versions ago - so the deduplication table is 10x larger, even though the amount
     # of data that is read, hashed, and written is the same as in "all_new".
     "obsolete_base",
+    # No base slabs; every chunk lies on a staged slab that is a view of the original
+    # dataset. Edge slabs may be smaller than the chunk size.
+    "from_array",
 ]
 
 #: Number of chunks on the base slab that are left over from previous versions in the
@@ -121,6 +127,17 @@ def _commit_random(shape: tuple[int, ...], seed: int) -> StagedChangesArray:
     arr.commit()
     assert arr.n_base_slabs == 1
     return arr
+
+
+@cache
+def _buffer() -> np.ndarray:
+    """Return a writeable buffer of random data, of shape SHAPE.
+
+    This mimics the _buffer attribute of an InMemoryArrayDataset, the input to
+    StagedChangesArray.from_array(as_base_slabs=False) in
+    InMemoryArrayDatasetWrapper.resize().
+    """
+    return np.random.default_rng(0).random(SHAPE).astype(DTYPE)
 
 
 @cache
@@ -167,6 +184,11 @@ def make_array(state: str, n_obsolete_chunks: int = 0) -> StagedChangesArray:
     """Create a StagedChangesArray with the chunks laid out as described by STATES"""
     assert state in STATES
 
+    if state == "from_array":
+        return StagedChangesArray.from_array(
+            _buffer(), chunk_size=CHUNK_SIZE, fill_value=0, as_base_slabs=False
+        )
+
     if state in ("full", "fragmented"):
         arr = StagedChangesArray.full(SHAPE, chunk_size=CHUNK_SIZE, dtype=DTYPE)
         if state == "fragmented":
@@ -204,8 +226,8 @@ def make_committable(scenario: str) -> StagedChangesArray:
     """Create a StagedChangesArray with staged changes as described by
     COMMIT_SCENARIOS, ready to be committed
     """
-    if scenario == "fragmented":
-        return make_array("fragmented")
+    if scenario in ("fragmented", "from_array"):
+        return make_array(scenario)
 
     n_obsolete_chunks = N_OBSOLETE_CHUNKS if scenario == "obsolete_base" else 0
     arr = make_array("base", n_obsolete_chunks=n_obsolete_chunks)
@@ -266,7 +288,7 @@ class TimeSetItem(_MutatingBenchmark):
         self.value = np.asarray(self.arr[self.idx]) + 1.0
 
     def time_setitem_plan(self, case):
-        self.arr._setitem_plan(self.idx)
+        self.arr._setitem_plan(self.idx, copy=False)
 
     def time_setitem(self, case):
         # Internally calls _setitem_plan() and then executes the plan
@@ -274,21 +296,48 @@ class TimeSetItem(_MutatingBenchmark):
 
 
 class TimeResize(_MutatingBenchmark):
-    """Benchmark ResizePlan creation and execution"""
+    """Benchmark ResizePlan creation and execution.
 
-    params = [list(RESIZES)]
-    param_names = ["resize"]
+    For the "from_array" state, enlarging also deep-copies the trimmed staged slabs,
+    as in the resize() of an InMemoryArrayDataset.
+    """
 
-    def setup(self, resize):
-        self.arr = make_array("base")
+    params = [list(RESIZES), ["base", "from_array"]]
+    param_names = ["resize", "state"]
+
+    def setup(self, resize, state):
+        self.arr = make_array(state)
         self.shape = RESIZES[resize]
 
-    def time_resize_plan(self, resize):
-        self.arr._resize_plan(self.shape)
+    def time_resize_plan(self, resize, state):
+        self.arr._resize_plan(self.shape, copy=False)
 
-    def time_resize(self, resize):
+    def time_resize(self, resize, state):
         # Internally calls _resize_plan() and then executes the plan
         self.arr.resize(self.shape)
+
+
+class TimeFromArray:
+    """Benchmark StagedChangesArray.from_array().
+
+    This is the entry point of the resize() of an InMemoryArrayDataset, which calls
+    from_array(as_base_slabs=False) and then resize(). With as_base_slabs=False the
+    staged slabs are views of the input buffer; only the trimmed edge slabs are
+    deep-copied, and only later, upon resize() or first write.
+    """
+
+    params = [["base", "staged"]]
+    param_names = ["as_base_slabs"]
+
+    def setup(self, as_base_slabs):
+        self.arr = _buffer()
+
+    def time_from_array(self, as_base_slabs):
+        _ = StagedChangesArray.from_array(
+            self.arr,
+            chunk_size=CHUNK_SIZE,
+            as_base_slabs=as_base_slabs == "base",
+        )
 
 
 class TimeLoad(_MutatingBenchmark):
@@ -305,7 +354,7 @@ class TimeLoad(_MutatingBenchmark):
         self.arr = make_array(state)
 
     def time_load_plan(self, state):
-        self.arr._load_plan()
+        self.arr._load_plan(copy=False)
 
     def time_load(self, state):
         # Internally calls _load_plan() and then executes the plan
@@ -370,4 +419,4 @@ class TimeCommitPlan:
         self.arr._calc_hashes()
 
     def time_commit_plan(self, scenario):
-        self.arr._commit_plan()
+        self.arr._commit_plan(copy=False)

--- a/docs/staged_changes.rst
+++ b/docs/staged_changes.rst
@@ -324,6 +324,16 @@ be physically filled with the fill_value:
 2. then, there is a transfer from the full slab to the staged slab for the extra area
    that needs to be filled with the fill_value.
 
+Trimmed staged slabs
+^^^^^^^^^^^^^^^^^^^^
+``from_array(as_base_slabs=False)`` creates staged slabs as views of the input array.
+When the input array's shape is not exactly divisible by the ``chunk_size``, these views
+may not be large enough to contain the chunks after ``resize()`` enlarges the array.
+``resize()`` deep-copies trimmed slabs into new ones padded with empty data. It's
+important that this happens lazily, only when and if needed, to avoid unnecessary
+deep-copies when the array is never enlarged over its lifetime - notably, when it's
+created and then immediately consumed and destroyed when committing an
+InMemoryArrayDataset.
 
 ``load()`` algorithm
 --------------------

--- a/docs/staged_changes.rst
+++ b/docs/staged_changes.rst
@@ -333,7 +333,7 @@ may not be large enough to contain the chunks after ``resize()`` enlarges the ar
 important that this happens lazily, only when and if needed, to avoid unnecessary
 deep-copies when the array is never enlarged over its lifetime - notably, when it's
 created and then immediately consumed and destroyed when committing an
-InMemoryArrayDataset.
+``InMemoryArrayDataset``.
 
 ``load()`` algorithm
 --------------------

--- a/docs/staged_changes.rst
+++ b/docs/staged_changes.rst
@@ -324,6 +324,7 @@ be physically filled with the fill_value:
 2. then, there is a transfer from the full slab to the staged slab for the extra area
    that needs to be filled with the fill_value.
 
+
 Trimmed staged slabs
 ^^^^^^^^^^^^^^^^^^^^
 ``from_array(as_base_slabs=False)`` creates staged slabs as views of the input array.

--- a/tests/test_staged_changes.py
+++ b/tests/test_staged_changes.py
@@ -1364,8 +1364,7 @@ def test_from_array_as_staged_slabs_6():
 def test_from_array_as_staged_slabs_trimmed_shapes():
     """from_array(..., as_base_slabs=False)
 
-    Edge slabs are trimmed to the exact edge size, never padded,
-    and _has_trimmed_staged_slabs is set.
+    Edge slabs are trimmed to the exact edge size, never padded.
     """
     arr = np.arange(35).reshape((5, 7))
     a = StagedChangesArray.from_array(arr, chunk_size=(3, 4), as_base_slabs=False)

--- a/tests/test_staged_changes.py
+++ b/tests/test_staged_changes.py
@@ -35,14 +35,16 @@ def action_st(shape: tuple[int, ...], max_size: int = 20):
 def staged_array_st(
     draw, max_ndim: int = 4, max_size: int = 20, max_actions: int = 6
 ) -> tuple[
-    Literal["full", "from_array"],  # how to create the base array
+    Literal["full", "from_array", "from_array_staged"],  # how to create the base array
     tuple[int, ...],  # initial shape
     tuple[int, ...],  # chunk size
     list[tuple[Literal["getitem", "setitem", "resize"], Any]],  # 0 or more actions
 ]:
-    base, (shape, chunks), n_actions = draw(
+    base_kind, (shape, chunks), n_actions = draw(
         st.tuples(
-            st.one_of(st.just("full"), st.just("from_array")),
+            st.one_of(
+                st.just("full"), st.just("from_array"), st.just("from_array_staged")
+            ),
             shape_chunks_st(max_ndim=max_ndim, min_size=0, max_size=max_size),
             st.integers(0, max_actions),
         )
@@ -56,25 +58,25 @@ def staged_array_st(
         if label == "resize":
             shape = arg
 
-    return base, orig_shape, chunks, actions
+    return base_kind, orig_shape, chunks, actions
 
 
 @pytest.mark.slow
 @given(staged_array_st())
 @hypothesis.settings(max_examples=max_examples, deadline=None)
 def test_staged_array(args):
-    base, shape, chunks, actions = args
+    base_kind, shape, chunks, actions = args
 
     rng = np.random.default_rng(0)
     fill_value = 42
 
-    if base == "full":
+    if base_kind == "full":
         base = np.full(shape, fill_value, dtype="u4")
         arr = StagedChangesArray.full(
             shape, chunk_size=chunks, fill_value=fill_value, dtype=base.dtype
         )
         assert arr.n_base_slabs == 0
-    elif base == "from_array":
+    elif base_kind == "from_array":
         base = rng.integers(2**32, size=shape, dtype="u4")
         # copy base to detect bugs where the StagedChangesArray
         # accidentally writes back to the base slabs
@@ -85,6 +87,14 @@ def test_staged_array(args):
             assert arr.n_base_slabs == 0
         else:
             assert arr.n_base_slabs > 0
+    elif base_kind == "from_array_staged":
+        base = rng.integers(2**32, size=shape, dtype="u4")
+        # The staged slabs are writeable views of base: __setitem__ intentionally
+        # writes back into base, and resize() deep-copies the trimmed slabs.
+        arr = StagedChangesArray.from_array(
+            base, chunk_size=chunks, fill_value=fill_value, as_base_slabs=False
+        )
+        assert arr.n_base_slabs == 0
     else:
         raise AssertionError("unreachable")
 
@@ -94,6 +104,7 @@ def test_staged_array(args):
     assert arr.fill_value.dtype == base.dtype
     assert arr.slabs[0].dtype == base.dtype
     assert arr.slabs[0].shape == chunks
+    assert arr.n_slabs == len(arr.slabs)
     assert arr.itemsize == 4
     assert arr.size == np.prod(shape)
     assert arr.nbytes == np.prod(shape) * 4  # dtype=uint32
@@ -104,9 +115,18 @@ def test_staged_array(args):
     assert len(arr.n_chunks) == len(shape)
     for n, s, c in zip(arr.n_chunks, shape, chunks, strict=True):
         assert n == s // c + (s % c > 0)
-    assert arr.n_staged_slabs == 0
-    assert arr.n_base_slabs + 1 == arr.n_slabs == len(arr.slabs)
-    assert not arr.has_changes
+    if base_kind == "from_array_staged":
+        assert arr.n_staged_slabs == arr.n_slabs - 1
+        if base.size > 0:
+            assert arr.n_staged_slabs > 0
+            assert arr.has_changes
+        else:
+            assert arr.n_staged_slabs == 0
+            assert not arr.has_changes
+    else:
+        assert arr.n_staged_slabs == 0
+        assert not arr.has_changes
+        assert arr.n_base_slabs + 1 == arr.n_slabs == len(arr.slabs)
 
     expect = base.copy()
 
@@ -142,7 +162,9 @@ def test_staged_array(args):
     # - a round-trip where an array is created empty, resized, filled, wiped by
     #   resize(0), and then # resized to the original shape will have has_changes=True
     #   even if identical to the original.
-    if expect.shape != base.shape or (expect != base).any():
+    if base_kind == "from_array_staged" and base.size > 0:
+        assert arr.has_changes
+    elif expect.shape != base.shape or (expect != base).any():
         assert arr.has_changes
     elif all(label == "getitem" for label, _ in actions):
         assert not arr.has_changes
@@ -1213,26 +1235,26 @@ def test_from_array_as_staged_slabs_2():
     """from_array(..., as_base_slabs=False)
 
     Input array is not exactly divisible by chunk_size.
-    Edge slabs are deep-copied; everything else is a writeable view.
+    All slabs are views of the original array, including the trimmed edge slabs.
+    resize() deep-copies the trimmed slabs if and when it is called.
     """
     arr = np.arange(15).reshape((3, 5))
     a = StagedChangesArray.from_array(arr, chunk_size=(2, 2), as_base_slabs=False)
     assert_array_equal(a, arr)
-    # Test that non-edge chunks are views
+    # Test that all chunks are views, including the edge chunks
+    for slab in a.staged_slabs:
+        assert slab is not None
+        assert np.shares_memory(slab, arr)
     a[:, :] = -1
     assert_array_equal(a, np.full((3, 5), -1))
-    assert_array_equal(
-        arr,
-        np.array(
-            [
-                [-1, -1, -1, -1, 4],
-                [-1, -1, -1, -1, 9],
-                [10, 11, 12, 13, 14],
-            ]
-        ),
-    )
-    # Enlarging at a later time is OK
+    assert_array_equal(arr, np.full((3, 5), -1))  # All slabs are views
+    # resize() deep-copies and pads the trimmed slabs; from now on writes to a
+    # don't propagate to arr
     a.resize((4, 6))
+    for slab in a.staged_slabs:
+        assert slab is not None
+        assert slab.shape == (4, 2)  # padded from (3, 2) or (3, 1) to (4, 2)
+        assert not np.shares_memory(slab, arr)
     a[0, -1] = 22
     a[-1, 0] = 33
     assert_array_equal(
@@ -1257,22 +1279,58 @@ def test_from_array_as_staged_slabs_3():
     a = StagedChangesArray.from_array(arr, chunk_size=(2, 2), as_base_slabs=False)
     assert_array_equal(a, arr)
     a[:, :] = -1
-    assert_array_equal(a, np.array([[-1, -1, -1], [-1, -1, -1]]))
-    assert_array_equal(arr, np.array([[-1, -1, 2], [-1, -1, 5]]))
+    assert_array_equal(a, np.full((2, 3), -1))
+    assert_array_equal(arr, np.full((2, 3), -1))  # All slabs are views
+
+    # resize() deep-copies the trimmed slab only; the full-size slab is still a view
+    a.resize((4, 5))
+    full_slab = a.staged_slabs[0]
+    assert full_slab is not None
+    assert full_slab.shape == (2, 2)
+    assert np.shares_memory(full_slab, arr)
+    trimmed_slab = a.staged_slabs[1]
+    assert trimmed_slab is not None
+    assert trimmed_slab.shape == (2, 2)
+    assert not np.shares_memory(trimmed_slab, arr)
+    assert_array_equal(
+        a,
+        np.array(
+            [
+                [-1, -1, -1, 0, 0],
+                [-1, -1, -1, 0, 0],
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+            ]
+        ),
+    )
+    a[:] = 5
+    assert_array_equal(arr, np.array([[5, 5, -1], [5, 5, -1]]))
 
 
 def test_from_array_as_staged_slabs_4():
     """from_array(..., as_base_slabs=False)
 
     Input array is too small to fully cover even a single chunk;
-    all slabs are deep-copied.
+    the slab is a trimmed writeable view of the input array,
+    and resize() deep-copies it into a padded slab.
     """
     arr = np.asarray([1, 2])
     a = StagedChangesArray.from_array(arr, chunk_size=(3,), as_base_slabs=False)
     assert_array_equal(a, arr)
+    assert a.slabs[1].shape == (2,)
+    assert np.shares_memory(a.slabs[1], arr)
+
     a[:] = -1
     assert_array_equal(a, np.array([-1, -1]))
-    assert_array_equal(arr, np.array([1, 2]))
+    assert_array_equal(arr, np.array([-1, -1]))
+
+    # resize() deep-copies and pads the trimmed slab
+    a.resize((5,))
+    assert a.slabs[1].shape == (3,)  # padded from (2,) to (3,)
+    assert not np.shares_memory(a.slabs[1], arr)
+    assert_array_equal(a, np.array([-1, -1, 0, 0, 0]))
+    a[0] = 7
+    assert_array_equal(arr, np.array([-1, -1]))
 
 
 def test_from_array_as_staged_slabs_5():
@@ -1284,7 +1342,7 @@ def test_from_array_as_staged_slabs_5():
     arr.flags.writeable = False
     a = StagedChangesArray.from_array(arr, chunk_size=(2,), as_base_slabs=False)
     assert_array_equal(a, arr)
-    assert a.slabs[1].base is arr
+    assert np.shares_memory(a.slabs[1], arr)
     a[:] = -1
     assert_array_equal(a, [-1, -1, -1])
     assert_array_equal(arr, [0, 1, 2])
@@ -1301,6 +1359,151 @@ def test_from_array_as_staged_slabs_6():
     a[:] = -1
     assert_array_equal(a, [-1, -1, -1])
     assert_array_equal(arr, [0, 1, 2])
+
+
+def test_from_array_as_staged_slabs_trimmed_shapes():
+    """from_array(..., as_base_slabs=False)
+
+    Edge slabs are trimmed to the exact edge size, never padded,
+    and _has_trimmed_staged_slabs is set.
+    """
+    arr = np.arange(35).reshape((5, 7))
+    a = StagedChangesArray.from_array(arr, chunk_size=(3, 4), as_base_slabs=False)
+    assert sorted(slab.shape for slab in a.staged_slabs) == [(5, 3), (5, 4)]
+    assert_array_equal(a, arr)
+
+
+def test_from_array_as_staged_slabs_resize_shrink_and_noop():
+    """resize() deep-copies trimmed staged slabs only when enlarging beyond a trimmed
+    edge; a shrink or a no-op resize leaves them as views. Enlarging afterwards still
+    works."""
+    arr = np.arange(15).reshape((3, 5))
+
+    # Shrink
+    a = StagedChangesArray.from_array(arr, chunk_size=(2, 2), as_base_slabs=False)
+    a.resize((2, 3))
+    assert a.shape == (2, 3)
+    assert_array_equal(a, arr[:2, :3])
+    for slab in a.staged_slabs:
+        if slab is None:
+            continue
+        assert np.shares_memory(slab, arr)  # still views
+    # Enlarging again works
+    a.resize((4, 5))
+    expected = np.zeros((4, 5), dtype=arr.dtype)
+    expected[:2, :3] = arr[:2, :3]
+    assert_array_equal(a, expected)
+    for slab in a.staged_slabs:
+        if slab is None:
+            continue
+        assert slab.shape[1:] == (2,)
+
+    # No-op
+    b = StagedChangesArray.from_array(arr, chunk_size=(2, 2), as_base_slabs=False)
+    b.resize((3, 5))
+    assert_array_equal(b, arr)
+    for slab in b.staged_slabs:
+        assert slab is not None
+        assert np.shares_memory(slab, arr)  # still views
+    # Enlarging again works
+    b.resize((4, 6))
+    expected = np.zeros((4, 6), dtype=arr.dtype)
+    expected[:3, :5] = arr
+    assert_array_equal(b, expected)
+    for slab in b.staged_slabs:
+        assert slab is not None
+        assert slab.shape == (4, 2)
+
+
+def test_from_array_as_staged_slabs_changes():
+    """changes() yields edge chunks trimmed to the exact edge size."""
+    arr = np.arange(15).reshape((3, 5))
+    a = StagedChangesArray.from_array(arr, chunk_size=(2, 2), as_base_slabs=False)
+
+    a[1, 1] = -1
+    final = np.zeros_like(arr)
+    for idx, _, chunk in a.changes():
+        assert not isinstance(chunk, tuple)  # all chunks lie on staged slabs
+        final[idx] = chunk  # chunk.shape must match the size of idx
+    assert_array_equal(final, a)
+
+
+def test_from_array_as_staged_slabs_commit():
+    """commit() hashes, deduplicates, and consolidates trimmed staged slabs."""
+    arr = np.arange(15).reshape((3, 5))
+    a = StagedChangesArray.from_array(arr, chunk_size=(2, 2), as_base_slabs=False)
+    a[2, 2] = -1
+    a.commit()
+    assert a.n_base_slabs == 1
+    assert a.n_staged_slabs == 0
+    assert_array_equal(
+        a,
+        np.array(
+            [
+                [0, 1, 2, 3, 4],
+                [5, 6, 7, 8, 9],
+                [10, 11, -1, 13, 14],
+            ]
+        ),
+    )
+    for _, slab_idx, chunk in a.changes():
+        assert slab_idx == 1
+        assert isinstance(chunk, tuple)  # now read from the base slab
+
+    # Identical trimmed chunks are deduplicated at commit time
+    arr2 = np.full((7, 1), 5)
+    b = StagedChangesArray.from_array(arr2, chunk_size=(3, 1), as_base_slabs=False)
+    b.commit()
+    assert b.n_base_slabs == 1
+    assert b.base_slabs[0].shape == (6, 1)  # 2 unique chunks, not 3
+    assert_array_equal(b, arr2)
+
+
+def test_from_array_as_staged_slabs_copy():
+    """copy() CoW-deep-copies trimmed staged slabs upon first write access."""
+    arr = np.arange(15).reshape((3, 5))
+    a = StagedChangesArray.from_array(arr, chunk_size=(2, 2), as_base_slabs=False)
+    b = a.copy()
+    b[0, 0] = -1
+    assert b[0, 0] == -1
+    assert a[0, 0] == 0
+    assert arr[0, 0] == 0
+    # Only the slab touched by the write has been deep-copied; the other
+    # slabs are still read-only views of arr.
+    assert not np.shares_memory(b.slabs[1], arr)
+    assert np.shares_memory(b.slabs[2], arr)
+
+
+def test_from_array_as_staged_slabs_astype():
+    """astype() lazily converts trimmed staged slabs."""
+    arr = np.arange(15).reshape((3, 5))
+    a = StagedChangesArray.from_array(arr, chunk_size=(2, 2), as_base_slabs=False)
+    c = a.astype("i8")
+    assert c.dtype == np.dtype("i8")
+    assert_array_equal(c, arr)
+    c[2, 4] = -2
+    assert c[2, 4] == -2
+    assert arr[2, 4] == 14
+
+
+def test_from_array_as_staged_slabs_refill():
+    """refill() rewrites fill_value points on trimmed staged slabs in place."""
+    arr = np.arange(15).reshape((3, 5))
+    a = StagedChangesArray.from_array(arr, chunk_size=(2, 2), as_base_slabs=False)
+    d = a.refill(42)
+    assert d.fill_value == 42
+    expected = arr.copy()
+    expected[expected == 0] = 42
+    assert_array_equal(d, expected)
+
+
+def test_from_array_as_staged_slabs_rechunk():
+    """rechunk() works on trimmed staged slabs."""
+    arr = np.arange(15).reshape((3, 5))
+    a = StagedChangesArray.from_array(arr, chunk_size=(2, 2), as_base_slabs=False)
+    e = a.rechunk((4, 4))
+    assert e.chunk_size == (4, 4)
+    assert_array_equal(e, arr)
 
 
 # ---------------------------------------------------------------------------

--- a/versioned_hdf5/staged_changes.py
+++ b/versioned_hdf5/staged_changes.py
@@ -27,7 +27,7 @@ from versioned_hdf5.subchunk_map import (
     read_many_slices_params_nd,
 )
 from versioned_hdf5.tools import asarray, format_ndindex, ix_with_slices
-from versioned_hdf5.typing_ import ArrayProtocol, MutableArrayProtocol
+from versioned_hdf5.typing_ import MutableArrayProtocol
 
 if cython.compiled:  # pragma: nocover
     from cython.cimports import numpy as np
@@ -159,9 +159,13 @@ class StagedChangesArray(MutableMapping[Any, T]):
     #: They can be any read-only numpy-like object.
     #: slabs[n_base_slabs + 1:] contain the staged chunks.
     #:
-    #: Edge slabs that don't fully cover the chunk_size are padded with uninitialized
-    #: cells; the shape of each staged slab is always
-    #: (n*chunk_size[0], *chunk_size[1:]).
+    #: Edge slabs that don't fully cover the chunk_size are typically padded with
+    #: uninitialized cells; the shape of each slab is therefore
+    #: (n*chunk_size[0], *chunk_size[1:]), where n is the number of chunks in the slab.
+    #:
+    #: Exceptionally, if all chunks on the slab are edge chunks that don't fit the full
+    #: chunk size, the slab may be smaller than the above. Trimmed staged slabs must be
+    #: replaced with full ones when resize() enlarges the array.
     #:
     #: When resize() shrinks the array, causing a *staged* slab to no longer hold
     #: any chunk, the slab is dereferenced and
@@ -584,8 +588,10 @@ class StagedChangesArray(MutableMapping[Any, T]):
         if writeable and isinstance(slab, np.ndarray) and not slab.flags.writeable:
             assert idx is not None  # __getitem__ return value is always writeable
             assert idx > self.n_base_slabs  # Only staged slabs are writeable
-            # There was a previous call to copy()
-            slab = slab.copy()
+            # There was a previous call to copy(), or the slab is a view of a read-only
+            # array from from_array(as_base_slabs=False); it may be smaller than the
+            # full chunk size, in which case the copy is also padded.
+            slab = self._copy_slab(slab)
             self.slabs[idx] = slab
 
         return slab
@@ -721,6 +727,10 @@ class StagedChangesArray(MutableMapping[Any, T]):
         Staged slabs that are no longer needed are dereferenced; their location in the
         slabs list is replaced with None.
         This never causes base slabs or the full slab to be dereferenced.
+
+        When enlarging, trimmed staged slabs created by from_array(as_base_slabs=False)
+        are deep-copied into new slabs padded to a whole number of chunks, as enlarging
+        the array may otherwise need to write beyond the edge of a trimmed slab.
         """
         if not self.writeable:
             raise ValueError("assignment destination is read-only")
@@ -730,6 +740,16 @@ class StagedChangesArray(MutableMapping[Any, T]):
 
         plan = self._resize_plan(shape, copy=False)
 
+        untrim_axes = [
+            axis
+            for axis, (o, n, c) in enumerate(
+                zip(self.shape, shape, self.chunk_size, strict=True)
+            )
+            if n > o and o % c
+        ]
+        if untrim_axes:
+            self._untrim_staged_slabs(untrim_axes)
+
         # A resize may change the slab_indices and slab_offsets, but won't necessarily
         # impact any chunks. In such cases, this is a no-op.
         self._apply_mutating_plan(plan)
@@ -737,6 +757,29 @@ class StagedChangesArray(MutableMapping[Any, T]):
         if shape != self.shape:
             self.shape = shape
             self._resized = True
+
+    def _copy_slab(self, slab: NDArray[T]) -> NDArray[T]:
+        """Deep-copy a slab into a new NumPy array, padded to full chunk_size."""
+        padded_shape = (
+            int(ceil_a_over_b(slab.shape[0], self.chunk_size[0])) * self.chunk_size[0],
+            *self.chunk_size[1:],
+        )
+        new_slab = np.empty(padded_shape, dtype=slab.dtype)
+        new_slab[tuple(slice(s) for s in slab.shape)] = slab
+        return new_slab
+
+    def _untrim_staged_slabs(self, axes: list[int]) -> None:
+        """Deep-copy trimmed staged slabs into new slabs padded to full chunk_size.
+
+        Trimmed staged slabs are only ever created by from_array(as_base_slabs=False).
+        """
+        for slab_idx in range(self.staged_slabs_start, self.n_slabs):
+            slab = self.slabs[slab_idx]
+            if slab is None:
+                continue
+            if not any(slab.shape[axis] % self.chunk_size[axis] for axis in axes):
+                continue
+            self.slabs[slab_idx] = self._copy_slab(slab)
 
     def load(self) -> None:
         """Load all chunks that are not yet in memory from the base array."""
@@ -938,10 +981,16 @@ class StagedChangesArray(MutableMapping[Any, T]):
             if slab is None:
                 continue
             mask = slab == self.fill_value
-            if np.any(mask):
-                # Potentially remove read-only flag and convert dtype
-                slab = out._get_slab(idx, writeable=True)
-                slab[mask] = fill_value
+            if not np.any(mask):
+                continue
+            # Potentially remove read-only flag and convert dtype;
+            # this may also pad a trimmed slab.
+            wslab = out._get_slab(idx, writeable=True)
+            if wslab.shape != slab.shape:
+                # Apply mask to view with the old shape; everything outside of it is
+                # uninitialized memory.
+                wslab = wslab[tuple(slice(s) for s in slab.shape)]
+            wslab[mask] = fill_value
         return out
 
     def rechunk(self, chunk_size: tuple[int, ...]) -> StagedChangesArray[T]:
@@ -1021,31 +1070,14 @@ class StagedChangesArray(MutableMapping[Any, T]):
                 Set the base slabs as read-only views of ``arr``.
                 This is mostly useful for debugging and testing.
             False
-                Do not create any base slabs.
-                Set the staged slabs as writeable views of ``arr`` if possible;
-                otherwise as read-only views; otherwise as deep copies.
+                Do not create any base slabs. If ``arr`` is a NumPy array,
+                set the staged slabs as views of ``arr``.
+                Edge chunks that are not exactly divisible by chunk_size are stored in
+                trimmed slabs; they will be later deep-copied if resize() is invoked to
+                enlarge the array.
         """
         # Don't deep-copy array-like objects, as long as they allow for views
         arr = cast(np.ndarray, asarray(arr))
-
-        if not as_base_slabs:
-            # If a staged slab is not exactly divisible by chunk_size, it is going to be
-            # problematic down the line if we call resize() to enlarge the array.
-            # Use views of the array for all complete chunks and deep-copy the partial
-            # edge chunks.
-            shape_round_down = tuple(
-                s // c * c for s, c in zip(arr.shape, chunk_size, strict=True)
-            )
-            if shape_round_down != arr.shape:
-                out = StagedChangesArray.from_array(
-                    arr[tuple(slice(s) for s in shape_round_down)],
-                    chunk_size=chunk_size,
-                    fill_value=fill_value,
-                    as_base_slabs=False,
-                )
-                out.resize(arr.shape)
-                _set_edges(out, arr, shape_round_down)
-                return out
 
         out = StagedChangesArray.full(
             arr.shape, chunk_size=chunk_size, fill_value=fill_value, dtype=arr.dtype
@@ -1076,12 +1108,9 @@ class StagedChangesArray(MutableMapping[Any, T]):
                 # writing to them anyway.
                 if isinstance(slab, np.ndarray):
                     slab.flags.writeable = False
-            else:
-                assert slab.shape[0] % chunk_size[0] == 0
-                assert slab.shape[1:] == chunk_size[1:]
-                if not isinstance(slab, np.ndarray):
-                    # Staged slabs must be numpy arrays.
-                    slab = np.asarray(slab)
+            elif not isinstance(slab, np.ndarray):
+                # Staged slabs must be NumPy arrays
+                slab = out._copy_slab(slab)
 
             out.slabs.append(slab)
             out.hash_tables.append(None)
@@ -2567,25 +2596,3 @@ def _make_transfer_plans(
             slab_indices=slab_indices,
             slab_offsets=slab_offsets,
         )
-
-
-def _set_edges(
-    dst: MutableArrayProtocol, src: ArrayProtocol, shape: tuple[int, ...]
-) -> None:
-    """Copy src into dst, but only for the edge area outside the given shape
-    (aligned to the top left corner).
-
-    This is equivalent to::
-
-        mask = np.ones(dst.shape, dtype=bool)
-        mask[*(slice(s) for s in shape)] = False
-        dst[mask] = src[mask]
-
-    except that the above would be ~O(dst.size) whereas this function is ~O(edge size).
-    """
-    assert src.shape == dst.shape
-    assert len(shape) == dst.ndim
-    for i, (start, stop) in enumerate(zip(shape, dst.shape, strict=True)):
-        if stop > start:
-            idx = tuple(slice(s) for s in shape[:i]) + (slice(start, stop),)
-            dst[idx] = src[idx]


### PR DESCRIPTION
Towards https://github.com/deshaw/versioned-hdf5/issues/398

`StagedChangesArray.from_array(as_base_slabs=False)` used to eagerly deep-copy the edge chunks of the input NumPy array, to cater for the possibility that the array may be enlarged later on.
This PR makes the deep-copy lazy, making it happen inside `resize()` when and if it is actually invoked.

This speeds up the following use cases:

- a new dense dataset (`InMemoryArrayDataset`), with shape not exactly divisible by chunk size, is enlarged with `resize()`. This causes `DatasetWrapper` to hot-swap it for a `InMemorySparseDataset`. The dataset is not enlarged again before being committed.
- any dataset, with shape not exactly divisible by chunk size, is completely overwritten with `__setitem__`, which triggers a hot-swap to `InMemoryArrayDataset`, and then enlarged, which triggers a second hot-swap to `InMemorySparseDataset`; it is not enlarged again afterwards.
- _(the important one)_ downstream of #547, a new dense dataset, with shape not exactly divisible by chunk size, is committed.

# Benchmark

ASV shows how the deep-copy is pushed from StagedChangesArray.from_array to `resize()`:

| Change   | Before [43aa364a]   | After    | Ratio   | Benchmark (Parameter)                                               |
|----------|------------------------------|------------------------------------------------|---------|---------------------------------------------------------------------|
| -        | 943±200μs                    | 139±50μs                                       | 0.15    | staged_changes.TimeFromArray.time_from_array('staged')              |
| +        | 300±20μs                     | 2.94±0.2ms                                     | 9.82    | staged_changes.TimeResize.time_resize('append', 'from_array')       |
| +        | 640±100μs                    | 3.41±0.3ms                                     | 5.32    | staged_changes.TimeResize.time_resize('enlarge', 'from_array')      |
