### PR TITLE
resize(): don't deep-copy a whole slab to enlarge just the last chunk

### DIFF
--- a/docs/staged_changes.rst
+++ b/docs/staged_changes.rst
@@ -320,9 +320,13 @@ Enlarging edge chunks that don't lie on the full slab is more involved, as they 
 be physically filled with the fill_value:
 
 1. If a chunk lies on a base slab, it first needs to be transferred over to a staged
-   slab, which is created brand new for the occasion;
-2. then, there is a transfer from the full slab to the staged slab for the extra area
-   that needs to be filled with the fill_value.
+   slab, which is created brand new for the occasion.
+2. If an edge chunk along axis 0 lies at the bottom of a trimmed staged slab (see below)
+   and can't hold the enlarged chunk, it is relocated to a brand new staged slab, as the
+   fill of the next step would overflow the trimmed slab; the original slab is then
+   shrunk in place, or dropped if it became empty.
+3. Finally, there is a transfer from the full slab to the staged slab for the extra
+   area that needs to be filled with the fill_value.
 
 
 Trimmed staged slabs
@@ -330,11 +334,28 @@ Trimmed staged slabs
 ``from_array(as_base_slabs=False)`` creates staged slabs as views of the input array.
 When the input array's shape is not exactly divisible by the ``chunk_size``, these views
 may not be large enough to contain the chunks after ``resize()`` enlarges the array.
-``resize()`` deep-copies trimmed slabs into new ones padded with empty data. It's
-important that this happens lazily, only when and if needed, to avoid unnecessary
-deep-copies when the array is never enlarged over its lifetime - notably, when it's
-created and then immediately consumed and destroyed when committing an
+It's important that the slabs are fixed lazily, only when and if needed, to avoid
+unnecessary deep-copies when the array is never enlarged over its lifetime - notably,
+when it's created and then immediately consumed and destroyed when committing an
 ``InMemoryArrayDataset``.
+
+How ``resize()`` fixes the trimmed slabs depends on which axes are being enlarged:
+
+- When enlarging along axis 1+, each slab that is trimmed along any of those axes
+  is deep-copied into a new one padded with uninitialized data to a whole number of
+  chunks along all axes.
+- When enlarging along axis 0, each slab that is trimmed exclusively along axis 0 is
+  instead handled by ``ResizePlan``: its last chunk - the only one that would overflow -
+  is copied to a brand new staged slab; the original slab is then truncated in place
+  (using a no-op NumPy view) to a whole number of chunks. A slab that only held the
+  relocated chunk becomes empty and is dropped.
+
+The relocations are one ``TransferPlan`` per source slab, but they skip the
+``IndexChunkMapper`` machinery: the ``read_many_slices()`` parameters of all the
+relocated chunks are computed in bulk, and each ``TransferPlan`` is then initialized
+with a plain slice of them. This is because each source slab typically contributes a
+single tiny chunk, so the per-chunk index arithmetic would cost more than the copy
+itself.
 
 ``load()`` algorithm
 --------------------

--- a/tests/test_staged_changes.py
+++ b/tests/test_staged_changes.py
@@ -1236,7 +1236,9 @@ def test_from_array_as_staged_slabs_2():
 
     Input array is not exactly divisible by chunk_size.
     All slabs are views of the original array, including the trimmed edge slabs.
-    resize() deep-copies the trimmed slabs if and when it is called.
+    resize() enlarging along axis 0 relocates the trimmed last chunk of every
+    trimmed slab and truncates the originals; the slabs that are also trimmed
+    along axis 1+ are deep-copied and padded first.
     """
     arr = np.arange(15).reshape((3, 5))
     a = StagedChangesArray.from_array(arr, chunk_size=(2, 2), as_base_slabs=False)
@@ -1248,13 +1250,27 @@ def test_from_array_as_staged_slabs_2():
     a[:, :] = -1
     assert_array_equal(a, np.full((3, 5), -1))
     assert_array_equal(arr, np.full((3, 5), -1))  # All slabs are views
-    # resize() deep-copies and pads the trimmed slabs; from now on writes to a
-    # don't propagate to arr
+    # resize() enlarging along both axes:
+    # - the last chunk of each of the 3 trimmed slabs is relocated to a brand new
+    #   (6, 2) slab
+    # - the width-trimmed slab is deep-copied and padded to (4, 2) first, so that
+    #   the fill of the enlarged edge fits; all trimmed slabs are then truncated
+    #   from 3 to 2 rows
     a.resize((4, 6))
-    for slab in a.staged_slabs:
+    assert a.n_staged_slabs == 4
+    for slab_idx in (1, 2):
+        slab = a.slabs[slab_idx]
         assert slab is not None
-        assert slab.shape == (4, 2)  # padded from (3, 2) or (3, 1) to (4, 2)
-        assert not np.shares_memory(slab, arr)
+        assert slab.shape == (2, 2)  # truncated from (3, 2) to (2, 2)
+        assert np.shares_memory(slab, arr)  # untouched interior still a view
+    slab = a.slabs[3]
+    assert slab is not None
+    assert slab.shape == (2, 2)  # deep-copied to (4, 2), then truncated to (2, 2)
+    assert not np.shares_memory(slab, arr)
+    slab = a.slabs[4]
+    assert slab is not None
+    assert slab.shape == (6, 2)  # brand new slab holding the 3 relocated chunks
+    assert not np.shares_memory(slab, arr)
     a[0, -1] = 22
     a[-1, 0] = 33
     assert_array_equal(
@@ -1311,8 +1327,9 @@ def test_from_array_as_staged_slabs_4():
     """from_array(..., as_base_slabs=False)
 
     Input array is too small to fully cover even a single chunk;
