### PR TITLE
Release v2.5.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,10 +1,57 @@
 # Changelog
 
+## 2.5.0 (2026-09-04)
+
+### Major Changes
+
+- This release delivers the first phase of a performance overhaul in the commit phase.
+  Staged writes are now hashed, deduplicated, and written to disk fully in Cython
+  through the `StagedChangesArray` backend. The creation of the virtual datasets at the
+  end of commit is still using the legacy path and will be migrated in a future release.
+  `delete_versions()` also temporarily remains on the old, slow code path.
+
+  In short, this translates to:
+
+  - No changes to the user-facing API
+  - Major speed-ups (up to 40%) when committing a large number of small chunks
+  - Major speed-ups (up to 40%) when committing string datasets with prevalently very
+    short strings, regardless of chunk size
+  - No material speed-ups (for now) when only a small portion of a dataset changes
+
+- Sped up hot loops of many small `__setitem__` / `__getitem__` calls on
+  `InMemoryDataset` and `InMemorySparseDataset`.
+- Sped up the use case where a user first completely overwrites the contents of a
+  dataset with a single `__setitem__` call and then calls `resize()` to enlarge it.
+
+### Minor Changes
+
+- Removed the `ENABLE_CHUNK_REUSE_VALIDATION` environment variable. Its function is now
+  served by a much more thorough corpus of unit tests.
+- Scalar (0-d) datasets are now explicitly unsupported and raise `NotImplementedError`
+  on creation/access instead of failing obscurely downstream.
+- Fixed a data leak in `delete_versions()`: edge (corner) chunks rewritten after version
+  deletion could leave padding filled with data from the deleted versions instead of the
+  fill value.
+- Fixed bug where datasets with variable-length string dtype would, in certain cases,
+  end up with the default fillvalue set to integer `0` instead of an empty string.
+- Fixed a deadlock on Python <3.12 between `InMemoryDataset.staged_changes` and h5py's
+  global lock.
+- Fixed `get_version_by_timestamp()` failures on Windows caused by low filesystem
+  timestamp precision.
+- Added a build-time requirement for a C++ compiler (g++ / clang++).
+- Added support for Cython 3.2.6 and 3.3.
+
+### Developers-only Changes
+
+- Extensive improvements to the ASV benchmark coverage
+- Added `asv-compare` tool to produce side-by-side benchmarks between versions
+- Added AGENTS.md and development guidelines for AI-assisted contributions
+
 ## 2.4.0 (2026-04-28)
 
 ### Major Changes
 
-- This release reinstates Linux and MacOS binary wheels and adds Windows wheels. All
+- This release reinstates Linux and macOS binary wheels and adds Windows wheels. All
   wheels pin the exact version of h5py they were built against, in order to prevent
   future breakages due to hdf5 ABI incompatibility. If you want more flexibility on
   which version of h5py and hdf5 to use, you should install either from conda or
@@ -12,14 +59,14 @@
 
 ### Minor Changes
 
-- Fix regression where a ArrayDataset of fixed-size strings is incorrectly swapped with
-  a different array of a differently sized strings.
+- Fix regression where an ArrayDataset of fixed-size strings is incorrectly swapped
+  with a different array of differently sized strings.
 
 ## 2.3.1 (2026-03-05)
 
 ### Minor Changes
 
-- conda-forge packages are available for both hdf5 1.4 and 2.1.
+- conda-forge packages are available for both hdf5 1.14 and 2.1.
   The hdf5=2.1 build pins h5py>=3.16.
 - Added support for h5py >=3.16 to `Group` methods `get()`, `items()`, `values()`,
   and `repr()`
@@ -43,7 +90,7 @@
   | 2.2.1 Linux wheels | h5py >=3.15.0,<=3.15.1     |
   | 2.1.0 Linux wheels | h5py >=3.8.0,<3.15.0       |
 
-  MacOSX wheels, conda-forge binaries, and sources are compatible with all h5py releases.
+  macOS wheels, conda-forge binaries, and sources are compatible with all h5py releases.
 
 ### Minor Changes
 
@@ -56,14 +103,14 @@
 - The development workflow has been migrated to Pixi. This allows for fully reproducible
   builds between local environments and CI and makes dev deployment much easier.
 - Added support for editable installs (`pip install . --editable --no-build-isolation`)
