### PR TITLE
Reduce peak memory in recreate_dataset

### DIFF
--- a/benchmarks/replay.py
+++ b/benchmarks/replay.py
@@ -12,8 +12,8 @@ from versioned_hdf5.replay import recreate_dataset, tmp_group
 from .common import Benchmark
 
 #: Shape of the dataset in every version, and its chunk size:
-#: 64 MiB of float64 in 256 KiB chunks, i.e. 256 chunks
-SHAPE = (8192, 1024)
+#: 128 MiB of float64 in 256 KiB chunks, i.e. 256 chunks
+SHAPE = (8192, 2048)
 CHUNK_SIZE = (32, 1024)
 DATASET_BYTES = np.prod(SHAPE) * 8
 CHUNK_BYTES = np.prod(CHUNK_SIZE) * 8

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -9,9 +9,11 @@ from numpy.testing import assert_equal
 from versioned_hdf5.backend import (
     DEFAULT_CHUNK_SIZE,
     Filters,
+    _chunk_blocks,
     _data_v4_to_sc_hash_table,
     create_base_dataset,
     create_virtual_dataset,
+    rewrite_dataset,
     write_dataset,
 )
 
@@ -953,3 +955,93 @@ def test_commit_staged_changes_out_of_order_hashtable(vfile):
     raw_data, hash_table = _raw_data_hashtable(vfile, "x")
     assert raw_data.shape == (4,)  # No new chunk was written
     assert hash_table.attrs["largest_index"] == 2