-    the slab is a trimmed writeable view of the input array,
-    and resize() deep-copies it into a padded slab.
+    the slab is a trimmed writeable view of the input array.
+    resize() relocates its only chunk to a brand new padded slab and drops
+    the original, now empty, slab.
     """
     arr = np.asarray([1, 2])
     a = StagedChangesArray.from_array(arr, chunk_size=(3,), as_base_slabs=False)
@@ -1324,10 +1341,13 @@ def test_from_array_as_staged_slabs_4():
     assert_array_equal(a, np.array([-1, -1]))
     assert_array_equal(arr, np.array([-1, -1]))
 
-    # resize() deep-copies and pads the trimmed slab
+    # resize() relocates the single trimmed chunk to a new (3,) slab;
+    # the original slab becomes empty and is dropped.
     a.resize((5,))
-    assert a.slabs[1].shape == (3,)  # padded from (2,) to (3,)
-    assert not np.shares_memory(a.slabs[1], arr)
+    assert a.slabs[1] is None
+    assert a.hash_tables[1] is None
+    assert a.slabs[2].shape == (3,)
+    assert not np.shares_memory(a.slabs[2], arr)
     assert_array_equal(a, np.array([-1, -1, 0, 0, 0]))
     a[0] = 7
     assert_array_equal(arr, np.array([-1, -1]))
@@ -1404,14 +1424,205 @@ def test_from_array_as_staged_slabs_resize_shrink_and_noop():
     for slab in b.staged_slabs:
         assert slab is not None
         assert np.shares_memory(slab, arr)  # still views
-    # Enlarging again works
+    # Enlarging again works: the last chunk of each of the 3 trimmed slabs is
+    # relocated to a brand new slab; the width-trimmed slab is deep-copied and
+    # padded first, and all trimmed slabs are then truncated.
     b.resize((4, 6))
     expected = np.zeros((4, 6), dtype=arr.dtype)
     expected[:3, :5] = arr
     assert_array_equal(b, expected)
-    for slab in b.staged_slabs:
-        assert slab is not None
-        assert slab.shape == (4, 2)
+    assert b.slabs[1].shape == (2, 2)
+    assert np.shares_memory(b.slabs[1], arr)
+    assert b.slabs[2].shape == (2, 2)
+    assert np.shares_memory(b.slabs[2], arr)
+    assert b.slabs[3].shape == (2, 2)
+    assert not np.shares_memory(b.slabs[3], arr)
+    assert b.slabs[4].shape == (6, 2)
+    assert not np.shares_memory(b.slabs[4], arr)
+
+
+def test_from_array_as_staged_slabs_untrim_axis0_only_noop():
+    """_untrim_staged_slabs() does nothing when only axis 0 is being enlarged.
+
+    Slabs trimmed along axis 0 are left for ResizePlan, which relocates only their
+    last chunk instead of deep-copying the whole slab.
+    """
+    arr = np.arange(15).reshape((3, 5))
+    a = StagedChangesArray.from_array(arr, chunk_size=(2, 2), as_base_slabs=False)
+    before = list(a.slabs)
+    a._untrim_staged_slabs((6, 5))  # Enlarge axis 0 only
+    assert a.slabs == before  # hot-swap would replace the objects
+    for slab, old in zip(a.staged_slabs, before[1:], strict=True):
+        assert slab is old
+
+    # Enlarging along axis 1+ triggers a deep-copy of the width-trimmed slabs
+    # (including padding along axis 0 as a side effect)
+    a._untrim_staged_slabs((4, 6))
+    assert a.slabs[1] is before[1]  # (3, 2): full width, left alone
+    assert a.slabs[2] is before[2]
+    assert a.slabs[3] is not before[3]  # (3, 1): trimmed width, padded to (4, 2)
+    assert a.slabs[3].shape == (4, 2)
+
+
+def test_from_array_as_staged_slabs_resize_axis0_only():
+    """Enlarging only along axis 0 relocates trimmed last chunks instead of
+    deep-copying whole slabs.
+    """
+    arr = np.arange(35).reshape((5, 7))
+    a = StagedChangesArray.from_array(arr, chunk_size=(3, 4), as_base_slabs=False)
+    # Slabs: (5, 4) full width + (5, 3) trimmed width; both trimmed along axis 0
+    # (5 % 3 == 2). Enlarging 5 -> 6 along axis 0 only must not invoke _untrim.
+    assert sorted(s.shape for s in a.staged_slabs) == [(5, 3), (5, 4)]
+    plan = a._resize_plan((6, 7), copy=True)
+    # One new slab for the relocated chunks, one per trimmed staged slab
+    assert len(plan.append_slabs) == 1
+    assert plan.append_slabs[0] == (6, 4)  # 2 relocated chunks x 3 rows
+    assert plan.shrink_slabs == [(1, 3), (2, 3)]  # (slab idx, new size along axis 0)
+    # One relocation transfer (single chunk) per trimmed staged slab, moving the last
+    # chunk (rows 3:5, 2 rows) to the new slab, followed by the fill of the new edge
+    # (from the full slab), which targets the relocated chunks now all on the new slab
+    assert len(plan.transfers) == 3
+    assert plan.transfers[0].src_slab_idx == 1
+    assert plan.transfers[0].dst_slab_idx == 3
+    assert len(plan.transfers[0]) == 1
+    assert plan.transfers[1].src_slab_idx == 2
+    assert plan.transfers[1].dst_slab_idx == 3
+    assert len(plan.transfers[1]) == 1
+    assert plan.transfers[2].src_slab_idx == 0
+    assert plan.transfers[2].dst_slab_idx == 3
+    assert len(plan.transfers[2]) == 2
+    assert "4 slice transfers among 3 slab pairs" in repr(plan)
+
+    a.resize((6, 7))
+    expected = np.zeros((6, 7), dtype=arr.dtype)
+    expected[:5, :7] = arr
+    assert_array_equal(a, expected)
+    # Originals shrunk to full chunks (3 rows) and stay views of arr
+    assert a.slabs[1].shape == (3, 4)
+    assert np.shares_memory(a.slabs[1], arr)
+    assert a.slabs[2].shape == (3, 3)
+    assert np.shares_memory(a.slabs[2], arr)
+    # New slab holds the relocated 2-row edge plus 1 fill row per chunk
+    assert a.slabs[3].shape == (6, 4)
+    assert not np.shares_memory(a.slabs[3], arr)
+
+
+def test_from_array_as_staged_slabs_resize_shrink_hash_tables():
+    """Relocating trimmed staged slabs also truncates their hash tables, if present."""
+    arr = np.arange(15).reshape((3, 5))
+    a = StagedChangesArray.from_array(arr, chunk_size=(2, 2), as_base_slabs=False)
+    a._calc_hashes()
+    assert a.hash_tables[1] is not None
+    assert a.hash_tables[1].shape == (2, 4)  # ceil(3 / 2) chunks
+    assert a.hash_tables[2].shape == (2, 4)
+    assert a.hash_tables[3].shape == (2, 4)
+
+    a.resize((4, 6))
+    # Slabs 1 and 2 were truncated (3, 2) -> (2, 2): 2 chunks -> 1 chunk.
+    # Their surviving chunks were not written to, so the truncated hash tables
+    # (first chunk only) are still valid.
+    assert a.slabs[1].shape == (2, 2)
+    assert a.hash_tables[1] is not None
+    assert a.hash_tables[1].shape == (1, 4)
+    assert a.slabs[2].shape == (2, 2)
+    assert a.hash_tables[2].shape == (1, 4)
+    # Slab 3 was deep-copied by _untrim (width-trimmed) and truncated like the
+    # others; its surviving chunk was then partially overwritten by the fill of
+    # the enlarged edge, which invalidated its hash table
+    assert a.slabs[3].shape == (2, 2)
+    assert a.hash_tables[3] is None
+    # New slab holding relocated chunks has no hashes yet
+    assert a.slabs[4].shape == (6, 2)
+    assert a.hash_tables[4] is None
+    # Data is unchanged and commit() still works (rehashes everything)
+    expected = np.zeros((4, 6), dtype=arr.dtype)
+    expected[:3, :5] = arr
+    assert_array_equal(a, expected)
+    a.commit()
+    assert a.n_staged_slabs == 0
+    assert_array_equal(a, expected)
+
+
+def test_from_array_as_staged_slabs_resize_full_edge_no_reloc():
+    """Full edge chunks living on trimmed staged slabs are filled in place.
+
+    After shrinking (3, 5) -> (2, 3), the trimmed slabs still span 3 rows but the
+    edge chunks (rows 0:2) are full. Enlarging (2, 3) -> (2, 5) along axis 1+ only
+    must not relocate anything along axis 0 and must not create new slabs for
+    trimmed staged slabs.
+    """
+    arr = np.arange(15).reshape((3, 5))
+    a = StagedChangesArray.from_array(arr, chunk_size=(2, 2), as_base_slabs=False)
+    a.resize((2, 3))
+    n_slabs_before = a.n_slabs
+    plan = a._resize_plan((2, 5), copy=True)
+    assert plan.append_slabs == []
+    assert plan.shrink_slabs == []
+    assert plan.drop_slabs == []
+    a.resize((2, 5))
+    assert a.n_slabs == n_slabs_before
+    expected = np.zeros((2, 5), dtype=arr.dtype)
+    expected[:, :3] = arr[:2, :3]
+    assert_array_equal(a, expected)
+    for slab in a.staged_slabs:
+        if slab is None:
+            continue
+        assert np.shares_memory(slab, arr)  # still views, filled in place
+
+
+def test_from_array_as_staged_slabs_resize_axis0_enlarge_axis1_shrink():
+    """Enlarging axis 0 while shrinking axis 1 relocates the trimmed last chunks and
+    drops the slabs left unreferenced by the shrink.
+    """
+    arr = np.arange(35).reshape((5, 7))
+    a = StagedChangesArray.from_array(arr, chunk_size=(3, 4), as_base_slabs=False)
+    a.resize((6, 4))
+    expected = np.zeros((6, 4), dtype=arr.dtype)
+    expected[:5, :4] = arr[:5, :4]
+    assert_array_equal(a, expected)
+    # Slab 1 had its last chunk (rows 3:5) relocated to a new slab and was shrunk
+    # from (5, 4) to (3, 4); it's still a view of arr
+    assert a.slabs[1].shape == (3, 4)
+    assert np.shares_memory(a.slabs[1], arr)
+    # Slab 2 became unreferenced by the shrink along axis 1 and was dropped
+    assert a.slabs[2] is None
+    # New slab holding the relocated chunk (2 data rows + 1 fill row)
+    assert a.slabs[3].shape == (3, 4)
+    assert not np.shares_memory(a.slabs[3], arr)
+
+
+def test_from_array_as_staged_slabs_resize_axis0_enlarge_axis1_shrink_drop():
+    """Enlarging axis 0 relocates the only chunk of single-chunk trimmed slabs,
+    which drops them; the drop is re-derived from scratch together with the drops
+    caused by the concurrent shrink along axis 1.
+    """
+    arr = np.arange(14).reshape((2, 7))
+    a = StagedChangesArray.from_array(arr, chunk_size=(3, 4), as_base_slabs=False)
+    plan = a._resize_plan((3, 4), copy=True)
+    assert len(plan.append_slabs) == 1
+    assert plan.append_slabs[0] == (3, 4)
+    # The only chunk of slab 1 is relocated to the new slab, then filled
+    assert len(plan.transfers) == 2
+    assert plan.transfers[0].src_slab_idx == 1
+    assert plan.transfers[0].dst_slab_idx == 3
+    assert plan.transfers[1].src_slab_idx == 0
+    assert plan.transfers[1].dst_slab_idx == 3
+    # Both slabs were dropped: slab 1 by the relocation of its only chunk,
+    # slab 2 by the shrink along axis 1
+    assert plan.shrink_slabs == []
+    assert plan.drop_slabs == [1, 2]
+
+    a.resize((3, 4))
+    expected = np.zeros((3, 4), dtype=arr.dtype)
+    expected[:2, :4] = arr[:2, :4]
+    assert_array_equal(a, expected)
+    assert a.slabs[1] is None
+    assert a.hash_tables[1] is None
+    assert a.slabs[2] is None
+    assert a.slabs[3].shape == (3, 4)
+    a.commit()
+    assert a.n_staged_slabs == 0
+    assert_array_equal(a, expected)
 
 
 def test_from_array_as_staged_slabs_changes():

--- a/tests/test_staged_changes.py
+++ b/tests/test_staged_changes.py
@@ -1238,7 +1238,8 @@ def test_from_array_as_staged_slabs_2():
     All slabs are views of the original array, including the trimmed edge slabs.
     resize() enlarging along axis 0 relocates the trimmed last chunk of every
     trimmed slab and truncates the originals; the slabs that are also trimmed
-    along axis 1+ are deep-copied and padded first.
+    along axis 1+ are instead deep-copied and padded to a whole number of chunks
+    along all axes, which spares them the relocation.
     """
     arr = np.arange(15).reshape((3, 5))
     a = StagedChangesArray.from_array(arr, chunk_size=(2, 2), as_base_slabs=False)