-- The full unit tests suite now runs successfully on Windows and MacOS CI
+- The full unit tests suite now runs successfully on Windows and macOS CI
 
 ## 2.2.1 (2026-01-07)
 
 Fix wheels publishing issue on Linux.
 
 **Post-release note:** Linux wheels for this release are compatible with
-h5py >=3.15.0,<3.16.0 wheels; however the wheels don't include an upper pin. MacOSX
+h5py >=3.15.0,<3.16.0 wheels; however the wheels don't include an upper pin. macOS
 wheels, conda-forge binaries, and sources are compatible with all h5py releases.
 
 ## 2.2.0 (2026-01-07)
@@ -72,7 +119,7 @@ wheels, conda-forge binaries, and sources are compatible with all h5py releases.
 
 - Fixed binary incompatibility of versioned-hdf5 Linux wheels vs. the wheels for
   h5py >=3.15.0. Starting from this release, versioned-hdf5 wheels for Linux on PyPi
-  require h5py >=3.15.0 wheels. MacOSX wheels, conda-forge packages, and builds from
+  require h5py >=3.15.0 wheels. macOS wheels, conda-forge packages, and builds from
   source still require h5py >=3.8.0.
 - Added wheels for Python 3.14
 - Dropped support for Python 3.9
@@ -100,13 +147,13 @@ Filters have been overhauled:
 ### Major Changes
 
 - Binaries are now available:
-  - conda-forge packages for Linux, MacOSX, and Windows;
-  - pip wheels for Linux and MacOSX (but not Windows).
+  - conda-forge packages for Linux, macOS, and Windows;
+  - pip wheels for Linux and macOS (but not Windows).
 
   See [Installation](installation).
 
   **Post-release note:** Linux wheels for this release are compatible with
-  h5py >=3.8.0,<3.15.0 wheels; however the wheels don't include an upper pin. MacOSX
+  h5py >=3.8.0,<3.15.0 wheels; however the wheels don't include an upper pin. macOS
   wheels, conda-forge binaries, and sources are compatible with all h5py releases.
 
 - Added support for StringDType, a.k.a. NpyStrings.
@@ -422,7 +469,7 @@ Filters have been overhauled:
 
 ### Minor Changes
 
-- Improve the performance of reading a reading a dataset that hasn't been
+- Improve the performance of reading a dataset that hasn't been
   written to (e.g., reading from an already committed version).
 
 - Fix Versioned HDF5 to work with h5py 3.3.


### PR DESCRIPTION
Full benchmark:

Note: the apparent regressions in `TimeResize` are just caused by the buffer deep-copy moving from the setup phase to inside the test itself.

All benchmarks:

| Change   | Before [dd17129f] <v2.4.0>   | After [3a0936b8] <master>   | Ratio   | Benchmark (Parameter)                                                                                             |
|----------|------------------------------|-----------------------------|---------|-------------------------------------------------------------------------------------------------------------------|
|          | 1.04±0.02s                   | 982±10ms                    | 0.94    | replay.TimeModifyMetadata.time_modify_metadata('compress')                                                        |
|          | 578±7ms                      | 536±10ms                    | 0.93    | replay.TimeModifyMetadata.time_modify_metadata('dtype')                                                           |
|          | 688±5ms                      | 630±7ms                     | 0.91    | replay.TimeModifyMetadata.time_modify_metadata('fillvalue')                                                       |
| -        | 672±10ms                     | 603±9ms                     | 0.90    | replay.TimeModifyMetadata.time_modify_metadata('noop')                                                            |
|          | 591±20ms                     | 551±3ms                     | 0.93    | replay.TimeModifyMetadata.time_modify_metadata('rechunk')                                                         |
| -        | 1.02±0.01s                   | 387±6ms                     | 0.38    | replay.TimeRecreateDataset.time_recreate_dataset('drop_version')                                                  |
| -        | 1.29±0.02s                   | 523±6ms                     | 0.41    | replay.TimeRecreateDataset.time_recreate_dataset('no_callback')                                                   |
| -        | 4.49±0.9ms                   | 60.5±80μs                   | 0.01    | staged_changes.TimeFromArray.time_from_array('staged', '512 kiB')                                                 |
| -        | 2.02±0.3ms                   | 173±100μs                   | 0.09    | staged_changes.TimeFromArray.time_from_array('staged', '8 kiB')                                                   |
| -        | 37.0±1ms                     | 31.6±0.3ms                  | 0.85    | staged_changes.TimeGetItem.time_getitem('all_fragmented', '512 kiB')                                              |
|          | 49.8±6ms                     | 39.0±0.9ms                  | ~0.78   | staged_changes.TimeGetItem.time_getitem('all_fragmented', '8 kiB')                                                |
|          | 391±10μs                     | 2.35±2ms                    | ~6.01   | staged_changes.TimeResize.time_resize('append_row', 'from_array', '512 kiB')                                      |
| +        | 361±20μs                     | 3.28±2ms                    | 9.08    | staged_changes.TimeResize.time_resize('append_row', 'from_array', '8 kiB')                                        |
| +        | 1.68±0.03ms                  | 5.92±3ms                    | 3.53    | staged_changes.TimeResize.time_resize('enlarge', 'from_array', '512 kiB')                                         |
| +        | 1.51±0.2ms                   | 4.90±2ms                    | 3.26    | staged_changes.TimeResize.time_resize('enlarge', 'from_array', '8 kiB')                                           |
| -        | 30.6±2ms                     | 23.5±0.05ms                 | 0.77    | staged_changes.TimeSetItem.time_setitem('all_fragmented', '512 kiB')                                              |
| -        | 57.6±0.5ms                   | 48.1±1ms                    | 0.83    | staged_changes.TimeSetItem.time_setitem('all_fragmented', '8 kiB')                                                |
| -        | 12.7±0.2ms                   | 2.77±0.3ms                  | 0.22    | strings.TimeStrings.time_getitem('versioned_hdf5', 'O', 1)                                                        |
| -        | 3.43±0.2ms                   | 2.83±0.09ms                 | 0.83    | strings.TimeStrings.time_getitem('versioned_hdf5', 'S', 1)                                                        |
| -        | 10.6±0.2ms                   | 1.01±0.2ms                  | 0.09    | strings.TimeStrings.time_getitem('versioned_hdf5', 'T', 1)                                                        |
| -        | 93.4±0.5ms                   | 59.1±0.3ms                  | 0.63    | strings.TimeStrings.time_read_write_loop_different_chunk('versioned_hdf5', 'O', 1)                                |
| -        | 78.7±0.8ms                   | 59.2±1ms                    | 0.75    | strings.TimeStrings.time_read_write_loop_different_chunk('versioned_hdf5', 'S', 1)                                |
| -        | 97.9±0.5ms                   | 60.2±1ms                    | 0.62    | strings.TimeStrings.time_read_write_loop_different_chunk('versioned_hdf5', 'T', 1)                                |
| -        | 77.1±1ms                     | 61.6±0.8ms                  | 0.80    | strings.TimeStrings.time_read_write_loop_fast_astype('versioned_hdf5', 'O', 1)                                    |
| -        | 67.9±0.5ms                   | 59.5±0.5ms                  | 0.88    | strings.TimeStrings.time_read_write_loop_fast_astype('versioned_hdf5', 'S', 1)                                    |
| -        | 67.6±3ms                     | 59.9±0.2ms                  | 0.89    | strings.TimeStrings.time_read_write_loop_fast_astype('versioned_hdf5', 'S', 64)                                   |
| -        | 68.6±1ms                     | 60.5±0.6ms                  | 0.88    | strings.TimeStrings.time_read_write_loop_fast_astype('versioned_hdf5', 'S', 8)                                    |
| -        | 104±1ms                      | 90.1±0.7ms                  | 0.86    | strings.TimeStrings.time_read_write_loop_fast_astype('versioned_hdf5', 'T', 1)                                    |
| -        | 77.5±3ms                     | 61.4±0.6ms                  | 0.79    | strings.TimeStrings.time_read_write_loop_same_chunk('versioned_hdf5', 'O', 1)                                     |
| -        | 87.1±0.6ms                   | 78.0±0.7ms                  | 0.90    | strings.TimeStrings.time_read_write_loop_same_chunk('versioned_hdf5', 'O', 256)                                   |
| -        | 81.6±1ms                     | 74.1±0.5ms                  | 0.91    | strings.TimeStrings.time_read_write_loop_same_chunk('versioned_hdf5', 'O', 8)                                     |
| -        | 69.9±2ms                     | 57.5±0.2ms                  | 0.82    | strings.TimeStrings.time_read_write_loop_same_chunk('versioned_hdf5', 'S', 1)                                     |
| -        | 70.5±0.9ms                   | 62.9±0.6ms                  | 0.89    | strings.TimeStrings.time_read_write_loop_same_chunk('versioned_hdf5', 'S', 256)                                   |
| -        | 71.1±1ms                     | 61.7±1ms                    | 0.87    | strings.TimeStrings.time_read_write_loop_same_chunk('versioned_hdf5', 'S', 64)                                    |
| -        | 98.5±2ms                     | 61.1±2ms                    | 0.62    | strings.TimeStrings.time_read_write_loop_same_chunk('versioned_hdf5', 'T', 1)                                     |
| -        | 105±0.8ms                    | 95.8±0.5ms                  | 0.91    | strings.TimeStrings.time_read_write_loop_same_chunk('versioned_hdf5', 'T', 8)                                     |
| -        | 10.4±0.1ms                   | 4.77±0.1ms                  | 0.46    | strings.TimeStrings.time_update_different('versioned_hdf5', 'O', 1)                                               |
| -        | 24.3±0.2ms                   | 19.5±0.2ms                  | 0.80    | strings.TimeStrings.time_update_different('versioned_hdf5', 'O', 64)                                              |
| -        | 23.4±0.1ms                   | 18.9±0.2ms                  | 0.81    | strings.TimeStrings.time_update_different('versioned_hdf5', 'O', 8)                                               |
| +        | 18.4±0.2ms                   | 21.0±0.1ms                  | 1.14    | strings.TimeStrings.time_update_different('versioned_hdf5', 'S', 256)                                             |
| +        | 6.55±0.07ms                  | 7.99±0.06ms                 | 1.22    | strings.TimeStrings.time_update_different('versioned_hdf5', 'S', 64)                                              |
| +        | 3.48±0.2ms                   | 4.49±0.08ms                 | 1.29    | strings.TimeStrings.time_update_different('versioned_hdf5', 'S', 8)                                               |
| -        | 11.5±0.3ms                   | 5.86±0.2ms                  | 0.51    | strings.TimeStrings.time_update_different('versioned_hdf5', 'T', 1)                                               |
| -        | 33.8±0.4ms                   | 29.4±0.2ms                  | 0.87    | strings.TimeStrings.time_update_different('versioned_hdf5', 'T', 64)                                              |
| -        | 30.2±0.2ms                   | 25.8±0.5ms                  | 0.86    | strings.TimeStrings.time_update_different('versioned_hdf5', 'T', 8)                                               |
| -        | 10.5±0.09ms                  | 4.69±0.03ms                 | 0.44    | strings.TimeStrings.time_update_identical('versioned_hdf5', 'O', 1)                                               |
| -        | 14.6±0.3ms                   | 10.2±0.08ms                 | 0.70    | strings.TimeStrings.time_update_identical('versioned_hdf5', 'O', 256)                                             |
| -        | 12.8±0.2ms                   | 7.29±0.1ms                  | 0.57    | strings.TimeStrings.time_update_identical('versioned_hdf5', 'O', 64)                                              |
| -        | 11.5±0.1ms                   | 6.38±0.06ms                 | 0.56    | strings.TimeStrings.time_update_identical('versioned_hdf5', 'O', 8)                                               |
| +        | 10.00±0.07ms                 | 11.6±0.04ms                 | 1.16    | strings.TimeStrings.time_update_identical('versioned_hdf5', 'S', 256)                                             |
| +        | 4.01±0.09ms                  | 5.14±0.09ms                 | 1.28    | strings.TimeStrings.time_update_identical('versioned_hdf5', 'S', 64)                                              |
| +        | 2.78±0.06ms                  | 3.47±0.07ms                 | 1.25    | strings.TimeStrings.time_update_identical('versioned_hdf5', 'S', 8)                                               |
| -        | 11.6±0.1ms                   | 6.07±0.2ms                  | 0.52    | strings.TimeStrings.time_update_identical('versioned_hdf5', 'T', 1)                                               |
| -        | 17.9±0.2ms                   | 14.1±0.1ms                  | 0.79    | strings.TimeStrings.time_update_identical('versioned_hdf5', 'T', 256)                                             |
| -        | 14.5±0.4ms                   | 9.99±0.05ms                 | 0.69    | strings.TimeStrings.time_update_identical('versioned_hdf5', 'T', 64)                                              |
| -        | 12.6±0.3ms                   | 8.28±0.08ms                 | 0.66    | strings.TimeStrings.time_update_identical('versioned_hdf5', 'T', 8)                                               |
| -        | 204±8ms                      | 97.4±8ms                    | 0.48    | wrappers.TimeCommit.time_commit('v1_dense', (25, 25))                                                             |
| -        | 59.8±2ms                     | 35.0±3ms                    | 0.59    | wrappers.TimeCommit.time_commit('v1_dense', (50, 50))                                                             |
| -        | 77.5±6ms                     | 9.17±0.5ms                  | 0.12    | wrappers.TimeCommit.time_commit('v1_dense_fillvalue', (25, 25))                                                   |
| -        | 23.9±2ms                     | 8.23±0.4ms                  | 0.34    | wrappers.TimeCommit.time_commit('v1_dense_fillvalue', (50, 50))                                                   |
| -        | 84.2±6ms                     | 7.90±0.3ms                  | 0.09    | wrappers.TimeCommit.time_commit('v1_sparse_fillvalue', (25, 25))                                                  |
| -        | 9.75±0.3ms                   | 7.24±0.5ms                  | 0.74    | wrappers.TimeCommit.time_commit('v1_sparse_fillvalue', (250, 250))                                                |
| -        | 28.4±1ms                     | 7.12±0.3ms                  | 0.25    | wrappers.TimeCommit.time_commit('v1_sparse_fillvalue', (50, 50))                                                  |
| -        | 190±7ms                      | 86.1±8ms                    | 0.45    | wrappers.TimeCommit.time_commit('v1_sparse_full', (25, 25))                                                       |
| -        | 54.6±3ms                     | 30.3±3ms                    | 0.55    | wrappers.TimeCommit.time_commit('v1_sparse_full', (50, 50))                                                       |
| -        | 201±2ms                      | 91.8±1ms                    | 0.46    | wrappers.TimeCommit.time_commit('v2_hotswap_all_changes', (25, 25))                                               |
| -        | 60.5±2ms                     | 34.2±0.6ms                  | 0.57    | wrappers.TimeCommit.time_commit('v2_hotswap_all_changes', (50, 50))                                               |
| -        | 182±1ms                      | 86.8±3ms                    | 0.48    | wrappers.TimeCommit.time_commit('v2_modified_all_changes', (25, 25))                                              |
| -        | 51.7±1ms                     | 29.7±2ms                    | 0.57    | wrappers.TimeCommit.time_commit('v2_modified_all_changes', (50, 50))                                              |
| -        | 96.0±3ms                     | 78.1±2ms                    | 0.81    | wrappers.TimeCommit.time_commit('v3_restore_obsolete', (25, 25))                                                  |
| +        | 6.93±0.04ms                  | 7.80±0.03ms                 | 1.12    | wrappers.TimeCommit.time_commit('v3_restore_obsolete_hotswap', (250, 250))                                        |
| -        | 67.0±4ms                     | 32.3±3ms                    | 0.48    | wrappers.TimeCreateDataset.time_create_dataset('dense', 'versioned_hdf5')                                         |
| -        | 64.3±3ms                     | 31.5±3ms                    | 0.49    | wrappers.TimeWrappers.time_resize_bigger('InMemoryArrayDataset')                                                  |
| -        | 47.1±2ms                     | 35.3±2ms                    | 0.75    | wrappers.TimeWrappers.time_resize_bigger('InMemoryDataset')                                                       |
| -        | 65.2±3ms                     | 31.1±3ms                    | 0.48    | wrappers.TimeWrappers.time_setattr('InMemoryArrayDataset')                                                        |