+
+
+@pytest.mark.parametrize(
+    ("shape", "chunk_size", "max_bytes", "expect"),
+    [
+        # A generous budget yields a single block covering everything
+        ((5,), (2,), 1000, [(slice(0, 5),)]),
+        # One chunk per block; the last block is trimmed to the edge of the array
+        ((5,), (2,), 16, [(slice(0, 2),), (slice(2, 4),), (slice(4, 5),)]),
+        # Two chunks per block
+        ((7,), (2,), 32, [(slice(0, 4),), (slice(4, 7),)]),
+        # max_bytes is rounded up to one whole chunk
+        ((4,), (2,), 0, [(slice(0, 2),), (slice(2, 4),)]),
+        # Blocks grow from the last axis, so that they are as contiguous as possible
+        (
+            (4, 6),
+            (2, 2),
+            64,
+            [
+                (slice(0, 2), slice(0, 4)),
+                (slice(0, 2), slice(4, 6)),
+                (slice(2, 4), slice(0, 4)),
+                (slice(2, 4), slice(4, 6)),
+            ],
+        ),
+        # Axis 1 fits entirely, so axis 0 starts growing too
+        ((4, 6), (2, 2), 96, [(slice(0, 2), slice(0, 6)), (slice(2, 4), slice(0, 6))]),
+        ((4, 6), (2, 2), 192, [(slice(0, 4), slice(0, 6))]),
+        # Size-0 arrays have no chunks at all
+        ((0,), (2,), 1000, []),
+        ((4, 0), (2, 2), 1000, []),
+    ],
+)
+def test_chunk_blocks(shape, chunk_size, max_bytes, expect):
+    assert list(_chunk_blocks(shape, chunk_size, 8, max_bytes)) == expect
+
+
+# One whole chunk, one chunk row, and the whole array at a time
+@pytest.mark.parametrize("max_bytes", [0, 8, 24, 1000])
+def test_rewrite_dataset(vfile, max_bytes):
+    """rewrite_dataset() copies every chunk of an array into a brand new raw_data,
+    deduplicating them, and returns the same {virtual index: raw_data slice} mapping
+    regardless of how many chunks it buffers at a time.
+    """
+    # Chunk (1, 0) is a duplicate of chunk (0, 1) and chunk (1, 1) of chunk (0, 0);
+    # the last row is a pair of edge chunks.
+    data = np.array(
+        [
+            [1, 2, 3, 4],
+            [5, 6, 7, 8],
+            [3, 4, 1, 2],
+            [7, 8, 5, 6],
+            [9, 9, 0, 0],
+        ]
+    )
+    create_base_dataset(vfile.f, "x", data=data[:0], chunks=(2, 2), fillvalue=0)
+    slices = rewrite_dataset(
+        vfile.f, "x", data, chunks=(2, 2), fillvalue=0, max_bytes=max_bytes
+    )
+
+    assert slices == {
+        Tuple(Slice(0, 2, 1), Slice(0, 2, 1)): Slice(0, 2, 1),
+        Tuple(Slice(0, 2, 1), Slice(2, 4, 1)): Slice(2, 4, 1),
+        Tuple(Slice(2, 4, 1), Slice(0, 2, 1)): Slice(2, 4, 1),
+        Tuple(Slice(2, 4, 1), Slice(2, 4, 1)): Slice(0, 2, 1),
+        Tuple(Slice(4, 5, 1), Slice(0, 2, 1)): Slice(4, 5, 1),
+        Tuple(Slice(4, 5, 1), Slice(2, 4, 1)): Slice(6, 7, 1),
+    }
+
+    # Only 4 chunks were written; the two duplicates were deduplicated away.
+    # raw_data always grows by whole chunks, so the two edge chunks are padded.
+    raw_data, hash_table = _raw_data_hashtable(vfile, "x")
+    assert hash_table.attrs["largest_index"] == 4
+    assert_equal(
+        raw_data[:],
+        [[1, 2], [5, 6], [3, 4], [7, 8], [9, 9], [0, 0], [0, 0], [0, 0]],
+    )
+
+    # The mapping stitches the original array back together
+    vfile.f["_version_data/versions"].create_group("r0")
+    create_virtual_dataset(vfile.f, "r0", "x", data.shape, slices, fillvalue=0)
+    assert_equal(vfile.f["_version_data/versions/r0/x"][:], data)
+
+
+@pytest.mark.parametrize("max_bytes", [0, 1000])
+def test_rewrite_dataset_empty(vfile, max_bytes):
+    """A size-0 dataset has no chunks to rewrite."""
+    data = np.empty((0, 3))
+    create_base_dataset(vfile.f, "x", data=data, chunks=(2, 2))
+    assert rewrite_dataset(vfile.f, "x", data, chunks=(2, 2), max_bytes=max_bytes) == {}

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -1,4 +1,7 @@
+import functools
+import gc
 import subprocess
+import tracemalloc
 from unittest import mock
 
 import h5py
@@ -10,8 +13,8 @@ from hypothesis import strategies as st
 from ndindex import Slice
 from numpy.testing import assert_array_equal
 