@@ -1251,11 +1252,10 @@ def test_from_array_as_staged_slabs_2():
     assert_array_equal(a, np.full((3, 5), -1))
     assert_array_equal(arr, np.full((3, 5), -1))  # All slabs are views
     # resize() enlarging along both axes:
-    # - the last chunk of each of the 3 trimmed slabs is relocated to a brand new
-    #   (6, 2) slab
-    # - the width-trimmed slab is deep-copied and padded to (4, 2) first, so that
-    #   the fill of the enlarged edge fits; all trimmed slabs are then truncated
-    #   from 3 to 2 rows
+    # - the width-trimmed slab is deep-copied and padded from (3, 1) to (4, 2), so
+    #   that the fill of the enlarged edge fits in place
+    # - the last chunk of each of the other 2 trimmed slabs is relocated to a brand
+    #   new (4, 2) slab and the originals are truncated from 3 to 2 rows
     a.resize((4, 6))
     assert a.n_staged_slabs == 4
     for slab_idx in (1, 2):
@@ -1265,11 +1265,11 @@ def test_from_array_as_staged_slabs_2():
         assert np.shares_memory(slab, arr)  # untouched interior still a view
     slab = a.slabs[3]
     assert slab is not None
-    assert slab.shape == (2, 2)  # deep-copied to (4, 2), then truncated to (2, 2)
+    assert slab.shape == (4, 2)  # deep-copied and padded; not relocated
     assert not np.shares_memory(slab, arr)
     slab = a.slabs[4]
     assert slab is not None
-    assert slab.shape == (6, 2)  # brand new slab holding the 3 relocated chunks
+    assert slab.shape == (4, 2)  # brand new slab holding the 2 relocated chunks
     assert not np.shares_memory(slab, arr)
     a[0, -1] = 22
     a[-1, 0] = 33
@@ -1424,9 +1424,9 @@ def test_from_array_as_staged_slabs_resize_shrink_and_noop():
     for slab in b.staged_slabs:
         assert slab is not None
         assert np.shares_memory(slab, arr)  # still views
-    # Enlarging again works: the last chunk of each of the 3 trimmed slabs is
-    # relocated to a brand new slab; the width-trimmed slab is deep-copied and
-    # padded first, and all trimmed slabs are then truncated.
+    # Enlarging again works: the width-trimmed slab is deep-copied and padded, while
+    # the last chunk of each of the other 2 trimmed slabs is relocated to a brand new
+    # slab and the originals are truncated.
     b.resize((4, 6))
     expected = np.zeros((4, 6), dtype=arr.dtype)
     expected[:3, :5] = arr
@@ -1435,9 +1435,9 @@ def test_from_array_as_staged_slabs_resize_shrink_and_noop():
     assert np.shares_memory(b.slabs[1], arr)
     assert b.slabs[2].shape == (2, 2)
     assert np.shares_memory(b.slabs[2], arr)
-    assert b.slabs[3].shape == (2, 2)
+    assert b.slabs[3].shape == (4, 2)
     assert not np.shares_memory(b.slabs[3], arr)
-    assert b.slabs[4].shape == (6, 2)
+    assert b.slabs[4].shape == (4, 2)
     assert not np.shares_memory(b.slabs[4], arr)
 
 
@@ -1526,13 +1526,13 @@ def test_from_array_as_staged_slabs_resize_shrink_hash_tables():
     assert a.hash_tables[1].shape == (1, 4)
     assert a.slabs[2].shape == (2, 2)
     assert a.hash_tables[2].shape == (1, 4)
-    # Slab 3 was deep-copied by _untrim (width-trimmed) and truncated like the
-    # others; its surviving chunk was then partially overwritten by the fill of
-    # the enlarged edge, which invalidated its hash table
-    assert a.slabs[3].shape == (2, 2)
+    # Slab 3 was deep-copied and padded by _untrim (width-trimmed), so it wasn't
+    # relocated; both its chunks were then partially overwritten by the fill of the
+    # enlarged edges, which invalidated its hash table
+    assert a.slabs[3].shape == (4, 2)
     assert a.hash_tables[3] is None
     # New slab holding relocated chunks has no hashes yet
-    assert a.slabs[4].shape == (6, 2)
+    assert a.slabs[4].shape == (4, 2)
     assert a.hash_tables[4] is None
     # Data is unchanged and commit() still works (rehashes everything)
     expected = np.zeros((4, 6), dtype=arr.dtype)

--- a/versioned_hdf5/staged_changes.py
+++ b/versioned_hdf5/staged_changes.py
@@ -479,6 +479,7 @@ class StagedChangesArray(MutableMapping[Any, T]):
             slab_offsets=self.slab_offsets.copy() if copy else self.slab_offsets,
             n_slabs=self.n_slabs,
             n_base_slabs=self.n_base_slabs,
+            slab_lengths=[0 if slab is None else slab.shape[0] for slab in self.slabs],
         )
 
     def _load_plan(self, copy: bool = True) -> LoadPlan:
@@ -676,6 +677,16 @@ class StagedChangesArray(MutableMapping[Any, T]):
 
             tplan.transfer(src_slab, dst_slab)
 
+        for slab_idx, new_size0 in plan.shrink_slabs:
+            assert slab_idx > self.n_base_slabs  # Never shrink base slabs
+            slab = self.slabs[slab_idx]
+            assert slab is not None
+            self.slabs[slab_idx] = slab[:new_size0]
+            ht = self.hash_tables[slab_idx]
+            if ht is not None:
+                new_nchunks = int(ceil_a_over_b(new_size0, self.chunk_size[0]))
+                self.hash_tables[slab_idx] = ht[:new_nchunks]
+
         for slab_idx in plan.drop_slabs:
             assert slab_idx != 0  # Never drop the full slab
             self.slabs[slab_idx] = None
@@ -728,9 +739,17 @@ class StagedChangesArray(MutableMapping[Any, T]):
         slabs list is replaced with None.
         This never causes base slabs or the full slab to be dereferenced.
 
-        When enlarging, trimmed staged slabs created by from_array(as_base_slabs=False)
-        are deep-copied into new slabs padded to a whole number of chunks, as enlarging
-        the array may otherwise need to write beyond the edge of a trimmed slab.
+        Trimmed staged slabs, e.g. slabs with shape smaller than
+        (n * chunk_size[0], chunk_size[1:]) which are only ever created by
+        from_array(as_base_slabs=False), are handled differently depending on which axes
+        are being enlarged:
+
+        - When enlarging along axis 1+, a slab trimmed along any of those axes is
+          deep-copied into a new one padded to a whole number of chunks along all axes,
+          as the resize may otherwise need to write beyond the edge of the slab.
+        - When enlarging along axis 0, a slab that is trimmed exclusively along it is
+          instead handled by ResizePlan, which relocates only its last chunk to a brand
+          new staged slab and shrinks the original in place.
         """
         if not self.writeable:
             raise ValueError("assignment destination is read-only")
@@ -740,15 +759,8 @@ class StagedChangesArray(MutableMapping[Any, T]):
 
         plan = self._resize_plan(shape, copy=False)
 
-        untrim_axes = [
-            axis
-            for axis, (o, n, c) in enumerate(
-                zip(self.shape, shape, self.chunk_size, strict=True)
-            )
-            if n > o and o % c
-        ]
-        if untrim_axes:
-            self._untrim_staged_slabs(untrim_axes)
+        # When enlarging, add padding area to staged slabs that can't fit whole chunks
+        self._untrim_staged_slabs(shape)
 
         # A resize may change the slab_indices and slab_offsets, but won't necessarily
         # impact any chunks. In such cases, this is a no-op.
@@ -768,11 +780,23 @@ class StagedChangesArray(MutableMapping[Any, T]):
         new_slab[tuple(slice(s) for s in slab.shape)] = slab
         return new_slab
 
-    def _untrim_staged_slabs(self, axes: list[int]) -> None:
+    def _untrim_staged_slabs(self, new_shape: tuple[int, ...]) -> None:
         """Deep-copy trimmed staged slabs into new slabs padded to full chunk_size.
 
         Trimmed staged slabs are only ever created by from_array(as_base_slabs=False).