-from versioned_hdf5 import VersionedHDF5File
-from versioned_hdf5.backend import DEFAULT_CHUNK_SIZE
+from versioned_hdf5 import VersionedHDF5File, replay
+from versioned_hdf5.backend import DEFAULT_CHUNK_SIZE, rewrite_dataset
 from versioned_hdf5.h5py_compat import H5PY_VERSION
 from versioned_hdf5.hashtable import Hashtable
 from versioned_hdf5.replay import (
@@ -767,6 +770,79 @@ def test_recreate_dataset_staged_changes(vfile):
     hash_table = f["_version_data/x/hash_table"]
     assert raw_data.shape == (50,)
     assert hash_table.attrs["largest_index"] == 5
+
+
+# One whole chunk, one chunk row, and the whole dataset at a time
+@pytest.mark.parametrize("max_bytes", [0, 96, 10_000])
+def test_recreate_dataset_streams_chunks(vfile, monkeypatch, max_bytes):
+    """recreate_dataset() rewrites each version a block of chunks at a time, so that
+    peak memory usage doesn't scale with the size of the dataset. Neither the data nor
+    the deduplication across blocks and across versions may depend on the block size.
+    """
+    monkeypatch.setattr(
+        replay,
+        "rewrite_dataset",
+        functools.partial(rewrite_dataset, max_bytes=max_bytes),
+    )
+
+    # 3x2 chunks along axis 0 and 2 along axis 1, the last one of each being an edge
+    with vfile.stage_version("r0") as sv:
+        sv.create_dataset("x", data=np.arange(50.0).reshape(5, 10), chunks=(2, 4))
+    with vfile.stage_version("r1") as sv:
+        sv["x"][0, 0] = -1.0  # Rewrite chunk (0, 0) only
+    with vfile.stage_version("r2") as sv:
+        sv["x"][4, 9] = -2.0  # Rewrite edge chunk (2, 2) only
+
+    expected = {v: vfile[v]["x"][:] for v in ("r0", "r1", "r2")}
+
+    f = vfile.f
+    newf = tmp_group(f)
+    recreate_dataset(f, "x", newf)
+    swap(f, newf)
+
+    for v, want in expected.items():
+        assert_array_equal(vfile[v]["x"][:], want)
+
+    # r0 wrote 9 chunks; r1 and r2 added one each and deduplicated the other 8
+    # against the new raw_data.
+    raw_data = f["_version_data/x/raw_data"]
+    hash_table = f["_version_data/x/hash_table"]
+    assert hash_table.attrs["largest_index"] == 11
+    assert raw_data.shape == (22, 4)
+
+
+def test_recreate_dataset_bounded_memory(vfile, monkeypatch):
+    """recreate_dataset() streams the chunks of a committed dataset from the raw_data
+    of the source group into the raw_data of the target group, instead of loading whole
+    datasets in memory.
+    """
+    shape = (2048, 128)  # 2 MiB of float64
+    chunks = (32, 128)  # 32 kiB
+    max_bytes = 128 * 1024  # 128 kiB (16k points)
+    monkeypatch.setattr(
+        replay,
+        "rewrite_dataset",
+        functools.partial(rewrite_dataset, max_bytes=max_bytes),
+    )
+
+    rng = np.random.default_rng(0)
+    with vfile.stage_version("r0") as sv:
+        sv.create_dataset("x", data=rng.random(shape), chunks=chunks)
+    with vfile.stage_version("r1") as sv:
+        sv["x"][0, 0] = -1.0
+
+    f = vfile.f
+    newf = tmp_group(f)
+    gc.collect()
+    tracemalloc.start()
+    try:
+        recreate_dataset(f, "x", newf)
+        _, peak = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+
+    # Generous margin over max_bytes; loading a whole version would be 2 MiB
+    assert peak < np.prod(shape) * 8 // 2
 
 
 def test_delete_version(vfile):

--- a/tests/test_staged_changes.py
+++ b/tests/test_staged_changes.py
@@ -373,6 +373,35 @@ def test_has_changes():
     assert a.has_changes  # resize() flips it even without data changes
 
 
+def test_has_base_chunks():
+    a = StagedChangesArray.full((6,), chunk_size=(2,), fill_value=42)
+    # only full chunks
+    assert a.n_base_slabs == 0
+    assert a.n_staged_slabs == 0
+    assert not a.has_base_chunks
+    # full and staged chunks
+    a[0] = 1
+    assert a.n_base_slabs == 0
+    assert a.n_staged_slabs == 1
+    assert not a.has_base_chunks
+    # full and base chunks
+    a.commit()
+    assert a.n_base_slabs == 1
+    assert a.n_staged_slabs == 0
+    assert a.has_base_chunks
+    # full, base, and staged chunks
+    a[2] = 1
+    assert a.n_base_slabs == 1
+    assert a.n_staged_slabs == 1
+    assert a.has_base_chunks
+    # A base slab may no longer be referenced by slab_indices,
+    # but it remains in the slabs list.
+    a[:] = 2
+    assert a.n_base_slabs == 1
+    assert a.n_staged_slabs == 2
+    assert not a.has_base_chunks
+
+
 def test_resize_noop():
     a = StagedChangesArray.from_array(np.arange(4), chunk_size=(2,))
     a.resize((4,))

--- a/versioned_hdf5/backend.py
+++ b/versioned_hdf5/backend.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import datetime
+import itertools
 import logging
+import math
 import textwrap
 from collections.abc import Iterator
 from dataclasses import dataclass
@@ -14,16 +16,19 @@ from h5py._hl.selections import select
 from h5py._selector import Selector
 from ndindex import ChunkSize, Slice, Tuple
 
+from versioned_hdf5.cytools import ceil_a_over_b
 from versioned_hdf5.h5py_compat import HAS_NPYSTRINGS, h5py_astype
 from versioned_hdf5.hashtable import Hashtable
 from versioned_hdf5.slicetools import RawDataView
+from versioned_hdf5.staged_changes import StagedChangesArray
 from versioned_hdf5.typing_ import DEFAULT, Default
 
 if TYPE_CHECKING:
-    from versioned_hdf5.staged_changes import StagedChangesArray
     from versioned_hdf5.wrappers import FiltersMixin
 
 DEFAULT_CHUNK_SIZE = 2**12
+# Amount of RAM that rewrite_dataset() can allocate as a scratch area
+REWRITE_BUFFER_BYTES = 2**24  # 16 MiB
 DATA_VERSION = 4
 # data_version 2 has broken hashtables, always need to rebuild
 # data_version 3 hash collisions for string arrays which, when concatenated,
@@ -571,6 +576,115 @@ def commit_staged_changes(
         Tuple(*vds_slice): Slice(raw_data_slice[0])
         for vds_slice, _, raw_data_slice in sc.changes()
     }
+
+
+def _chunk_blocks(
+    shape: tuple[int, ...],
+    chunk_size: tuple[int, ...],
+    itemsize: int,
+    max_bytes: int,
+) -> Iterator[tuple[slice, ...]]:
+    """Tile `shape` into blocks of whole chunks, each at most `max_bytes` in size.
+
+    Blocks are grown one axis at a time, starting from the last one, so that each of
+    them is as contiguous as possible in both the source dataset and raw_data. A block
+    always contains at least one chunk, even if a single chunk is larger than
+    `max_bytes`.
+    """
+    n_chunks = [ceil_a_over_b(s, c) for s, c in zip(shape, chunk_size, strict=True)]
+    if not all(n_chunks):
+        return
+
+    # Number of chunks along each axis of a block
+    block = [1] * len(shape)
+    nbytes = itemsize * math.prod(chunk_size)
+    for axis in reversed(range(len(shape))):
+        block[axis] = max(1, min(n_chunks[axis], max_bytes // nbytes))
+        nbytes *= block[axis]
+        if block[axis] < n_chunks[axis]:
+            break
+
+    for start in itertools.product(
+        *[range(0, n, b) for n, b in zip(n_chunks, block, strict=True)]
+    ):
+        yield tuple(
+            slice(i * c, min((i + b) * c, s))
+            for i, b, c, s in zip(start, block, chunk_size, shape, strict=True)
+        )
+
+
+def rewrite_dataset(
+    f,
+    name: str,
+    data,
+    *,
+    chunks: tuple[int, ...],
+    fillvalue: Any = None,
+    max_bytes: int = REWRITE_BUFFER_BYTES,
+) -> dict[Tuple, Slice]:
+    """Copy every chunk of `data` into the `raw_data` of `f`, deduplicating it against
+    the chunks already there, and return the `{chunk_index: raw_data slice}` dict to be
+    passed to `create_virtual_dataset`.
+
+    Unlike `commit_staged_changes`, which updates the `raw_data` that its
+    StagedChangesArray is already built on top of, this rewrites `data` from scratch
+    into an unrelated `raw_data`, which may live in another file. This is what
+    `recreate_dataset` needs: it can't assume that the new hash table maps the chunks
+    to the same locations as the old one, even where the data is unchanged.
+
+    `data` is read one block of chunks at a time, so that peak memory usage is
+    O(max_bytes) instead of O(data.size). Deduplication is unaffected: each block is
+    deduplicated against the on-disk hash table, which by then already describes every
+    chunk written by the previous blocks and by the previous versions.
+
+    Parameters
+    ----------
+    f:
+        Versioned hdf5 file or group, already initialized, which must contain
+        ``_version_data/<name>/{raw_data,hash_table}``
+    name:
+        Name of the dataset
+    data:
+        Any NumPy-like object supporting ``__getitem__`` with a tuple of slices,
+        e.g. a NumPy array, a h5py Dataset, or any of versioned-hdf5's dataset wrappers
+    fillvalue:
+        Fill value of the dataset. Chunks that are entirely full of it are not
+        written to raw_data at all.
+    max_bytes:
+        Maximum amount of memory, in bytes, to use to buffer the chunks in transit.
+        Rounded up to one chunk. This is only indicative for object string dtypes,
+        where the size of the buffer doesn't account for the strings themselves.
+
+    See Also
+    --------
+    commit_staged_changes
+    """
+    slices = {}
+
+    for block in _chunk_blocks(data.shape, chunks, data.dtype.itemsize, max_bytes):
+        staged_changes = StagedChangesArray.from_array(
+            data[block],
+            chunk_size=chunks,
+            fill_value=fillvalue,
+            as_base_slabs=False,
+        )
+        block_slices = commit_staged_changes(f, name, staged_changes)
+
+        # The chunk indices are relative to the block; shift them back to `data`
+        offsets = [s.start for s in block]
+        if any(offsets):
+            block_slices = {
+                Tuple(
+                    *[
+                        Slice(c.args[0] + o, c.args[1] + o, c.args[2])
+                        for c, o in zip(idx.args, offsets, strict=True)
+                    ]
+                ): raw_data_slice
+                for idx, raw_data_slice in block_slices.items()
+            }
+        slices.update(block_slices)
+
+    return slices
 
 
 def create_virtual_dataset(

--- a/versioned_hdf5/backend.py
+++ b/versioned_hdf5/backend.py
@@ -28,7 +28,8 @@ if TYPE_CHECKING:
 
 DEFAULT_CHUNK_SIZE = 2**12
 # Amount of RAM that rewrite_dataset() can allocate as a scratch area
-REWRITE_BUFFER_BYTES = 2**24  # 16 MiB
+# This is a compromise between minimizing RAM usage and runtime.
+REWRITE_BUFFER_BYTES = 2**26  # 64 MiB
 DATA_VERSION = 4
 # data_version 2 has broken hashtables, always need to rebuild
 # data_version 3 hash collisions for string arrays which, when concatenated,

--- a/versioned_hdf5/backend.py
+++ b/versioned_hdf5/backend.py
@@ -648,6 +648,8 @@ def rewrite_dataset(
     data:
         Any NumPy-like object supporting ``__getitem__`` with a tuple of slices,
         e.g. a NumPy array, a h5py Dataset, or any of versioned-hdf5's dataset wrappers
+    chunks:
+        shape of a single chunk
     fillvalue:
         Fill value of the dataset. Chunks that are entirely full of it are not
         written to raw_data at all.

--- a/versioned_hdf5/replay.py
+++ b/versioned_hdf5/replay.py
@@ -23,6 +23,7 @@ from versioned_hdf5.backend import (
     create_base_dataset,
     create_virtual_dataset,
     initialize,
+    rewrite_dataset,
 )
 from versioned_hdf5.hashtable import Hashtable
 from versioned_hdf5.slicetools import spaceid_to_slice
@@ -105,28 +106,37 @@ def recreate_dataset(f, name, newf, callback=None):
                     filters=filters,
                 )
                 first = False
-            # Read in all the chunks of the dataset (we can't assume the new
+            if not isinstance(chunks, tuple):
+                chunks = tuple(newf["_version_data"][name]["raw_data"].attrs["chunks"])
+
+            # Rewrite all the chunks of the dataset (we can't assume the new
             # hash table has the raw data in the same locations, even if the
             # data is unchanged).
             if isinstance(dataset, DatasetWrapper):
                 dataset = dataset.dataset
-            if isinstance(dataset, (InMemoryDataset, InMemorySparseDataset)):
-                dataset.staged_changes.load()
-                slices = commit_staged_changes(newf, name, dataset.staged_changes)
-            elif isinstance(dataset, InMemoryArrayDataset):
-                if not isinstance(chunks, tuple):
-                    chunks = tuple(
-                        newf["_version_data"][name]["raw_data"].attrs["chunks"]
-                    )
+            if isinstance(dataset, InMemoryArrayDataset):
                 staged_changes = StagedChangesArray.from_array(
                     dataset._buffer,
                     chunk_size=chunks,
                     fill_value=fillvalue,
                     as_base_slabs=False,
                 )
-                slices = commit_staged_changes(newf, name, staged_changes)
+            elif isinstance(dataset, (InMemoryDataset, InMemorySparseDataset)):
+                staged_changes = dataset.staged_changes
             else:
                 raise TypeError(f"Unexpected: {type(dataset)}")  # pragma: no cover
+
+            if staged_changes.has_base_chunks:
+                # Some or all chunks lie on the raw_data of the *source* file, which
+                # the hash table of newf knows nothing about, so they must all be
+                # rewritten. Stream them a block of chunks at a time; loading them all
+                # in memory first would make peak memory usage O(dataset size).
+                slices = rewrite_dataset(
+                    newf, name, dataset, chunks=chunks, fillvalue=fillvalue
+                )
+            else:
+                # Every chunk is already in memory
+                slices = commit_staged_changes(newf, name, staged_changes)
 
             create_virtual_dataset(
                 newf,

--- a/versioned_hdf5/staged_changes.py
+++ b/versioned_hdf5/staged_changes.py
@@ -367,6 +367,19 @@ class StagedChangesArray(MutableMapping[Any, T]):
         return self.hash_tables[self.staged_slabs_start :]
 
     @property
+    def has_base_chunks(self) -> bool:
+        """If any chunks lay on a base slab."""
+        if self.n_base_slabs == 0:
+            return False
+        if self.n_staged_slabs == 0:
+            return (self.slab_indices > 0).any()
+        # base chunks may no longer be referenced by slab_indices, but base slabs are
+        # retained for the purpose of hashing.
+        return (
+            (self.slab_indices > 0) & (self.slab_indices <= self.n_base_slabs)
+        ).any()
+
+    @property
     def has_changes(self) -> bool:
         """Return True if any chunks have been modified or if a lazy transformation
         took place; False otherwise.


### PR DESCRIPTION
Fix performance regression introduced by #547, where `recreate_dataset` started loading each version of a dataset fully in memory.

| [3d4d08cc] (master)   | #547   |   This PR | Benchmark (Parameter)                                               |
|------------------------------|-----------------------------------|---------|---------------------------------------------------------------------|
| 151M                         | 151M                              |    151M | replay.Baseline.peakmem_baseline('baseline')                        |
| 151M                         | 169M                              |    151M | replay.TimeRecreateDataset.peakmem_recreate_dataset('drop_version') |
| 151M                         | 173M                              |    151M | replay.TimeRecreateDataset.peakmem_recreate_dataset('no_callback')  |
| 508±4ms                      | 195±7ms                           | 213±3ms | replay.TimeRecreateDataset.time_recreate_dataset('drop_version')    |
| 631±3ms                      | 257±4ms                           | 278±5ms | replay.TimeRecreateDataset.time_recreate_dataset('no_callback')     |