+        Slabs that are exclusively trimmed along axis 0 are left alone; only the last
+        chunk of the slab is affected and ResizePlan relocates it more cheaply.
         """
+        axes = [
+            axis
+            for axis, (o, n, c) in enumerate(
+                zip(self.shape, new_shape, self.chunk_size, strict=True)
+            )
+            if axis > 0 and n > o and o % c
+        ]
+        if not axes:
+            return
+
         for slab_idx in range(self.staged_slabs_start, self.n_slabs):
             slab = self.slabs[slab_idx]
             if slab is None:
@@ -1121,42 +1145,13 @@ class StagedChangesArray(MutableMapping[Any, T]):
 
 
 @cython.cclass
-@dataclass(init=False, eq=False, repr=False, kw_only=True)
+@dataclass(eq=False, repr=False, kw_only=True)
 class TransferPlan:
     """Instructions to transfer data:
 
     - from a slab to the return value of __getitem__, or
     - from the value parameter of __setitem__ to a slab, or
     - between two slabs.
-
-    Parameters
-    ----------
-    mappers:
-        List of IndexChunkMapper objects, one for each axis, defining the selection.
-    src_slab_idx:
-        Index of the source slab in StagedChangesArray.slabs.
-        During __setitem__, it must be None to indicate the value parameter.
-    dst_slab_idx:
-        Index of the destination slab in StagedChangesArray.slabs.
-        During __getitem__, it must be None to indicate the output array.
-    chunk_idxidx:
-        2D array with shape (nchunks, ndim), one row per chunk being transferred and one
-        columns per dimension. chunk_idxidx[i, j] represents the address on
-        mappers[j].chunk_indices for the i-th chunk; in other words,
-        mappers[j].chunk_indices[chunk_idxidx[i, j]] * chunk_size[j] is the address
-        along axis j of the top-left corner of the chunk in the virtual dataset.
-    src_slab_offsets:
-        Offset of each chunk within the source slab along axis 0.
-        Ignored during __setitem__.
-    dst_slab_offsets:
-        Offset of each chunk within the destination slab along axis 0.
-        Ignored during __getitem__.
-    slab_indices: optional
-        StagedChangesArray.slab_indices. It will be updated in place.
-        Ignored during __getitem__.
-    slab_offsets: optional
-        StagedChangesArray.slab_offsets. It will be updated in place.
-        Ignored during __getitem__.
     """
 
     #: Index of the source slab in StagedChangesArray.slabs.
@@ -1174,8 +1169,9 @@ class TransferPlan:
     src_stride: hsize_t[:, :]
     dst_stride: hsize_t[:, :]
 
-    def __init__(
-        self,
+    @classmethod
+    def from_mappers(
+        cls,
         mappers: list[IndexChunkMapper],
         *,
         src_slab_idx: int | None,
@@ -1185,9 +1181,38 @@ class TransferPlan:
         dst_slab_offsets: hsize_t[:],
         slab_indices: NDArray[np_hsize_t] | None = None,
         slab_offsets: NDArray[np_hsize_t] | None = None,
-    ):
-        self.src_slab_idx = src_slab_idx
-        self.dst_slab_idx = dst_slab_idx
+    ) -> TransferPlan:
+        """Define the selection of each chunk through IndexChunkMappers.
+
+        Parameters
+        ----------
+        mappers:
+            List of IndexChunkMapper objects, one for each axis, defining the selection.
+        src_slab_idx:
+            Index of the source slab in StagedChangesArray.slabs.
+            During __setitem__, it must be None to indicate the value parameter.
+        dst_slab_idx:
+            Index of the destination slab in StagedChangesArray.slabs.
+            During __getitem__, it must be None to indicate the output array.
+        chunk_idxidx:
+            2D array with shape (nchunks, ndim), one row per chunk being transferred and
+            one column per dimension. chunk_idxidx[i, j] represents the address on
+            mappers[j].chunk_indices for the i-th chunk; in other words,
+            mappers[j].chunk_indices[chunk_idxidx[i, j]] * chunk_size[j] is the address
+            along axis j of the top-left corner of the chunk in the virtual dataset.
+        src_slab_offsets:
+            Offset of each chunk within the source slab along axis 0.
+            Ignored during __setitem__.
+        dst_slab_offsets:
+            Offset of each chunk within the destination slab along axis 0.
+            Ignored during __getitem__.
+        slab_indices: optional
+            StagedChangesArray.slab_indices. It will be updated in place.
+            Ignored during __getitem__.
+        slab_offsets: optional
+            StagedChangesArray.slab_offsets. It will be updated in place.
+            Ignored during __getitem__.
+        """
         nchunks = chunk_idxidx.shape[0]
         ndim = chunk_idxidx.shape[1]
 
@@ -1209,12 +1234,6 @@ class TransferPlan:
             src_slab_offsets,
             dst_slab_offsets,
         )
-        # Refer to subchunk_map.pxd::ReadManySlicesNDColumn for column indices
-        self.src_start = slices_nd[:, 0, :]
-        self.dst_start = slices_nd[:, 1, :]
-        self.count = slices_nd[:, 2, :]
-        self.src_stride = slices_nd[:, 3, :]
-        self.dst_stride = slices_nd[:, 4, :]
 
         # Finally, update slab_indices and slab_offsets in place
         if slab_indices is not None:
@@ -1229,6 +1248,17 @@ class TransferPlan:
             chunk_indices_tup = tuple(chunk_indices)
             slab_indices[chunk_indices_tup] = dst_slab_idx
             slab_offsets[chunk_indices_tup] = np.asarray(dst_slab_offsets)
+
+        # Refer to subchunk_map.pxd::ReadManySlicesNDColumn for column indices
+        return cls(
+            src_slab_idx=src_slab_idx,
+            dst_slab_idx=dst_slab_idx,
+            src_start=slices_nd[:, 0, :],
+            dst_start=slices_nd[:, 1, :],
+            count=slices_nd[:, 2, :],
+            src_stride=slices_nd[:, 3, :],
+            dst_stride=slices_nd[:, 4, :],
+        )
 
     @cython.ccall
     def transfer(self, src: NDArray[T], dst: NDArray[T]):
@@ -1358,18 +1388,23 @@ class MutatingPlan:
     #: and append them to StagedChangesArray.slabs
     append_slabs: list[tuple[int, ...]] = field(init=False, default_factory=list)
 
-    #: data transfers between slabs or from the __setitem__ value to a slab.
+    #: Data transfers between slabs or from the __setitem__ value to a slab.
     #: dst_slab_idx can include the slabs just created by append_slabs.
     transfers: list[TransferPlan] = field(init=False, default_factory=list)
 
-    #: indices of StagedChangesArray.slabs to replace with None,
+    #: Tuples of (slab idx, new slab size along axis 0).
+    #: Truncate staged slabs in place after the last trimmed chunk has been removed.
+    #: Hash tables, if present, are truncated accordingly.
+    shrink_slabs: list[tuple[int, int]] = field(init=False, default_factory=list)
+
+    #: Indices of StagedChangesArray.slabs to replace with None,
     #: thus dereferencing the slab. This must happen *after* the transfers.
     drop_slabs: list[int] = field(init=False, default_factory=list)
 
     @property
     def mutates(self) -> bool:
         """True if this plan alters the state of the StagedChangesArray"""
-        return bool(self.transfers or self.drop_slabs)
+        return bool(self.transfers or self.shrink_slabs or self.drop_slabs)
 
     @property
     def head(self) -> str:
@@ -1393,6 +1428,8 @@ class MutatingPlan:
                 s += f"\n  slabs.append(empty({shape}))  # slabs[{slab_idx}]"
 
         s += "".join(str(tplan) for tplan in self.transfers)
+        for slab_idx, new_size0 in self.shrink_slabs:
+            s += f"\n  slabs[{slab_idx}] = slabs[{slab_idx}][:{new_size0}]"
         for slab_idx in self.drop_slabs:
             s += f"\n  slabs[{slab_idx}] = None"
         s += f"\nslab_indices:\n{self.slab_indices}"
@@ -1720,6 +1757,7 @@ class ResizePlan(MutatingPlan):
         slab_offsets: NDArray[np_hsize_t],
         n_slabs: int,
         n_base_slabs: int,
+        slab_lengths: list[int],
     ):
         """Generate instructions to execute StagedChangesArray.resize().
 
@@ -1729,6 +1767,8 @@ class ResizePlan(MutatingPlan):
             StagedChangesArray.shape before the resize operation
         new_shape:
             StagedChangesArray.shape after the resize operation
+        slab_lengths:
+            Size along axis 0 of each slab (0 where slab is None)
 
         All other parameters are the matching attributes of StagedChangesArray.
         """
@@ -1808,6 +1848,7 @@ class ResizePlan(MutatingPlan):
                             axis=axis,
                             n_slabs=n_slabs + len(self.append_slabs),
                             n_base_slabs=n_base_slabs,
+                            slab_lengths=slab_lengths,
                         )
                         prev_shape = next_shape
 
@@ -1858,6 +1899,7 @@ class ResizePlan(MutatingPlan):
         axis: ssize_t,
         n_slabs: int,
         n_base_slabs: int,
+        slab_lengths: list[int],
     ):
         """Enlarge along a single axis"""
         old_size = old_shape[axis]
@@ -1869,15 +1911,19 @@ class ResizePlan(MutatingPlan):
 
         new_size = min(new_shape[axis], old_floor_size + chunk_size[axis])
 
-        # Two steps:
+        # Three steps:
         # 1. Find edge chunks on base slabs that were partial and became full, or
         #    vice versa, or remain partial but larger.
         #    Load them into a new slab at slab_idx=n_slabs.
-        # 2. Find edge chunks that need filling with fill_value
+        # 2. (Only when axis==0)
+        #    Find edge chunks on staged slabs trimmed along axis 0 and relocate
+        #    them to a brand new staged slab, shrinking the originals.
+        # 3. Find the edge chunks that need filling with fill_value
         #    and transfer from slabs[0] (the full chunk) into them.
-        #    This includes chunks we just transferred in the previous step)
+        #    This includes chunks we just transferred in the previous steps.
 
         # Step 1
+        n_append_before = len(self.append_slabs)
         self._load_edge_chunks_along_axis(
             shape=new_shape,
             chunk_size=chunk_size,
@@ -1887,8 +1933,20 @@ class ResizePlan(MutatingPlan):
             n_slabs=n_slabs,
             n_base_slabs=n_base_slabs,
         )
+        n_slabs += len(self.append_slabs) - n_append_before
 
         # Step 2
+        if axis == 0:
+            n_slabs = self._relocate_trimmed_staged_chunks_along_axis0(
+                old_shape=old_shape,
+                new_shape=new_shape,
+                chunk_size=chunk_size,
+                n_slabs=n_slabs,
+                n_base_slabs=n_base_slabs,
+                slab_lengths=slab_lengths,
+            )
+
+        # Step 3
         idx = (slice(None),) * axis + (slice(old_size, new_size),)
         _, mappers = index_chunk_mappers(idx, new_shape, chunk_size)
         if not mappers:
@@ -1914,6 +1972,138 @@ class ResizePlan(MutatingPlan):
                     dst_slab_idx="chunks",
                 )
             )
+
+    @cython.cfunc
+    def _relocate_trimmed_staged_chunks_along_axis0(
+        self,
+        old_shape: tuple[int, ...],
+        new_shape: tuple[int, ...],
+        chunk_size: tuple[int, ...],
+        n_slabs: int,
+        n_base_slabs: int,
+        slab_lengths: list[int],
+    ) -> int:
+        """Relocate the edge chunks that lie on staged slabs trimmed along axis 0.
+
+        Trimmed staged slabs are only ever created by from_array(as_base_slabs=False).
+        When enlarging along axis 0, the last chunk of each of them cannot be filled in
+        place, as writing beyond the old edge would overflow the slab. Instead of
+        deep-copying the whole slabs (see _untrim_staged_slabs), relocate only the
+        overflowing chunks to a brand new staged slab, then shrink the originals in
+        place (or drop them if they become empty).
+
+        The relocations are one TransferPlan per source slab, defined by directly
+        invoking the plain constructor with read_many_slices() parameters computed
+        in bulk, bypassing the expensive from_mappers(); each trimmed slab typically
+        contributes a single tiny chunk, so the per-chunk index arithmetic of the
+        mappers would cost more than the copy itself.
+
+        When also enlarging along axis 1+, slabs that are also trimmed along that axis
+        don't reach this method: they were already deep-copied and padded by
+        _untrim_staged_slabs before the plan was created.
+
+        Return the next free slab index (n_slabs + 1 if a new slab was appended, else
+        n_slabs).
+        """
+        cs0 = chunk_size[0]
+        old_size = old_shape[0]
+        old_floor_size = old_size - old_size % cs0
+        assert old_floor_size < old_size
+        ndim = len(chunk_size)
+
+        # Height along axis 0 of each slab (0 for the None slabs, which can never
+        # be trimmed as 0 % cs0 == 0)
+        slab_lengths_nd = np.array(slab_lengths, dtype=np_hsize_t)
+        trimmed = slab_lengths_nd % cs0 != 0
+        trimmed[: n_base_slabs + 1] = False  # Never relocate the full or base slabs
+        if not trimmed[n_base_slabs + 1 :].any():
+            return n_slabs
+
+        # The edge chunks along axis 0 are the last row of the chunk grid. Only the
+        # chunks that would overflow their (trimmed) slab are relocated: the last
+        # chunk of each trimmed slab. Full edge chunks (e.g. after a prior shrink)
+        # already have room for the fill and are updated in place by step 3.
+        idx = (slice(old_floor_size, old_size),)
+        _, mappers = index_chunk_mappers(idx, new_shape, chunk_size)
+        if not mappers:
+            return n_slabs  # Resizing to size 0 along another axis
+        chunks = np.asarray(
+            _chunks_in_selection(
+                self.slab_indices,
+                self.slab_offsets,
+                mappers,
+            )
+        )
+        slab_idx_col = chunks[:, ndim]
+        overflow = chunks[:, ndim + 1] + cs0 > slab_lengths_nd[slab_idx_col]
+        chunks = chunks[trimmed[slab_idx_col] & overflow]
+        n_reloc = chunks.shape[0]
+        if n_reloc == 0:
+            return n_slabs
+
+        # Remap the relocated chunks onto the new slab, one chunk per cs0 rows.
+        # The first ndim columns of chunks are the chunk indices within the grid
+        # of slab_indices and slab_offsets.
+        dst_offsets = np.arange(0, n_reloc * cs0, cs0, dtype=np_hsize_t)
+        grid = tuple(chunks[:, j] for j in range(ndim))
+        self.slab_indices[grid] = n_slabs
+        self.slab_offsets[grid] = dst_offsets
+
+        # The count along axis 0 is the same for all edge chunks; along the other
+        # axes it's the extent of the chunk within the old array, which is also
+        # the width of the (from_array) slab.
+        count = np.empty((n_reloc, ndim), dtype=np_hsize_t)
+        count[:, 0] = old_size - old_floor_size
+        for j in range(1, ndim):
+            count[:, j] = np.minimum(
+                chunk_size[j], old_shape[j] - chunks[:, j] * chunk_size[j]
+            )
+
+        # read_many_slices() parameters of all the relocations, computed in bulk.
+        # Along the axes 1+ the chunks always sit at the top left corner of their
+        # slot on the slab; a single-row stride array is broadcast by
+        # read_many_slices() across all the slices of each TransferPlan.
+        src_start = np.empty((n_reloc, ndim), dtype=np_hsize_t)
+        src_start[:, 0] = chunks[:, ndim + 1]
+        src_start[:, 1:] = 0
+        dst_start = np.empty((n_reloc, ndim), dtype=np_hsize_t)
+        dst_start[:, 0] = dst_offsets
+        dst_start[:, 1:] = 0
+        stride = np.ones((1, ndim), dtype=np_hsize_t)
+
+        self.append_slabs.append((n_reloc * cs0, *chunk_size[1:]))
+
+        # chunks is sorted by source slab (see _chunks_in_selection); split it into
+        # one TransferPlan per source slab
+        start = 0
+        for stop in [*np.flatnonzero(np.diff(chunks[:, ndim])) + 1, n_reloc]:
+            self.transfers.append(
+                TransferPlan(
+                    src_slab_idx=int(chunks[start, ndim]),
+                    dst_slab_idx=n_slabs,
+                    src_start=src_start[start:stop],
+                    dst_start=dst_start[start:stop],
+                    count=count[start:stop],
+                    src_stride=stride,
+                    dst_stride=stride,
+                )
+            )
+            start = stop
+
+        # Shrink the slabs that had their last chunk relocated. A slab that only
+        # held the relocated chunk becomes empty; drop it so that
+        # (slab is None) == (hash table is None) still holds for commit().
+        for old_slab_idx in np.unique(chunks[:, ndim]).tolist():
+            old_size_i = slab_lengths[old_slab_idx]
+            trim = old_size_i % cs0
+            if trim == 0:
+                pass
+            elif trim == old_size_i:
+                self.drop_slabs.append(old_slab_idx)
+            else:
+                self.shrink_slabs.append((old_slab_idx, old_size_i - trim))
+
+        return n_slabs + 1
 
     @cython.cfunc
     def _load_edge_chunks_along_axis(
@@ -2235,18 +2425,22 @@ class CommitPlan(MutatingPlan):
                     old_to_new_chunk[cl_key] = hash_to_old_chunk[ch_key]
 
             if n_slab_transfers > 0:
-                tplan = TransferPlan.__new__(TransferPlan)
-                tplan.src_slab_idx = old_slab_idx
-                # slab_idx of the new base slab, before the staged slabs are removed
-                tplan.dst_slab_idx = len(hash_tables)
-                tplan.src_start = src_start[out_row - n_slab_transfers : out_row]
-                tplan.dst_start = dst_start[out_row - n_slab_transfers : out_row]
-                # Note: this is a view; it's important since we're going to refine
-                # tplan_count values later in this method.
-                tplan.count = tplan_count[out_row - n_slab_transfers : out_row]
-                tplan.src_stride = np.ones((n_slab_transfers, ndim), dtype=np_hsize_t)
-                tplan.dst_stride = tplan.src_stride
-                self.transfers.append(tplan)
+                stride = np.ones((n_slab_transfers, ndim), dtype=np_hsize_t)
+                self.transfers.append(
+                    TransferPlan(
+                        src_slab_idx=old_slab_idx,
+                        # slab_idx of the new base slab, before the staged
+                        # slabs are removed
+                        dst_slab_idx=len(hash_tables),
+                        src_start=src_start[out_row - n_slab_transfers : out_row],
+                        dst_start=dst_start[out_row - n_slab_transfers : out_row],
+                        # Note: this is a view; it's important since we're going to
+                        # refine tplan_count values later in this method.
+                        count=tplan_count[out_row - n_slab_transfers : out_row],
+                        src_stride=stride,
+                        dst_stride=stride,
+                    )
+                )
 
         # Append a single new base slab for the surviving unique staged chunks, but only
         # if there are any (they have not been found to be duplicates of chunks in the
@@ -2586,7 +2780,7 @@ def _make_transfer_plans(
         src_slab_offsets_group = src_slab_offsets_v[start:stop]
         dst_slab_offsets_group = dst_slab_offsets_v[start:stop]
 
-        yield TransferPlan(
+        yield TransferPlan.from_mappers(
             mappers,
             src_slab_idx=src_slab_idx_i,
             dst_slab_idx=dst_slab_idx_i,

--- a/versioned_hdf5/staged_changes.py
+++ b/versioned_hdf5/staged_changes.py
@@ -761,12 +761,17 @@ class StagedChangesArray(MutableMapping[Any, T]):
 
         # Sanitize input (e.g. convert np.int64 to int)
         shape = tuple(int(s) for s in shape)
+        if len(self.shape) != len(shape):
+            raise ValueError(
+                f"Can't change dimensionality from {self.shape} to {shape}"
+            )
 
-        plan = self._resize_plan(shape, copy=False)
-
-        # When enlarging, add padding area to staged slabs that can't fit whole chunks
+        # When enlarging, add padding area to staged slabs that can't fit whole chunks.
+        # This must happen before the plan is created, so that the plan won't also
+        # relocate the last chunk of the slabs that were just deep-copied.
         self._untrim_staged_slabs(shape)
 
+        plan = self._resize_plan(shape, copy=False)
         # A resize may change the slab_indices and slab_offsets, but won't necessarily
         # impact any chunks. In such cases, this is a no-op.
         self._apply_mutating_plan(plan)

--- a/versioned_hdf5/staged_changes.py
+++ b/versioned_hdf5/staged_changes.py
@@ -471,6 +471,11 @@ class StagedChangesArray(MutableMapping[Any, T]):
         """
         copy = copy or not self.slab_indices.flags.writeable
 
+        if shape[0] > self.shape[0] and self.shape[0] % self.chunk_size[0]:
+            slab_lengths = [0 if slab is None else slab.shape[0] for slab in self.slabs]
+        else:
+            slab_lengths = None
+
         return ResizePlan(
             old_shape=self.shape,
             new_shape=shape,
@@ -479,7 +484,7 @@ class StagedChangesArray(MutableMapping[Any, T]):
             slab_offsets=self.slab_offsets.copy() if copy else self.slab_offsets,
             n_slabs=self.n_slabs,
             n_base_slabs=self.n_base_slabs,
-            slab_lengths=[0 if slab is None else slab.shape[0] for slab in self.slabs],
+            slab_lengths=slab_lengths,
         )
 
     def _load_plan(self, copy: bool = True) -> LoadPlan:
@@ -1757,7 +1762,7 @@ class ResizePlan(MutatingPlan):
         slab_offsets: NDArray[np_hsize_t],
         n_slabs: int,
         n_base_slabs: int,
-        slab_lengths: list[int],
+        slab_lengths: list[int] | None,
     ):
         """Generate instructions to execute StagedChangesArray.resize().
 
@@ -1768,7 +1773,8 @@ class ResizePlan(MutatingPlan):
         new_shape:
             StagedChangesArray.shape after the resize operation
         slab_lengths:
-            Size along axis 0 of each slab (0 where slab is None)
+            Size along axis 0 of each slab (0 where slab is None). Mandatory when
+            enlarging an array that can't be exactly divided by chunk_size.
 
         All other parameters are the matching attributes of StagedChangesArray.
         """
@@ -1899,7 +1905,7 @@ class ResizePlan(MutatingPlan):
         axis: ssize_t,
         n_slabs: int,
         n_base_slabs: int,
-        slab_lengths: list[int],
+        slab_lengths: list[int] | None,
     ):
         """Enlarge along a single axis"""
         old_size = old_shape[axis]
@@ -1937,6 +1943,7 @@ class ResizePlan(MutatingPlan):
 
         # Step 2
         if axis == 0:
+            assert slab_lengths is not None
             n_slabs = self._relocate_trimmed_staged_chunks_along_axis0(
                 old_shape=old_shape,
                 new_shape=new_shape,


### PR DESCRIPTION
#554 introduced a regression when a user calls `StagedChangedArray.from_array()` from a numpy array that is not exactly divisible by chunk size along axis 0, then calls `resize()` along axis 0 to enlarge. This caused the whole slab to be deep-copied just for the sake of giving the last chunk enough living space.

This PR fixes the regression by adding a special case for axis 0 to the machinery introduced by #554: skip the use case in `_untrim_staged_slabs`; then use ResizePlan to deep-copy just the offending last chunk to the new slab, and finally replace the slab with a truncated view of itself.

 | Benchmark | master | this PR |
 |---|---|---|
 | `staged_changes.TimeResize.time_resize('append_row', 'from_array', '8 kiB')` | 71.7ms | 3.38ms |
 | `staged_changes.TimeResize.time_resize('append_row', 'from_array', '512 kiB')` | 37.3ms | 2.26ms |
 | `staged_changes.TimeResize.time_resize('append_col', 'from_array', '8 kiB')` | 814μs | 819μs |
 | `staged_changes.TimeResize.time_resize('append_col', 'from_array', '512 kiB')` | 2.17ms | 2.07ms |
 | `staged_changes.TimeResize.time_resize('enlarge', 'from_array', '8 kiB')` | 73.2ms | 5.08ms |
 | `staged_changes.TimeResize.time_resize('enlarge', 'from_array', '512 kiB')` | 39.8ms | 5.77ms |
 | `staged_changes.TimeResize.time_resize('shrink', 'from_array', '8 kiB')` | 149μs | 161μs |
 | `staged_changes.TimeResize.time_resize('shrink', 'from_array', '512 kiB')` | 72.1μs | 75.5μs |
 | `staged_changes.TimeResize.time_resize_plan('append_row', 'from_array', '8 kiB')` | 1.06ms | 0.72ms |
 | `staged_changes.TimeResize.time_resize_plan('append_row', 'from_array', '512 kiB')` | 243μs | 390μs |
 | `staged_changes.TimeResize.time_resize_plan('append_col', 'from_array', '8 kiB')` | 182μs | 189μs |
 | `staged_changes.TimeResize.time_resize_plan('append_col', 'from_array', '512 kiB')` | 177μs | 177μs |
 | `staged_changes.TimeResize.time_resize_plan('enlarge', 'from_array', '8 kiB')` | 1.80ms | 1.86ms |
 | `staged_changes.TimeResize.time_resize_plan('enlarge', 'from_array', '512 kiB')` | 437μs | 588μs |
 | `staged_changes.TimeResize.time_resize_plan('shrink', 'from_array', '8 kiB')` | 143μs | 152μs |
 | `staged_changes.TimeResize.time_resize_plan('shrink', 'from_array', '512 kiB')` | 66.6μs | 72.9μs |
